### PR TITLE
Prevent possible endless read chunk look in in VST connection

### DIFF
--- a/vst/protocol/chunk.go
+++ b/vst/protocol/chunk.go
@@ -87,6 +87,9 @@ func buildChunks(messageID uint64, maxChunkSize uint32, messageParts ...[]byte) 
 func readBytes(dst []byte, r io.Reader) error {
 	offset := 0
 	remaining := len(dst)
+	if remaining == 0 {
+		return nil
+	}
 	for {
 		n, err := r.Read(dst[offset:])
 		offset += n

--- a/vst/protocol/chunk.go
+++ b/vst/protocol/chunk.go
@@ -88,6 +88,7 @@ func readBytes(dst []byte, r io.Reader) error {
 	offset := 0
 	remaining := len(dst)
 	if remaining == 0 {
+		// Nothing left to read
 		return nil
 	}
 	for {


### PR DESCRIPTION
This PR break the read chunk loop of a VST connection when it encounters to many errors in succession.
It also adds a few safety checks.