### PR TITLE
Fix ReturnOld/New for edge/vertex operations.

### DIFF
--- a/context.go
+++ b/context.go
@@ -385,12 +385,12 @@ func withDocumentAt(ctx context.Context, index int) (context.Context, error) {
 	// ReturnOld
 	if v := ctx.Value(keyReturnOld); v != nil {
 		val := reflect.ValueOf(v)
-		ctx = WithReturnOld(ctx, val.Index(index).Interface())
+		ctx = WithReturnOld(ctx, val.Index(index).Addr().Interface())
 	}
 	// ReturnNew
 	if v := ctx.Value(keyReturnNew); v != nil {
 		val := reflect.ValueOf(v)
-		ctx = WithReturnNew(ctx, val.Index(index).Interface())
+		ctx = WithReturnNew(ctx, val.Index(index).Addr().Interface())
 	}
 
 	return ctx, nil

--- a/edge_collection_documents_impl.go
+++ b/edge_collection_documents_impl.go
@@ -148,6 +148,9 @@ func (c *edgeCollection) CreateDocuments(ctx context.Context, documents interfac
 	silent := false
 	for i := 0; i < documentCount; i++ {
 		doc := documentsVal.Index(i)
+		if !doc.Kind() != reflect.Ptr {
+			doc = doc.Addr()
+		}
 		ctx, err := withDocumentAt(ctx, i)
 		if err != nil {
 			return nil, nil, WithStack(err)
@@ -256,6 +259,9 @@ func (c *edgeCollection) UpdateDocuments(ctx context.Context, keys []string, upd
 	silent := false
 	for i := 0; i < updateCount; i++ {
 		update := updatesVal.Index(i)
+		if !update.Kind() != reflect.Ptr {
+			update = update.Addr()
+		}
 		ctx, err := withDocumentAt(ctx, i)
 		if err != nil {
 			return nil, nil, WithStack(err)
@@ -375,6 +381,9 @@ func (c *edgeCollection) ReplaceDocuments(ctx context.Context, keys []string, do
 	silent := false
 	for i := 0; i < documentCount; i++ {
 		doc := documentsVal.Index(i)
+		if !doc.Kind() != reflect.Ptr {
+			doc = doc.Addr()
+		}
 		ctx, err := withDocumentAt(ctx, i)
 		if err != nil {
 			return nil, nil, WithStack(err)

--- a/edge_collection_documents_impl.go
+++ b/edge_collection_documents_impl.go
@@ -148,7 +148,7 @@ func (c *edgeCollection) CreateDocuments(ctx context.Context, documents interfac
 	silent := false
 	for i := 0; i < documentCount; i++ {
 		doc := documentsVal.Index(i)
-		if !doc.Kind() != reflect.Ptr {
+		if doc.Kind() != reflect.Ptr {
 			doc = doc.Addr()
 		}
 		ctx, err := withDocumentAt(ctx, i)
@@ -259,7 +259,7 @@ func (c *edgeCollection) UpdateDocuments(ctx context.Context, keys []string, upd
 	silent := false
 	for i := 0; i < updateCount; i++ {
 		update := updatesVal.Index(i)
-		if !update.Kind() != reflect.Ptr {
+		if update.Kind() != reflect.Ptr {
 			update = update.Addr()
 		}
 		ctx, err := withDocumentAt(ctx, i)
@@ -381,7 +381,7 @@ func (c *edgeCollection) ReplaceDocuments(ctx context.Context, keys []string, do
 	silent := false
 	for i := 0; i < documentCount; i++ {
 		doc := documentsVal.Index(i)
-		if !doc.Kind() != reflect.Ptr {
+		if doc.Kind() != reflect.Ptr {
 			doc = doc.Addr()
 		}
 		ctx, err := withDocumentAt(ctx, i)

--- a/edge_collection_documents_impl.go
+++ b/edge_collection_documents_impl.go
@@ -148,9 +148,6 @@ func (c *edgeCollection) CreateDocuments(ctx context.Context, documents interfac
 	silent := false
 	for i := 0; i < documentCount; i++ {
 		doc := documentsVal.Index(i)
-		if doc.Kind() != reflect.Ptr {
-			doc = doc.Addr()
-		}
 		ctx, err := withDocumentAt(ctx, i)
 		if err != nil {
 			return nil, nil, WithStack(err)
@@ -259,9 +256,6 @@ func (c *edgeCollection) UpdateDocuments(ctx context.Context, keys []string, upd
 	silent := false
 	for i := 0; i < updateCount; i++ {
 		update := updatesVal.Index(i)
-		if update.Kind() != reflect.Ptr {
-			update = update.Addr()
-		}
 		ctx, err := withDocumentAt(ctx, i)
 		if err != nil {
 			return nil, nil, WithStack(err)
@@ -381,9 +375,6 @@ func (c *edgeCollection) ReplaceDocuments(ctx context.Context, keys []string, do
 	silent := false
 	for i := 0; i < documentCount; i++ {
 		doc := documentsVal.Index(i)
-		if doc.Kind() != reflect.Ptr {
-			doc = doc.Addr()
-		}
 		ctx, err := withDocumentAt(ctx, i)
 		if err != nil {
 			return nil, nil, WithStack(err)
@@ -435,6 +426,9 @@ func (c *edgeCollection) removeDocument(ctx context.Context, key string) (Docume
 		return DocumentMeta{}, contextSettings{}, WithStack(err)
 	}
 	cs := applyContextSettings(ctx, req)
+	if cs.ReturnOld != nil {
+		return DocumentMeta{}, contextSettings{}, WithStack(InvalidArgumentError{Message: "ReturnOld is not support when removing edges"})
+	}
 	resp, err := c.conn.Do(ctx, req)
 	if err != nil {
 		return DocumentMeta{}, cs, WithStack(err)

--- a/test/edge_remove_test.go
+++ b/test/edge_remove_test.go
@@ -24,7 +24,6 @@ package test
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	driver "github.com/arangodb/go-driver"
@@ -62,11 +61,11 @@ func TestRemoveEdge(t *testing.T) {
 	}
 }
 
-// TestRemoveEdgeReturnOld creates a document, removes it checks the ReturnOld value.
+// TestRemoveEdgeReturnOld creates a document, removes it with ReturnOld, which is an invalid argument.
 func TestRemoveEdgeReturnOld(t *testing.T) {
 	var ctx context.Context
 	c := createClientFromEnv(t, true)
-	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
+	skipBelowVersion(c, "3.5", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
 	prefix := "remove_edge_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
@@ -87,17 +86,8 @@ func TestRemoveEdgeReturnOld(t *testing.T) {
 	}
 	var old RouteEdge
 	ctx = driver.WithReturnOld(ctx, &old)
-	if _, err := ec.RemoveDocument(ctx, meta.Key); err != nil {
-		t.Fatalf("Failed to remove document '%s': %s", meta.Key, describe(err))
-	}
-	// Check old document
-	if !reflect.DeepEqual(doc, old) {
-		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, old)
-	}
-	// Should not longer exist
-	var readDoc RouteEdge
-	if _, err := ec.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
-		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
+	if _, err := ec.RemoveDocument(ctx, meta.Key); !driver.IsInvalidArgument(err) {
+		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
 }
 

--- a/test/edge_remove_test.go
+++ b/test/edge_remove_test.go
@@ -65,7 +65,7 @@ func TestRemoveEdge(t *testing.T) {
 func TestRemoveEdgeReturnOld(t *testing.T) {
 	var ctx context.Context
 	c := createClientFromEnv(t, true)
-	skipBelowVersion(c, "3.5", t) // See https://github.com/arangodb/arangodb/issues/2363
+	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
 	prefix := "remove_edge_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)

--- a/test/edges_remove_test.go
+++ b/test/edges_remove_test.go
@@ -24,7 +24,6 @@ package test
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	driver "github.com/arangodb/go-driver"
@@ -117,18 +116,14 @@ func TestRemoveEdgesReturnOld(t *testing.T) {
 	}
 	oldDocs := make([]RouteEdge, len(docs))
 	ctx = driver.WithReturnOld(ctx, oldDocs)
-	if _, _, err := ec.RemoveDocuments(ctx, metas.Keys()); err != nil {
+	_, errs, err = ec.RemoveDocuments(ctx, metas.Keys())
+	if err != nil {
 		t.Fatalf("Failed to remove documents: %s", describe(err))
 	}
-	// Check old documents
-	for i, doc := range docs {
-		if !reflect.DeepEqual(doc, oldDocs[i]) {
-			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, oldDocs[i])
-		}
-		// Should not longer exist
-		var readDoc RouteEdge
-		if _, err := ec.ReadDocument(ctx, metas[i].Key, &readDoc); !driver.IsNotFound(err) {
-			t.Fatalf("Expected NotFoundError at %d, got  %s", i, describe(err))
+	// Check errors
+	for i, err := range errs {
+		if !driver.IsInvalidArgument(err) {
+			t.Fatalf("Expected InvalidArgumentError at %d, got  %s", i, describe(err))
 		}
 	}
 }

--- a/test/vertex_remove_test.go
+++ b/test/vertex_remove_test.go
@@ -24,7 +24,6 @@ package test
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	driver "github.com/arangodb/go-driver"
@@ -81,17 +80,8 @@ func TestRemoveVertexReturnOld(t *testing.T) {
 	}
 	var old Book
 	ctx = driver.WithReturnOld(ctx, &old)
-	if _, err := vc.RemoveDocument(ctx, meta.Key); err != nil {
-		t.Fatalf("Failed to remove document '%s': %s", meta.Key, describe(err))
-	}
-	// Check old document
-	if !reflect.DeepEqual(doc, old) {
-		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, old)
-	}
-	// Should not longer exist
-	var readDoc Book
-	if _, err := vc.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
-		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
+	if _, err := vc.RemoveDocument(ctx, meta.Key); !driver.IsInvalidArgument(err) {
+		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
 }
 

--- a/test/vertices_remove_test.go
+++ b/test/vertices_remove_test.go
@@ -24,7 +24,6 @@ package test
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	driver "github.com/arangodb/go-driver"
@@ -95,18 +94,14 @@ func TestRemoveVerticesReturnOld(t *testing.T) {
 	}
 	oldDocs := make([]Book, len(docs))
 	ctx = driver.WithReturnOld(ctx, oldDocs)
-	if _, _, err := vc.RemoveDocuments(ctx, metas.Keys()); err != nil {
+	_, errs, err = vc.RemoveDocuments(ctx, metas.Keys())
+	if err != nil {
 		t.Fatalf("Failed to remove documents: %s", describe(err))
 	}
-	// Check old documents
-	for i, doc := range docs {
-		if !reflect.DeepEqual(doc, oldDocs[i]) {
-			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, oldDocs[i])
-		}
-		// Should not longer exist
-		var readDoc Book
-		if _, err := vc.ReadDocument(ctx, metas[i].Key, &readDoc); !driver.IsNotFound(err) {
-			t.Fatalf("Expected NotFoundError at %d, got  %s", i, describe(err))
+	// Check errors
+	for i, err := range errs {
+		if !driver.IsInvalidArgument(err) {
+			t.Fatalf("Expected InvalidArgumentError at %d, got  %s", i, describe(err))
 		}
 	}
 }

--- a/vertex_collection_documents_impl.go
+++ b/vertex_collection_documents_impl.go
@@ -425,6 +425,9 @@ func (c *vertexCollection) removeDocument(ctx context.Context, key string) (Docu
 		return DocumentMeta{}, contextSettings{}, WithStack(err)
 	}
 	cs := applyContextSettings(ctx, req)
+	if cs.ReturnOld != nil {
+		return DocumentMeta{}, contextSettings{}, WithStack(InvalidArgumentError{Message: "ReturnOld is not support when removing vertices"})
+	}
 	resp, err := c.conn.Do(ctx, req)
 	if err != nil {
 		return DocumentMeta{}, cs, WithStack(err)


### PR DESCRIPTION
ReturnOld in combination with removing edges/vertices is not supported and now returns an `InvalidArgumentError`.

This PR depends on https://github.com/arangodb/arangodb/pull/4479