### PR TITLE
Adding `WithConfigured`

### DIFF
--- a/user.go
+++ b/user.go
@@ -61,6 +61,9 @@ type User interface {
 	// GetDatabaseAccess gets the access rights for this user to the given database.
 	// Pass a `nil` database to get the default access this user has to any new database.
 	// This function requires ArangoDB 3.2 and up.
+	// By default this function returns the "effective" grant.
+	// To return the "configured" grant, pass a context configured with `WithConfigured`.
+	// This distinction is only relevant in ArangoDB 3.3 in the context of a readonly database.
 	GetDatabaseAccess(ctx context.Context, db Database) (Grant, error)
 
 	// RemoveDatabaseAccess removes the access this user has to the given database.
@@ -82,6 +85,9 @@ type User interface {
 	// If you pass a `Collection`, it will get access for that collection.
 	// If you pass a `Database`, it will get the default collection access for that database.
 	// If you pass `nil`, it will get the default collection access for the default database.
+	// By default this function returns the "effective" grant.
+	// To return the "configured" grant, pass a context configured with `WithConfigured`.
+	// This distinction is only relevant in ArangoDB 3.3 in the context of a readonly database.
 	GetCollectionAccess(ctx context.Context, col AccessTarget) (Grant, error)
 
 	// RemoveCollectionAccess removes the access this user has to a collection.

--- a/user_impl.go
+++ b/user_impl.go
@@ -232,6 +232,7 @@ func (u *user) GetDatabaseAccess(ctx context.Context, db Database) (Grant, error
 	if err != nil {
 		return GrantNone, WithStack(err)
 	}
+	applyContextSettings(ctx, req)
 	resp, err := u.conn.Do(ctx, req)
 	if err != nil {
 		return GrantNone, WithStack(err)
@@ -322,6 +323,7 @@ func (u *user) GetCollectionAccess(ctx context.Context, col AccessTarget) (Grant
 	if err != nil {
 		return GrantNone, WithStack(err)
 	}
+	applyContextSettings(ctx, req)
 	resp, err := u.conn.Do(ctx, req)
 	if err != nil {
 		return GrantNone, WithStack(err)


### PR DESCRIPTION
This enable making the distinction between effective & configured database/collection access.

Note. This PR extends #62