### PR TITLE
Adds example of overriding Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,15 @@ if err != nil {
 fmt.Printf("Created document with key '%s', revision '%s'\n", meta.Key, meta.Rev)
 ```
 
+If you want to set the &#95;key, override the json marshaller.
+
+```go
+
+type Keyed struct {
+    Key string `json:"_key"`
+}
+```
+
 ## Removing a document 
 
 ```go


### PR DESCRIPTION
I added to the README how to override the key field with the new document. It took about 30 minutes of guesswork. Think it should save time for others.