### PR TITLE
Added upper limit to the number of concurrent requests to a single server.

### DIFF
--- a/test/concurrency_test.go
+++ b/test/concurrency_test.go
@@ -82,7 +82,7 @@ func TestConcurrentCreateSmallDocuments(t *testing.T) {
 
 	noCreators := getIntFromEnv("NOCREATORS", 25)
 	noReaders := getIntFromEnv("NOREADERS", 50)
-	noDocuments := getIntFromEnv("NODOCUMENTS", 10000) // per creator
+	noDocuments := getIntFromEnv("NODOCUMENTS", 1000) // per creator
 
 	wgCreators := sync.WaitGroup{}
 	// Run N concurrent creators
@@ -158,7 +158,7 @@ func TestConcurrentCreateBigDocuments(t *testing.T) {
 
 	noCreators := getIntFromEnv("NOCREATORS", 25)
 	noReaders := getIntFromEnv("NOREADERS", 50)
-	noDocuments := getIntFromEnv("NODOCUMENTS", 1000) // per creator
+	noDocuments := getIntFromEnv("NODOCUMENTS", 100) // per creator
 
 	wgCreators := sync.WaitGroup{}
 	// Run N concurrent creators


### PR DESCRIPTION
The HTTP client in the standard go-lang library (used by the go-drivers HTTP connection)
automatically adds new connections to a server when needed.
Under a highly-concurrent load, this can lead to more connections than the server
can safely handle.
This PR introduced a `ConnLimit` setting (with a default of 32) controlling the 
amount of concurrent requests made to a single server.