### PR TITLE
Adding failover tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,41 @@ if err != nil {
 Note that a valid endpoint is an URL to either a standalone server, or a URL to a coordinator 
 in a cluster.
 
+### Failover: Exact behavior
+
+The driver monitors the request being send to a specific server (endpoint). 
+As soon as the request has been completely written, failover will no longer happen.
+The reason for that is that several operations cannot be (safely) retried.
+E.g. when a request to create a document has been send to a server and a timeout 
+occurs, the driver has no way of knowing if the server did or did not create
+the document in the database.
+
+If the driver detects that a request has been completely written, but still gets 
+an error (other than an error response from Arango itself), it will wrap the 
+error in a `ResponseError`. The client can test for such an error using `IsResponseError`.
+
+If a client received a `ResponseError`, it can do one of the following:
+- Retry the operation and be prepared for some kind of duplicate record / unique constraint violation.
+- Perform a test operation to see if the "failed" operation did succeed after all.
+- Simply consider the operation failed. This is risky, since it can still be the case that the operation did succeed.
+
+### Failover: Timeouts
+
+To control the timeout of any function in the driver, you must pass it a context 
+configured with `context.WithTimeout` (or `context.WithDeadline`).
+
+In the case of multiple endpoints, the actual timeout used for requests will be shorter than 
+the timeout given in the context.
+The driver will divide the timeout by the number of endpoints with a maximum of 3.
+This ensures that the driver can try up to 3 different endpoints (in case of failover) without 
+being canceled due to the timeout given by the client.
+E.g.
+- With 1 endpoint and a given timeout of 1 minute, the actual request timeout will be 1 minute.
+- With 3 endpoints and a given timeout of 1 minute, the actual request timeout will be 20 seconds.
+- With 8 endpoints and a given timeout of 1 minute, the actual request timeout will be 20 seconds.
+
+For most requests you want a actual request timeout of at least 30 seconds.
+
 ### Secure connections (SSL)
 
 The driver supports endpoints that use SSL using the `https` URL scheme.

--- a/connection.go
+++ b/connection.go
@@ -60,6 +60,9 @@ type Request interface {
 	// SetHeader sets a single header arguments of the request.
 	// Any existing header argument with the same key is overwritten.
 	SetHeader(key, value string) Request
+	// Written returns true as soon as this request has been written completely to the network.
+	// This does not guarantee that the server has received or processed the request.
+	Written() bool
 }
 
 // Response represents the response from the server on a given request.

--- a/connection.go
+++ b/connection.go
@@ -66,6 +66,8 @@ type Request interface {
 type Response interface {
 	// StatusCode returns an HTTP compatible status code of the response.
 	StatusCode() int
+	// Endpoint returns the endpoint that handled the request.
+	Endpoint() string
 	// CheckStatus checks if the status of the response equals to one of the given status codes.
 	// If so, nil is returned.
 	// If not, an attempt is made to parse an error response in the body and an error is returned.

--- a/context.go
+++ b/context.go
@@ -40,6 +40,7 @@ const (
 	keyMergeObjects  = "arangodb-mergeObjects"
 	keyRawResponse   = "arangodb-rawResponse"
 	keyImportDetails = "arangodb-importDetails"
+	keyResponse      = "arangodb-response"
 )
 
 // WithRevision is used to configure a context to make document
@@ -116,6 +117,11 @@ func WithWaitForSync(parent context.Context, value ...bool) context.Context {
 // buffer.
 func WithRawResponse(parent context.Context, value *[]byte) context.Context {
 	return context.WithValue(contextOrBackground(parent), keyRawResponse, value)
+}
+
+// WithResponse is used to configure a context that will make all functions store the response into the given value.
+func WithResponse(parent context.Context, value *Response) context.Context {
+	return context.WithValue(contextOrBackground(parent), keyResponse, value)
 }
 
 // WithImportDetails is used to configure a context that will make import document requests return

--- a/http/connection.go
+++ b/http/connection.go
@@ -28,6 +28,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptrace"
 	"net/url"
 
 	driver "github.com/arangodb/go-driver"
@@ -131,9 +132,13 @@ func (c *httpConnection) Do(ctx context.Context, req driver.Request) (driver.Res
 		return nil, driver.WithStack(driver.InvalidArgumentError{Message: "request is not a httpRequest"})
 	}
 	r, err := httpReq.createHTTPRequest(c.endpoint)
-	if ctx != nil {
-		r = r.WithContext(ctx)
+	if ctx == nil {
+		ctx = context.Background()
 	}
+	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+		WroteRequest: httpReq.WroteRequest,
+	})
+	r = r.WithContext(ctx)
 	if err != nil {
 		return nil, driver.WithStack(err)
 	}

--- a/http/connection.go
+++ b/http/connection.go
@@ -104,6 +104,11 @@ type httpConnection struct {
 	client   *http.Client
 }
 
+// String returns the endpoint as string
+func (c *httpConnection) String() string {
+	return c.endpoint.String()
+}
+
 // NewRequest creates a new request with given method and path.
 func (c *httpConnection) NewRequest(method, path string) (driver.Request, error) {
 	switch method {

--- a/http/connection.go
+++ b/http/connection.go
@@ -37,6 +37,7 @@ import (
 
 const (
 	keyRawResponse = "arangodb-rawResponse"
+	keyResponse    = "arangodb-response"
 )
 
 // ConnectionConfig provides all configuration options for a HTTP connection.
@@ -132,13 +133,14 @@ func (c *httpConnection) Do(ctx context.Context, req driver.Request) (driver.Res
 		return nil, driver.WithStack(driver.InvalidArgumentError{Message: "request is not a httpRequest"})
 	}
 	r, err := httpReq.createHTTPRequest(c.endpoint)
-	if ctx == nil {
-		ctx = context.Background()
+	rctx := ctx
+	if rctx == nil {
+		rctx = context.Background()
 	}
-	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+	rctx = httptrace.WithClientTrace(rctx, &httptrace.ClientTrace{
 		WroteRequest: httpReq.WroteRequest,
 	})
-	r = r.WithContext(ctx)
+	r = r.WithContext(rctx)
 	if err != nil {
 		return nil, driver.WithStack(err)
 	}
@@ -155,7 +157,15 @@ func (c *httpConnection) Do(ctx context.Context, req driver.Request) (driver.Res
 		}
 	}
 
-	return &httpResponse{resp: resp, rawResponse: rawResponse}, nil
+	httpResp := &httpResponse{resp: resp, rawResponse: rawResponse}
+	if ctx != nil {
+		if v := ctx.Value(keyResponse); v != nil {
+			if respPtr, ok := v.(*driver.Response); ok {
+				*respPtr = httpResp
+			}
+		}
+	}
+	return httpResp, nil
 }
 
 // Unmarshal unmarshals the given raw object into the given result interface.

--- a/http/response.go
+++ b/http/response.go
@@ -46,6 +46,13 @@ func (r *httpResponse) StatusCode() int {
 	return r.resp.StatusCode
 }
 
+// Endpoint returns the endpoint that handled the request.
+func (r *httpResponse) Endpoint() string {
+	u := *r.resp.Request.URL
+	u.Path = ""
+	return u.String()
+}
+
 // CheckStatus checks if the status of the response equals to one of the given status codes.
 // If so, nil is returned.
 // If not, an attempt is made to parse an error response in the body and an error is returned.

--- a/http/response_element.go
+++ b/http/response_element.go
@@ -58,6 +58,11 @@ func (r *httpResponseElement) StatusCode() int {
 	return *r.statusCode
 }
 
+// Endpoint returns the endpoint that handled the request.
+func (r *httpResponseElement) Endpoint() string {
+	return ""
+}
+
 // CheckStatus checks if the status of the response equals to one of the given status codes.
 // If so, nil is returned.
 // If not, an attempt is made to parse an error response in the body and an error is returned.

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -94,9 +94,13 @@ func createConnectionFromEnv(t testEnv) driver.Connection {
 }
 
 // createClientFromEnv initializes a Client from information specified in environment variables.
-func createClientFromEnv(t testEnv, waitUntilReady bool) driver.Client {
+func createClientFromEnv(t testEnv, waitUntilReady bool, connection ...*driver.Connection) driver.Client {
+	conn := createConnectionFromEnv(t)
+	if len(connection) == 1 {
+		*connection[0] = conn
+	}
 	c, err := driver.NewClient(driver.ClientConfig{
-		Connection:     createConnectionFromEnv(t),
+		Connection:     conn,
 		Authentication: createAuthenticationFromEnv(t),
 	})
 	if err != nil {

--- a/test/failover_test.go
+++ b/test/failover_test.go
@@ -74,12 +74,10 @@ func failoverTest(action string, t *testing.T) {
 
 		// Perform low lever request and check handling endpoint
 		for {
-			req, err := conn.NewRequest("GET", "/_api/version")
-			if err != nil {
-				t.Fatalf("Cannot create request: %s", describe(err))
-			}
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*9)
-			resp, err := conn.Do(ctx, req)
+			var resp driver.Response
+			ctx := driver.WithResponse(nil, &resp)
+			ctx, cancel := context.WithTimeout(ctx, time.Second*9)
+			_, err := c.Version(ctx)
 			cancel()
 			if driver.IsResponseError(err) {
 				t.Logf("ResponseError in version request")

--- a/test/failover_test.go
+++ b/test/failover_test.go
@@ -1,0 +1,177 @@
+//
+// DISCLAIMER
+//
+// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+// +build failover
+
+package test
+
+import (
+	"context"
+	"math/rand"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	driver "github.com/arangodb/go-driver"
+	"github.com/coreos/go-iptables/iptables"
+)
+
+const (
+	filterTable = "filter"
+	chainName   = "ARANGOGODRIVER"
+)
+
+// TestFailoverDrop performs various tests while DROP'ng traffic to 1 coordinator.
+func TestFailoverDrop(t *testing.T) {
+	failoverTest("DROP", t)
+}
+
+// TestFailoverReject performs various tests while REJECT'ng traffic to 1 coordinator.
+func TestFailoverReject(t *testing.T) {
+	failoverTest("REJECT", t)
+}
+
+func failoverTest(action string, t *testing.T) {
+	iptc, err := iptables.New()
+	if err != nil {
+		t.Fatalf("Failed to create iptables client: %s", describe(err))
+	}
+	createChains(iptc, t)
+	defer cleanupChains(iptc, t)
+
+	coordinatorPorts := []int{7002, 7007, 7012}
+	var conn driver.Connection
+	c := createClientFromEnv(t, true, &conn)
+	db := ensureDatabase(nil, c, "failover_test", nil, t)
+	col := ensureCollection(nil, db, strings.ToLower(action)+"_test", nil, t)
+
+	lastEndpoint := ""
+	endpointChanges := 0
+	for i := 0; i < 1000 && endpointChanges < 10; i++ {
+		port := coordinatorPorts[rand.Intn(len(coordinatorPorts))]
+		ruleSpec := blockPort(iptc, port, action, t)
+
+		// Perform low lever request and check handling endpoint
+		req, err := conn.NewRequest("GET", "/_api/version")
+		if err != nil {
+			t.Fatalf("Cannot create request: %s", describe(err))
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*9)
+		resp, err := conn.Do(ctx, req)
+		cancel()
+		if err != nil {
+			t.Fatalf("Cannot execute request: %s", describe(err))
+		}
+		ep := resp.Endpoint()
+		if ep != lastEndpoint {
+			lastEndpoint = ep
+			endpointChanges++
+			t.Logf("New server detected: %s", ep)
+		}
+
+		// Create document & read it
+		doc := UserDoc{
+			"Jan",
+			40,
+		}
+		meta, err := col.CreateDocument(nil, doc)
+		if err != nil {
+			t.Fatalf("Failed to create new document: %s", describe(err))
+		}
+		// Document must exists now
+		var readDoc UserDoc
+		if _, err := col.ReadDocument(nil, meta.Key, &readDoc); err != nil {
+			t.Fatalf("Failed to read document '%s': %s", meta.Key, describe(err))
+		}
+		if !reflect.DeepEqual(doc, readDoc) {
+			t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
+		}
+
+		removeRuleSpec(iptc, ruleSpec, t)
+	}
+}
+
+func blockPort(client *iptables.IPTables, port int, action string, t *testing.T) []string {
+	ruleSpec := []string{
+		"-p", "tcp",
+		"-m", "tcp", "--dport", strconv.Itoa(port),
+		"-j", action,
+	}
+	t.Logf("Denying traffic to TCP port %d", port)
+	if found, err := client.Exists(filterTable, chainName, ruleSpec...); err != nil {
+		t.Fatalf("Failed to check existance of rulespec %q: %v", ruleSpec, err)
+	} else if !found {
+		if err := client.Insert(filterTable, chainName, 1, ruleSpec...); err != nil {
+			t.Fatalf("Failed to deny traffic to TCP port %d: %v", port, err)
+		}
+	}
+	return ruleSpec
+}
+
+func removeRuleSpec(client *iptables.IPTables, ruleSpec []string, t *testing.T) {
+	if found, err := client.Exists(filterTable, chainName, ruleSpec...); err != nil {
+		t.Fatalf("Failed to check existance of rulespec %q: %v", ruleSpec, err)
+	} else if found {
+		if err := client.Delete(filterTable, chainName, ruleSpec...); err != nil {
+			t.Fatalf("Failed to remove ruleSpec %q: %v", ruleSpec, err)
+		}
+	}
+}
+
+func createChains(client *iptables.IPTables, t *testing.T) {
+	if err := client.ClearChain(filterTable, chainName); err != nil {
+		t.Fatalf("Failed to create chain: %s", describe(err))
+	}
+	if err := client.Append(filterTable, chainName, "-j", "RETURN"); err != nil {
+		t.Fatalf("Failed to append RETURN to chain: %s", describe(err))
+	}
+	if err := client.Insert(filterTable, "INPUT", 1, "-j", chainName); err != nil {
+		t.Fatalf("Failed to insert INPUT chain: %s", describe(err))
+	}
+	if err := client.Insert(filterTable, "FORWARD", 1, "-j", chainName); err != nil {
+		t.Fatalf("Failed to insert FORWARD OUTPUT chain: %s", describe(err))
+	}
+	if err := client.Insert(filterTable, "OUTPUT", 1, "-j", chainName); err != nil {
+		t.Fatalf("Failed to insert OUTPUT chain: %s", describe(err))
+	}
+}
+
+// cleanupChains removes all generated iptables chain & rules made by createChains.
+func cleanupChains(client *iptables.IPTables, t *testing.T) {
+	if err := client.Delete(filterTable, "INPUT", "-j", chainName); err != nil {
+		t.Logf("Failed to remove INPUT chain rule: %v", err)
+	}
+	if err := client.Delete(filterTable, "FORWARD", "-j", chainName); err != nil {
+		t.Logf("Failed to remove FORWARD chain rule: %v", err)
+	}
+	if err := client.Delete(filterTable, "OUTPUT", "-j", chainName); err != nil {
+		t.Logf("Failed to remove OUTPUT chain rule: %v", err)
+	}
+	if err := client.ClearChain(filterTable, chainName); err != nil {
+		t.Logf("Failed to clear '%s' chain: %v", chainName, err)
+	}
+	if err := client.DeleteChain(filterTable, chainName); err != nil {
+		t.Logf("Failed to remove '%s' chain: %v", chainName, err)
+	}
+}


### PR DESCRIPTION
This PR adds tests (and fixes some bugs) regarding automatic failover.

Run the tests using:

```
make run-tests-cluster-failover
```

The test uses `iptables` to actively DROP or REJECT traffic to a random coordinator.
The test succeeds when a certain number of successful failovers has been detected.