### PR TITLE
Fixed Cursor.ReadDocument for queries returning non-documents

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -38,6 +38,8 @@ type Cursor interface {
 	// ReadDocument reads the next document from the cursor.
 	// The document data is stored into result, the document meta data is returned.
 	// If the cursor has no more documents, a NoMoreDocuments error is returned.
+	// Note: If the query (resulting in this cursor) does not return documents,
+	//       then the returned DocumentMeta will be empty.
 	ReadDocument(ctx context.Context, result interface{}) (DocumentMeta, error)
 
 	// Count returns the total number of result documents available.

--- a/cursor_impl.go
+++ b/cursor_impl.go
@@ -145,7 +145,8 @@ func (c *cursor) ReadDocument(ctx context.Context, result interface{}) (Document
 	c.resultIndex++
 	var meta DocumentMeta
 	if err := c.conn.Unmarshal(*c.Result[index], &meta); err != nil {
-		return DocumentMeta{}, WithStack(err)
+		// If a cursor returns something other than a document, this will fail.
+		// Just ignore it.
 	}
 	if err := c.conn.Unmarshal(*c.Result[index], result); err != nil {
 		return DocumentMeta{}, WithStack(err)

--- a/test/cursor_test.go
+++ b/test/cursor_test.go
@@ -127,6 +127,12 @@ func TestCreateCursor(t *testing.T) {
 			BindVars:      map[string]interface{}{"maxage": 20},
 			ExpectSuccess: false, // `@maxage` versus `@maxAge`
 		},
+		queryTest{
+			Query:             "FOR u IN users SORT u.age RETURN u.age",
+			ExpectedDocuments: []interface{}{12, 13, 25, 42, 67},
+			DocumentType:      reflect.TypeOf(12),
+			ExpectSuccess:     true,
+		},
 	}
 
 	// Setup context alternatives


### PR DESCRIPTION
fixes #20  

The problem was that a query that returning anything other than a document, would cause Cursor.ReadDocument to fail because it returned with an error when the DocumentMeta could not be unmarshaled.
This PR ignores such errors, assuming that when the DocumentMeta cannot be unmarshaled, it is probably not there.