### PR TITLE
Added NoDeduplicate field for hash & skiplist index options

### DIFF
--- a/collection_indexes.go
+++ b/collection_indexes.go
@@ -88,6 +88,10 @@ type EnsureHashIndexOptions struct {
 	Unique bool
 	// If true, then create a sparse index.
 	Sparse bool
+	// If true, de-duplication of array-values, before being added to the index, will be turned off.
+	// This flag requires ArangoDB 3.2.
+	// Note: this setting is only relevant for indexes with array fields (e.g. "fieldName[*]")
+	NoDeduplicate bool
 }
 
 // EnsurePersistentIndexOptions contains specific options for creating a persistent index.
@@ -104,4 +108,8 @@ type EnsureSkipListIndexOptions struct {
 	Unique bool
 	// If true, then create a sparse index.
 	Sparse bool
+	// If true, de-duplication of array-values, before being added to the index, will be turned off.
+	// This flag requires ArangoDB 3.2.
+	// Note: this setting is only relevant for indexes with array fields (e.g. "fieldName[*]")
+	NoDeduplicate bool
 }

--- a/collection_indexes_impl.go
+++ b/collection_indexes_impl.go
@@ -28,13 +28,14 @@ import (
 )
 
 type indexData struct {
-	ID        string   `json:"id,omitempty"`
-	Type      string   `json:"type"`
-	Fields    []string `json:"fields,omitempty"`
-	Unique    *bool    `json:"unique,omitempty"`
-	Sparse    *bool    `json:"sparse,omitempty"`
-	GeoJSON   *bool    `json:"geoJson,omitempty"`
-	MinLength int      `json:"minLength,omitempty"`
+	ID          string   `json:"id,omitempty"`
+	Type        string   `json:"type"`
+	Fields      []string `json:"fields,omitempty"`
+	Unique      *bool    `json:"unique,omitempty"`
+	Deduplicate *bool    `json:"deduplicate,omitempty"`
+	Sparse      *bool    `json:"sparse,omitempty"`
+	GeoJSON     *bool    `json:"geoJson,omitempty"`
+	MinLength   int      `json:"minLength,omitempty"`
 }
 
 type indexListResponse struct {
@@ -166,9 +167,13 @@ func (c *collection) EnsureHashIndex(ctx context.Context, fields []string, optio
 		Type:   "hash",
 		Fields: fields,
 	}
+	off := false
 	if options != nil {
 		input.Unique = &options.Unique
 		input.Sparse = &options.Sparse
+		if options.NoDeduplicate {
+			input.Deduplicate = &off
+		}
 	}
 	idx, created, err := c.ensureIndex(ctx, input)
 	if err != nil {
@@ -204,9 +209,13 @@ func (c *collection) EnsureSkipListIndex(ctx context.Context, fields []string, o
 		Type:   "skiplist",
 		Fields: fields,
 	}
+	off := false
 	if options != nil {
 		input.Unique = &options.Unique
 		input.Sparse = &options.Sparse
+		if options.NoDeduplicate {
+			input.Deduplicate = &off
+		}
 	}
 	idx, created, err := c.ensureIndex(ctx, input)
 	if err != nil {


### PR DESCRIPTION
Fixes #48 

The added field is `NoDeduplicate` and not `Deduplicate` to avoid breaking changes.
Since the default value for `deduplicate` is `true`, and the go field will default to `false` if left unspecified, you would get unexpected `deduplicate=false` behavior when just updating the go driver without updating your code.

See also https://github.com/arangodb/arangodb/pull/2644