### PR TITLE
Added WithEndpoint, used to force a specific endpoint for a request. 

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -191,6 +191,11 @@ func (c *authenticatedConnection) Unmarshal(data RawObject, result interface{}) 
 	return nil
 }
 
+// Endpoints returns the endpoints used by this connection.
+func (c *authenticatedConnection) Endpoints() []string {
+	return c.conn.Endpoints()
+}
+
 // prepare calls Authentication.Prepare if needed.
 func (c *authenticatedConnection) prepare(ctx context.Context) error {
 	c.prepareMutex.Lock()

--- a/connection.go
+++ b/connection.go
@@ -38,6 +38,9 @@ type Connection interface {
 
 	// Unmarshal unmarshals the given raw object into the given result interface.
 	Unmarshal(data RawObject, result interface{}) error
+
+	// Endpoints returns the endpoints used by this connection.
+	Endpoints() []string
 }
 
 // Request represents the input to a request on the server.

--- a/context.go
+++ b/context.go
@@ -41,6 +41,7 @@ const (
 	keyRawResponse   = "arangodb-rawResponse"
 	keyImportDetails = "arangodb-importDetails"
 	keyResponse      = "arangodb-response"
+	keyEndpoint      = "arangodb-endpoint"
 )
 
 // WithRevision is used to configure a context to make document
@@ -75,6 +76,13 @@ func WithDetails(parent context.Context, value ...bool) context.Context {
 		v = value[0]
 	}
 	return context.WithValue(contextOrBackground(parent), keyDetails, v)
+}
+
+// WithEndpoint is used to configure a context that forces a request to be executed on a specific endpoint.
+// If you specify and endpoint like this, failover is disabled.
+// If you specify an unknown endpoint, and InvalidArgumentError is returned from requests.
+func WithEndpoint(parent context.Context, endpoint string) context.Context {
+	return context.WithValue(contextOrBackground(parent), keyEndpoint, endpoint)
 }
 
 // WithKeepNull is used to configure a context to make update functions keep null fields (value==true)

--- a/database_impl.go
+++ b/database_impl.go
@@ -83,7 +83,7 @@ func (d *database) Query(ctx context.Context, query string, bindVars map[string]
 	if err := resp.ParseBody("", &data); err != nil {
 		return nil, WithStack(err)
 	}
-	col, err := newCursor(data, d)
+	col, err := newCursor(data, resp.Endpoint(), d)
 	if err != nil {
 		return nil, WithStack(err)
 	}

--- a/error.go
+++ b/error.go
@@ -149,8 +149,8 @@ func (e *ResponseError) Error() string {
 	return e.Err.Error()
 }
 
-// IsResponseError returns true if the given error is (or is caused by) a ResponseError.
-func IsResponseError(err error) bool {
+// IsResponse returns true if the given error is (or is caused by) a ResponseError.
+func IsResponse(err error) bool {
 	return isCausedBy(err, func(e error) bool { _, ok := e.(*ResponseError); return ok })
 }
 

--- a/http/connection.go
+++ b/http/connection.go
@@ -175,3 +175,8 @@ func (c *httpConnection) Unmarshal(data driver.RawObject, result interface{}) er
 	}
 	return nil
 }
+
+// Endpoints returns the endpoints used by this connection.
+func (c *httpConnection) Endpoints() []string {
+	return []string{c.endpoint.String()}
+}

--- a/test/failover_test.go
+++ b/test/failover_test.go
@@ -79,7 +79,7 @@ func failoverTest(action string, t *testing.T) {
 			ctx, cancel := context.WithTimeout(ctx, time.Second*9)
 			_, err := c.Version(ctx)
 			cancel()
-			if driver.IsResponseError(err) {
+			if driver.IsResponse(err) {
 				t.Logf("ResponseError in version request")
 				continue
 			} else if err != nil {


### PR DESCRIPTION
When a specific endpoint is set, failover is disabled.

`WithEndpoint` is used by Cursor implementation because cursors are only valid in the context of a specific coordinator.

fixed #16