### PR TITLE
Adding Response.Header(string) & tests

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -91,6 +91,10 @@ type Response interface {
 	// If so, nil is returned.
 	// If not, an attempt is made to parse an error response in the body and an error is returned.
 	CheckStatus(validStatusCodes ...int) error
+	// Header returns the value of a response header with given key.
+	// If no such header is found, an empty string is returned.
+	// On nested Response's, this function will always return an empty string.
+	Header(key string) string
 	// ParseBody performs protocol specific unmarshalling of the response data into the given result.
 	// If the given field is non-empty, the contents of that field will be parsed into the given result.
 	// This can only be used for requests that return a single object.

--- a/http/response_json.go
+++ b/http/response_json.go
@@ -77,6 +77,12 @@ func (r *httpJSONResponse) CheckStatus(validStatusCodes ...int) error {
 	}
 }
 
+// Header returns the value of a response header with given key.
+// If no such header is found, an empty string is returned.
+func (r *httpJSONResponse) Header(key string) string {
+	return r.resp.Header.Get(key)
+}
+
 // ParseBody performs protocol specific unmarshalling of the response data into the given result.
 // If the given field is non-empty, the contents of that field will be parsed into the given result.
 func (r *httpJSONResponse) ParseBody(field string, result interface{}) error {

--- a/http/response_json_element.go
+++ b/http/response_json_element.go
@@ -89,6 +89,12 @@ func (r *httpJSONResponseElement) CheckStatus(validStatusCodes ...int) error {
 	}
 }
 
+// Header returns the value of a response header with given key.
+// If no such header is found, an empty string is returned.
+func (r *httpJSONResponseElement) Header(key string) string {
+	return ""
+}
+
 // ParseBody performs protocol specific unmarshalling of the response data into the given result.
 // If the given field is non-empty, the contents of that field will be parsed into the given result.
 func (r *httpJSONResponseElement) ParseBody(field string, result interface{}) error {

--- a/http/response_vpack.go
+++ b/http/response_vpack.go
@@ -75,6 +75,12 @@ func (r *httpVPackResponse) CheckStatus(validStatusCodes ...int) error {
 	}
 }
 
+// Header returns the value of a response header with given key.
+// If no such header is found, an empty string is returned.
+func (r *httpVPackResponse) Header(key string) string {
+	return r.resp.Header.Get(key)
+}
+
 // ParseBody performs protocol specific unmarshalling of the response data into the given result.
 // If the given field is non-empty, the contents of that field will be parsed into the given result.
 func (r *httpVPackResponse) ParseBody(field string, result interface{}) error {

--- a/http/response_vpack_element.go
+++ b/http/response_vpack_element.go
@@ -87,6 +87,12 @@ func (r *httpVPackResponseElement) CheckStatus(validStatusCodes ...int) error {
 	}
 }
 
+// Header returns the value of a response header with given key.
+// If no such header is found, an empty string is returned.
+func (r *httpVPackResponseElement) Header(key string) string {
+	return ""
+}
+
 // ParseBody performs protocol specific unmarshalling of the response data into the given result.
 // If the given field is non-empty, the contents of that field will be parsed into the given result.
 func (r *httpVPackResponseElement) ParseBody(field string, result interface{}) error {

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -288,6 +288,9 @@ func TestResponseHeader(t *testing.T) {
 		if x := resp.Header("ETag"); x != expectedETag {
 			t.Errorf("Unexpected result from Header('ETag'), got '%s', expected '%s'", x, expectedETag)
 		}
+		if x := resp.Header("Etag"); x != expectedETag {
+			t.Errorf("Unexpected result from Header('Etag'), got '%s', expected '%s'", x, expectedETag)
+		}
 		if x := resp.Header("etag"); x != expectedETag {
 			t.Errorf("Unexpected result from Header('etag'), got '%s', expected '%s'", x, expectedETag)
 		}

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -27,6 +27,7 @@ import (
 	"crypto/tls"
 	httplib "net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -266,8 +267,7 @@ func TestResponseHeader(t *testing.T) {
 	db := ensureDatabase(ctx, c, "_system", nil, t)
 	col := ensureCollection(ctx, db, "response_header_test", nil, t)
 
-	// `ETag` header must contain the `_id` of the new document
-	// `ERev` header must contain the `_rev` of the new document
+	// `ETag` header must contain the `_rev` of the new document in quotes.
 	doc := map[string]string{
 		"Test":   "TestResponseHeader",
 		"Intent": "Check Response.Header",
@@ -276,13 +276,14 @@ func TestResponseHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDocument failed: %s", describe(err))
 	}
-	if x := resp.Header("ETag"); x != meta.Rev {
-		t.Errorf("Unexpected result from Header('ETag'), got '%s', expected '%s'", x, meta.Rev)
+	expectedETag := strconv.Quote(meta.Rev)
+	if x := resp.Header("ETag"); x != expectedETag {
+		t.Errorf("Unexpected result from Header('ETag'), got '%s', expected '%s'", x, expectedETag)
 	}
-	if x := resp.Header("etag"); x != meta.Rev {
-		t.Errorf("Unexpected result from Header('etag'), got '%s', expected '%s'", x, meta.Rev)
+	if x := resp.Header("etag"); x != expectedETag {
+		t.Errorf("Unexpected result from Header('etag'), got '%s', expected '%s'", x, expectedETag)
 	}
-	if x := resp.Header("ETAG"); x != meta.Rev {
-		t.Errorf("Unexpected result from Header('ETAG'), got '%s', expected '%s'", x, meta.Rev)
+	if x := resp.Header("ETAG"); x != expectedETag {
+		t.Errorf("Unexpected result from Header('ETAG'), got '%s', expected '%s'", x, expectedETag)
 	}
 }

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -163,7 +163,7 @@ func createClientFromEnv(t testEnv, waitUntilReady bool, connection ...*driver.C
 		t.Fatalf("Failed to create new client: %s", describe(err))
 	}
 	if waitUntilReady {
-		timeout := 3*time.Minute
+		timeout := 3 * time.Minute
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		if up := waitUntilServerAvailable(ctx, c, t); !up {
@@ -244,7 +244,7 @@ func TestCreateClientHttpConnectionCustomTransport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create new client: %s", describe(err))
 	}
-	timeout := 3*time.Minute
+	timeout := 3 * time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	if up := waitUntilServerAvailable(ctx, c, t); !up {
@@ -254,5 +254,32 @@ func TestCreateClientHttpConnectionCustomTransport(t *testing.T) {
 		t.Errorf("Version failed: %s", describe(err))
 	} else {
 		t.Logf("Got server version %s", info)
+	}
+}
+
+// TestResponseHeader checks the Response.Header function.
+func TestResponseHeader(t *testing.T) {
+	c := createClientFromEnv(t, true)
+	ctx := context.Background()
+	var resp driver.Response
+	if _, err := c.Version(driver.WithResponse(ctx, &resp)); err != nil {
+		t.Fatalf("Version failed: %s", describe(err))
+	}
+
+	// Check valid key
+	expectedServer := "ArangoDB"
+	if server := resp.Header("server"); server != expectedServer {
+		t.Errorf("Unexpected result from Header('server'), got '%s', expected '%s'", server, expectedServer)
+	}
+	if server := resp.Header("Server"); server != expectedServer {
+		t.Errorf("Unexpected result from Header('Server'), got '%s', expected '%s'", server, expectedServer)
+	}
+	if server := resp.Header("SERVER"); server != expectedServer {
+		t.Errorf("Unexpected result from Header('SERVER'), got '%s', expected '%s'", server, expectedServer)
+	}
+
+	// Check non-existing key
+	if value := resp.Header("keyNotFound"); value != "" {
+		t.Errorf("Unexpected result from Header('keyNotFound'), got '%s', expected ''", value)
 	}
 }

--- a/vst/response.go
+++ b/vst/response.go
@@ -24,6 +24,7 @@ package vst
 
 import (
 	"fmt"
+	"strings"
 
 	driver "github.com/arangodb/go-driver"
 	"github.com/arangodb/go-driver/vst/protocol"
@@ -148,6 +149,7 @@ func (r *vstResponse) CheckStatus(validStatusCodes ...int) error {
 // If no such header is found, an empty string is returned.
 func (r *vstResponse) Header(key string) string {
 	if r.meta != nil {
+		key = strings.ToLower(key)
 		if elem, err := r.meta.Get(key); err == nil {
 			if value, err := elem.GetString(); err == nil {
 				return value

--- a/vst/response_element.go
+++ b/vst/response_element.go
@@ -87,6 +87,12 @@ func (r *vstResponseElement) CheckStatus(validStatusCodes ...int) error {
 	}
 }
 
+// Header returns the value of a response header with given key.
+// If no such header is found, an empty string is returned.
+func (r *vstResponseElement) Header(key string) string {
+	return ""
+}
+
 // ParseBody performs protocol specific unmarshalling of the response data into the given result.
 // If the given field is non-empty, the contents of that field will be parsed into the given result.
 func (r *vstResponseElement) ParseBody(field string, result interface{}) error {


### PR DESCRIPTION
This PR adds a `Header(string)` function to the `Response` interface.
It is used to get response header values.