### PR TITLE
Added support for fetching job ID in CleanoutServer

### DIFF
--- a/cluster_impl.go
+++ b/cluster_impl.go
@@ -123,6 +123,10 @@ type cleanOutServerRequest struct {
 	Server string `json:"server"`
 }
 
+type cleanOutServerResponse struct {
+	JobID string `json:"id"`
+}
+
 // CleanOutServer triggers activities to clean out a DBServers.
 func (c *cluster) CleanOutServer(ctx context.Context, serverID string) error {
 	req, err := c.conn.NewRequest("POST", "_admin/cluster/cleanOutServer")
@@ -135,13 +139,20 @@ func (c *cluster) CleanOutServer(ctx context.Context, serverID string) error {
 	if _, err := req.SetBody(input); err != nil {
 		return WithStack(err)
 	}
-	applyContextSettings(ctx, req)
+	cs := applyContextSettings(ctx, req)
 	resp, err := c.conn.Do(ctx, req)
 	if err != nil {
 		return WithStack(err)
 	}
 	if err := resp.CheckStatus(200, 202); err != nil {
 		return WithStack(err)
+	}
+	var result cleanOutServerResponse
+	if err := resp.ParseBody("", &result); err != nil {
+		return WithStack(err)
+	}
+	if cs.JobIDResponse != nil {
+		*cs.JobIDResponse = result.JobID
 	}
 	return nil
 }

--- a/context.go
+++ b/context.go
@@ -56,6 +56,7 @@ const (
 	keyFollowLeaderRedirect     ContextKey = "arangodb-followLeaderRedirect"
 	keyDBServerID               ContextKey = "arangodb-dbserverID"
 	keyBatchID                  ContextKey = "arangodb-batchID"
+	keyJobIDResponse            ContextKey = "arangodb-jobIDResponse"
 )
 
 // WithRevision is used to configure a context to make document
@@ -213,6 +214,13 @@ func WithBatchID(parent context.Context, id string) context.Context {
 	return context.WithValue(contextOrBackground(parent), keyBatchID, id)
 }
 
+// WithJobIDResponse is used to configure a context that includes a reference to a JobID
+// that is filled on a error-free response.
+// This is used in cluster functions.
+func WithJobIDResponse(parent context.Context, jobID *string) context.Context {
+	return context.WithValue(contextOrBackground(parent), keyJobIDResponse, jobID)
+}
+
 type contextSettings struct {
 	Silent                   bool
 	WaitForSync              bool
@@ -229,6 +237,7 @@ type contextSettings struct {
 	FollowLeaderRedirect     *bool
 	DBServerID               string
 	BatchID                  string
+	JobIDResponse            *string
 }
 
 // applyContextSettings returns the settings configured in the context in the given request.
@@ -354,6 +363,12 @@ func applyContextSettings(ctx context.Context, req Request) contextSettings {
 		if id, ok := v.(string); ok {
 			req.SetQuery("batchId", id)
 			result.BatchID = id
+		}
+	}
+	// JobIDResponse
+	if v := ctx.Value(keyJobIDResponse); v != nil {
+		if idRef, ok := v.(*string); ok {
+			result.JobIDResponse = idRef
 		}
 	}
 	return result


### PR DESCRIPTION
This PR adds support for obtaining the job ID returned from a `CleanoutServer` request.
To get the JobID, prepare a context with `WithJobIDResponse`, passing in a reference to a string variable. After a successful call to `CleanoutServer`, the string variable will contain the job ID.

<!---
@huboard:{"order":166.0166,"milestone_order":131,"custom_state":""}
-->
