### PR TITLE
Added support for multiple VST connections per server

### DIFF
--- a/test/concurrency_test.go
+++ b/test/concurrency_test.go
@@ -1,0 +1,176 @@
+//
+// DISCLAIMER
+//
+// Copyright 2018 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Ewout Prangsma
+//
+
+package test
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"strconv"
+	"sync"
+	"testing"
+
+	driver "github.com/arangodb/go-driver"
+)
+
+// TestConcurrentCreateSmallDocuments make a lot of concurrent CreateDocument calls.
+// It then verifies that all documents "have arrived".
+func TestConcurrentCreateSmallDocuments(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skip on short tests")
+	}
+	c := createClientFromEnv(t, true)
+	db := ensureDatabase(nil, c, "document_test", nil, t)
+	col := ensureCollection(nil, db, "TestConcurrentCreateSmallDocuments", nil, t)
+
+	docChan := make(chan driver.DocumentMeta, 16*1024)
+
+	creator := func(limit, interval int) {
+		for i := 0; i < limit; i++ {
+			ctx := context.Background()
+			doc := UserDoc{
+				"Jan",
+				i * interval,
+			}
+			meta, err := col.CreateDocument(ctx, doc)
+			if err != nil {
+				t.Fatalf("Failed to create new document: %s", describe(err))
+			}
+			docChan <- meta
+		}
+	}
+
+	reader := func() {
+		for {
+			meta, ok := <-docChan
+			if !ok {
+				return
+			}
+			// Document must exists now
+			if found, err := col.DocumentExists(nil, meta.Key); err != nil {
+				t.Fatalf("DocumentExists failed for '%s': %s", meta.Key, describe(err))
+			} else if !found {
+				t.Errorf("DocumentExists returned false for '%s', expected true", meta.Key)
+			}
+			// Read document
+			var readDoc UserDoc
+			if _, err := col.ReadDocument(nil, meta.Key, &readDoc); err != nil {
+				t.Fatalf("Failed to read document '%s': %s", meta.Key, describe(err))
+			}
+		}
+	}
+
+	wgCreators := sync.WaitGroup{}
+	// Run 25 concurrent creators
+	for i := 0; i < 25; i++ {
+		wgCreators.Add(1)
+		go func() {
+			defer wgCreators.Done()
+			creator(10000, 50)
+		}()
+	}
+	wgReaders := sync.WaitGroup{}
+	// Run 50 readers
+	for i := 0; i < 50; i++ {
+		wgReaders.Add(1)
+		go func() {
+			defer wgReaders.Done()
+			reader()
+		}()
+	}
+	wgCreators.Wait()
+	close(docChan)
+	wgReaders.Wait()
+}
+
+// TestConcurrentCreateBigDocuments make a lot of concurrent CreateDocument calls.
+// It then verifies that all documents "have arrived".
+func TestConcurrentCreateBigDocuments(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skip on short tests")
+	}
+	c := createClientFromEnv(t, true)
+	db := ensureDatabase(nil, c, "document_test", nil, t)
+	col := ensureCollection(nil, db, "TestConcurrentCreateBigDocuments", nil, t)
+
+	docChan := make(chan driver.DocumentMeta, 16*1024)
+
+	creator := func(limit, interval int) {
+		data := make([]byte, 1024)
+		for i := 0; i < limit; i++ {
+			rand.Read(data)
+			ctx := context.Background()
+			doc := UserDoc{
+				"Jan" + strconv.Itoa(i) + hex.EncodeToString(data),
+				i * interval,
+			}
+			meta, err := col.CreateDocument(ctx, doc)
+			if err != nil {
+				t.Fatalf("Failed to create new document: %s", describe(err))
+			}
+			docChan <- meta
+		}
+	}
+
+	reader := func() {
+		for {
+			meta, ok := <-docChan
+			if !ok {
+				return
+			}
+			// Document must exists now
+			if found, err := col.DocumentExists(nil, meta.Key); err != nil {
+				t.Fatalf("DocumentExists failed for '%s': %s", meta.Key, describe(err))
+			} else if !found {
+				t.Errorf("DocumentExists returned false for '%s', expected true", meta.Key)
+			}
+			// Read document
+			var readDoc UserDoc
+			if _, err := col.ReadDocument(nil, meta.Key, &readDoc); err != nil {
+				t.Fatalf("Failed to read document '%s': %s", meta.Key, describe(err))
+			}
+		}
+	}
+
+	wgCreators := sync.WaitGroup{}
+	// Run 25 concurrent creators
+	for i := 0; i < 25; i++ {
+		wgCreators.Add(1)
+		go func() {
+			defer wgCreators.Done()
+			creator(1000, 50)
+		}()
+	}
+	wgReaders := sync.WaitGroup{}
+	// Run 50 readers
+	for i := 0; i < 50; i++ {
+		wgReaders.Add(1)
+		go func() {
+			defer wgReaders.Done()
+			reader()
+		}()
+	}
+	wgCreators.Wait()
+	close(docChan)
+	wgReaders.Wait()
+}

--- a/test/concurrency_test.go
+++ b/test/concurrency_test.go
@@ -82,7 +82,7 @@ func TestConcurrentCreateSmallDocuments(t *testing.T) {
 
 	noCreators := getIntFromEnv("NOCREATORS", 25)
 	noReaders := getIntFromEnv("NOREADERS", 50)
-	noDocuments := getIntFromEnv("NODOCUMENTS", 10000) // per creator
+	noDocuments := getIntFromEnv("NODOCUMENTS", 1000) // per creator
 
 	wgCreators := sync.WaitGroup{}
 	// Run N concurrent creators
@@ -158,7 +158,7 @@ func TestConcurrentCreateBigDocuments(t *testing.T) {
 
 	noCreators := getIntFromEnv("NOCREATORS", 25)
 	noReaders := getIntFromEnv("NOREADERS", 50)
-	noDocuments := getIntFromEnv("NODOCUMENTS", 1000) // per creator
+	noDocuments := getIntFromEnv("NODOCUMENTS", 100) // per creator
 
 	wgCreators := sync.WaitGroup{}
 	// Run N concurrent creators

--- a/test/concurrency_test.go
+++ b/test/concurrency_test.go
@@ -80,18 +80,22 @@ func TestConcurrentCreateSmallDocuments(t *testing.T) {
 		}
 	}
 
+	noCreators := getIntFromEnv("NOCREATORS", 25)
+	noReaders := getIntFromEnv("NOREADERS", 50)
+	noDocuments := getIntFromEnv("NODOCUMENTS", 10000) // per creator
+
 	wgCreators := sync.WaitGroup{}
-	// Run 25 concurrent creators
-	for i := 0; i < 25; i++ {
+	// Run N concurrent creators
+	for i := 0; i < noCreators; i++ {
 		wgCreators.Add(1)
 		go func() {
 			defer wgCreators.Done()
-			creator(10000, 50)
+			creator(noDocuments, noCreators)
 		}()
 	}
 	wgReaders := sync.WaitGroup{}
-	// Run 50 readers
-	for i := 0; i < 50; i++ {
+	// Run M readers
+	for i := 0; i < noReaders; i++ {
 		wgReaders.Add(1)
 		go func() {
 			defer wgReaders.Done()
@@ -152,18 +156,22 @@ func TestConcurrentCreateBigDocuments(t *testing.T) {
 		}
 	}
 
+	noCreators := getIntFromEnv("NOCREATORS", 25)
+	noReaders := getIntFromEnv("NOREADERS", 50)
+	noDocuments := getIntFromEnv("NODOCUMENTS", 1000) // per creator
+
 	wgCreators := sync.WaitGroup{}
-	// Run 25 concurrent creators
-	for i := 0; i < 25; i++ {
+	// Run N concurrent creators
+	for i := 0; i < noCreators; i++ {
 		wgCreators.Add(1)
 		go func() {
 			defer wgCreators.Done()
-			creator(1000, 50)
+			creator(noDocuments, noCreators)
 		}()
 	}
 	wgReaders := sync.WaitGroup{}
-	// Run 50 readers
-	for i := 0; i < 50; i++ {
+	// Run M readers
+	for i := 0; i < noReaders; i++ {
 		wgReaders.Add(1)
 		go func() {
 			defer wgReaders.Done()

--- a/test/util.go
+++ b/test/util.go
@@ -26,6 +26,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	driver "github.com/arangodb/go-driver"
@@ -80,4 +83,17 @@ func formatRawResponse(raw []byte) string {
 		return string(raw)
 	}
 	return hex.EncodeToString(raw)
+}
+
+// getIntFromEnv looks for an environment variable with given key.
+// If found, it parses the value to an int, if success that value is returned.
+// In all other cases, the given default value is returned.
+func getIntFromEnv(envKey string, defaultValue int) int {
+	v := strings.TrimSpace(os.Getenv(envKey))
+	if v != "" {
+		if result, err := strconv.Atoi(v); err == nil {
+			return result
+		}
+	}
+	return defaultValue
 }

--- a/vst/protocol/connection.go
+++ b/vst/protocol/connection.go
@@ -103,6 +103,12 @@ func dial(version Version, addr string, tlsConfig *tls.Config) (*Connection, err
 	return c, nil
 }
 
+// load returns an indication of the amount of work this connection has.
+// 0 means no work at all, >0 means some work.
+func (c *Connection) load() int {
+	return c.msgStore.Size()
+}
+
 // Close the connection to the server
 func (c *Connection) Close() error {
 	if !c.closing {

--- a/vst/protocol/message_store.go
+++ b/vst/protocol/message_store.go
@@ -32,6 +32,14 @@ type messageStore struct {
 	messages map[uint64]*Message
 }
 
+// Size returns the number of messages in this store.
+func (s *messageStore) Size() int {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return len(s.messages)
+}
+
 // Get returns the message with given id, or nil if not found
 func (s *messageStore) Get(id uint64) *Message {
 	s.mutex.RLock()

--- a/vst/protocol/transport.go
+++ b/vst/protocol/transport.go
@@ -33,6 +33,7 @@ import (
 
 const (
 	DefaultIdleConnTimeout = time.Minute
+	DefaultConnLimit       = 3
 )
 
 // TransportConfig contains configuration options for Transport.
@@ -42,6 +43,11 @@ type TransportConfig struct {
 	// itself.
 	// Zero means no limit.
 	IdleConnTimeout time.Duration
+
+	// ConnLimit is the upper limit to the number of connections to a single server.
+	// Due to the nature of the VST protocol, this value does not have to be high.
+	// The default is 3 (DefaultConnLimit).
+	ConnLimit int
 
 	// Version specifies the version of the Velocystream protocol
 	Version Version
@@ -62,6 +68,9 @@ type Transport struct {
 func NewTransport(hostAddr string, tlsConfig *tls.Config, config TransportConfig) *Transport {
 	if config.IdleConnTimeout == 0 {
 		config.IdleConnTimeout = DefaultIdleConnTimeout
+	}
+	if config.ConnLimit == 0 {
+		config.ConnLimit = DefaultConnLimit
 	}
 	return &Transport{
 		TransportConfig: config,
@@ -154,15 +163,35 @@ func (c *Transport) getAvailableConnection() *Connection {
 	c.connMutex.Lock()
 	defer c.connMutex.Unlock()
 
+	// Select the connection with the least amount of traffic
+	var bestConn *Connection
+	bestConnLoad := 0
+	activeConnCount := 0
 	for _, conn := range c.connections {
 		if !conn.IsClosed() {
-			conn.updateLastActivity()
-			return conn
+			activeConnCount++
+			connLoad := conn.load()
+			if bestConn == nil || connLoad < bestConnLoad {
+				bestConn = conn
+				bestConnLoad = connLoad
+			}
+
 		}
 	}
 
-	// No connections available
-	return nil
+	if bestConn == nil {
+		// No connections available
+		return nil
+	}
+
+	// Is load is >0 AND the number of connections is below the limit, create a new one
+	if bestConnLoad > 0 && activeConnCount < c.ConnLimit {
+		return nil
+	}
+
+	// Use the best connection found
+	bestConn.updateLastActivity()
+	return bestConn
 }
 
 // createConnection creates a new connection.


### PR DESCRIPTION
Due to the nature of the VST protocol, multiple concurrent messages
can already be "in-flight" at the same time on the same connection.
On high concurrency, it may be helpful to use multiple connections to 
the same server. This PR makes that possible.

The upper limit of the number of connections is controlled
by the new `ConnLimit` field in `TransportConfig`.