### PR TITLE
ArangoView API Changes

### DIFF
--- a/view_arangosearch.go
+++ b/view_arangosearch.go
@@ -101,16 +101,21 @@ const (
 // ArangoSearchConsolidationPolicy holds threshold values specifying when to
 // consolidate view data.
 // Semantics of the values depend on where they are used.
-type ArangoSearchConsolidationPolicy interface {
+type ArangoSearchConsolidationPolicy struct {
 	// Type returns the type of the ConsolidationPolicy. This interface can then be casted to the corresponding ArangoSearchConsolidationPolicy* struct.
-	Type() ArangoSearchConsolidationPolicyType
+	Type ArangoSearchConsolidationPolicyType
+
+	ArangoSearchConsolidationPolicyBytesAccum
+	ArangoSearchConsolidationPolicyTier
 }
 
+// ArangoSearchConsolidationPolicyBytesAccum contains fields used for ArangoSearchConsolidationPolicyTypeBytesAccum
 type ArangoSearchConsolidationPolicyBytesAccum struct {
 	// Threshold, see ArangoSearchConsolidationTypeBytesAccum
 	Threshold *float64 `json:"threshold,omitempty"`
 }
 
+// ArangoSearchConsolidationPolicyTier contains fields used for ArangoSearchConsolidationPolicyTypeTier
 type ArangoSearchConsolidationPolicyTier struct {
 	// MinSegments specifies the minimum number of segments that will be evaluated as candidates for consolidation.
 	MinSegments *int64 `json:"minSegments,omitempty"`

--- a/view_arangosearch.go
+++ b/view_arangosearch.go
@@ -64,7 +64,7 @@ type ArangoSearchViewProperties struct {
 	// any added benefits.
 	ConsolidationInterval *int64 `json:"consolidationIntervalMsec,omitempty"`
 	// ConsolidationPolicy specifies thresholds for consolidation.
-	ConsolidationPolicy *ArangoSearchConsolidationPolicy `json:"consolidationPolicy,omitempty"`
+	ConsolidationPolicy ArangoSearchConsolidationPolicy `json:"consolidationPolicy,omitempty"`
 
 	// WriteBufferIdel specifies the maximum number of writers (segments) cached in the pool.
 	// 0 value turns off caching, default value is 64.
@@ -86,33 +86,32 @@ type ArangoSearchViewProperties struct {
 	Links ArangoSearchLinks `json:"links,omitempty"`
 }
 
-// ArangoSearchConsolidationType strings for consolidation types
-type ArangoSearchConsolidationType string
+// ArangoSearchConsolidationPolicyType strings for consolidation types
+type ArangoSearchConsolidationPolicyType string
 
 const (
-	// ArangoSearchConsolidationTypeTier consolidate based on segment byte size and live document count as dictated by the customization attributes.
-	ArangoSearchConsolidationTypeTier ArangoSearchConsolidationType = "tier"
-	// ArangoSearchConsolidationTypeBytesAccum consolidate if and only if ({threshold} range [0.0, 1.0])
+	// ArangoSearchConsolidationPolicyTypeTier consolidate based on segment byte size and live document count as dictated by the customization attributes.
+	ArangoSearchConsolidationPolicyTypeTier ArangoSearchConsolidationPolicyType = "tier"
+	// ArangoSearchConsolidationPolicyTypeBytesAccum consolidate if and only if ({threshold} range [0.0, 1.0])
 	// {threshold} > (segment_bytes + sum_of_merge_candidate_segment_bytes) / all_segment_bytes,
 	// i.e. the sum of all candidate segment's byte size is less than the total segment byte size multiplied by the {threshold}.
-	ArangoSearchConsolidationTypeBytesAccum ArangoSearchConsolidationType = "bytes_accum"
+	ArangoSearchConsolidationPolicyTypeBytesAccum ArangoSearchConsolidationPolicyType = "bytes_accum"
 )
 
 // ArangoSearchConsolidationPolicy holds threshold values specifying when to
 // consolidate view data.
 // Semantics of the values depend on where they are used.
-type ArangoSearchConsolidationPolicy struct {
-	// Type segment candidates for the "consolidation" operation are selected based upon several possible configurable formulas as defined by their types.
-	// See ArangoSearchConsolidationType constants.
-	Type ArangoSearchConsolidationType `json:"type"`
+type ArangoSearchConsolidationPolicy interface {
+	// Type returns the type of the ConsolidationPolicy. This interface can then be casted to the corresponding ArangoSearchConsolidationPolicy* struct.
+	Type() ArangoSearchConsolidationPolicyType
+}
 
-	// Relevant for `type == "bytes_accum"`
-
+type ArangoSearchConsolidationPolicyBytesAccum struct {
 	// Threshold, see ArangoSearchConsolidationTypeBytesAccum
 	Threshold *float64 `json:"threshold,omitempty"`
+}
 
-	// Relevant for `type == "tier"`
-
+type ArangoSearchConsolidationPolicyTier struct {
 	// MinSegments specifies the minimum number of segments that will be evaluated as candidates for consolidation.
 	MinSegments *int64 `json:"minSegments,omitempty"`
 	// MaxSegments specifies the maximum number of segments that will be evaluated as candidates for consolidation.

--- a/view_arangosearch.go
+++ b/view_arangosearch.go
@@ -51,7 +51,7 @@ type ArangoSearchViewProperties struct {
 	// For the case where the consolidation policies rarely merge segments
 	// (i.e. few inserts/deletes), a higher value will impact performance
 	// without any added benefits.
-	CleanupIntervalStep int64 `json:"cleanupIntervalStep,omitempty"`
+	CleanupIntervalStep *int64 `json:"cleanupIntervalStep,omitempty"`
 	// ConsolidationInterval specifies the minimum number of milliseconds that must be waited
 	// between committing index data changes and making them visible to queries.
 	// Defaults to 60000.
@@ -62,33 +62,69 @@ type ArangoSearchViewProperties struct {
 	// For the case where there are a few inserts/updates, a higher value will
 	// impact performance and waste disk space for each commit call without
 	// any added benefits.
-	ConsolidationInterval int64 `json:"consolidationIntervalMsec,omitempty"`
+	ConsolidationInterval *int64 `json:"consolidationIntervalMsec,omitempty"`
 	// ConsolidationPolicy specifies thresholds for consolidation.
 	ConsolidationPolicy *ArangoSearchConsolidationPolicy `json:"consolidationPolicy,omitempty"`
 
-	/*
-		// Locale specifies the default locale used for queries on analyzed string values.
-		// Defaults to "C". TODO What is that?
-		Locale Locale `json:"locale,omitempty"`
-	*/
+	// WriteBufferIdel specifies the maximum number of writers (segments) cached in the pool.
+	// 0 value turns off caching, default value is 64.
+	WriteBufferIdel *int64 `json:"writebufferIdle,omitempty"`
+
+	// WriteBufferActive specifies the maximum number of concurrent active writers (segments) performs (a transaction).
+	// Other writers (segments) are wait till current active writers (segments) finish.
+	// 0 value turns off this limit and used by default.
+	WriteBufferActive *int64 `json:"writebufferActive,omitempty"`
+
+	// WriteBufferSizeMax specifies maximum memory byte size per writer (segment) before a writer (segment) flush is triggered.
+	// 0 value turns off this limit fon any writer (buffer) and will be flushed only after a period defined for special thread during ArangoDB server startup.
+	// 0 value should be used with carefully due to high potential memory consumption.
+	WriteBufferSizeMax *int64 `json:"writebufferSizeMax,omitempty"`
+
 	// Links contains the properties for how individual collections
 	// are indexed in thie view.
 	// The key of the map are collection names.
 	Links ArangoSearchLinks `json:"links,omitempty"`
 }
 
-// Locale is a strongly typed specifier of a locale.
-// TODO specify semantics.
-type Locale string
+// ArangoSearchConsolidationType strings for consolidation types
+type ArangoSearchConsolidationType string
+
+const (
+	// ArangoSearchConsolidationTypeTier consolidate based on segment byte size and live document count as dictated by the customization attributes.
+	ArangoSearchConsolidationTypeTier ArangoSearchConsolidationType = "tier"
+	// ArangoSearchConsolidationTypeBytesAccum consolidate if and only if ({threshold} range [0.0, 1.0])
+	// {threshold} > (segment_bytes + sum_of_merge_candidate_segment_bytes) / all_segment_bytes,
+	// i.e. the sum of all candidate segment's byte size is less than the total segment byte size multiplied by the {threshold}.
+	ArangoSearchConsolidationTypeBytesAccum ArangoSearchConsolidationType = "bytes_accum"
+)
 
 // ArangoSearchConsolidationPolicy holds threshold values specifying when to
 // consolidate view data.
 // Semantics of the values depend on where they are used.
 type ArangoSearchConsolidationPolicy struct {
-	// Threshold is a percentage (0..1)
-	Threshold float64 `json:"threshold,omitempty"`
-	// SegmentThreshold is an absolute value.
-	SegmentThreshold int64 `json:"segmentThreshold,omitempty"`
+	// Type segment candidates for the "consolidation" operation are selected based upon several possible configurable formulas as defined by their types.
+	// See ArangoSearchConsolidationType constants.
+	Type ArangoSearchConsolidationType `json:"type"`
+
+	// Relevant for `type == "bytes_accum"`
+
+	// Threshold, see ArangoSearchConsolidationTypeBytesAccum
+	Threshold *float64 `json:"threshold,omitempty"`
+
+	// Relevant for `type == "tier"`
+
+	// MinSegments specifies the minimum number of segments that will be evaluated as candidates for consolidation.
+	MinSegments *int64 `json:"minSegments,omitempty"`
+	// MaxSegments specifies the maximum number of segments that will be evaluated as candidates for consolidation.
+	MaxSegments *int64 `json:"maxSegments,omitempty"`
+	// SegmentsBytesMax specifies the maxinum allowed size of all consolidated segments in bytes.
+	SegmentsBytesMax *int64 `json:"segmentsBytesMax,omitempty"`
+	// SegmentsBytesFloor defines the value (in bytes) to treat all smaller segments as equal for consolidation selection.
+	SegmentsBytesFloor *int64 `json:"segmentsBytesFloor,omitempty"`
+	// Lookahead specifies the number of additionally searched tiers except initially chosen candidated based on min_segments,
+	// max_segments, segments_bytes_max, segments_bytes_floor with respect to defined values.
+	// Default value falls to integer_traits<size_t>::const_max (in C++ source code).
+	Lookahead *int64 `json:"lookahead,omitempty"`
 }
 
 // ArangoSearchLinks is a strongly typed map containing links between a

--- a/view_arangosearch_impl.go
+++ b/view_arangosearch_impl.go
@@ -24,8 +24,6 @@ package driver
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"path"
 )
 
@@ -73,73 +71,4 @@ func (v *viewArangoSearch) SetProperties(ctx context.Context, options ArangoSear
 		return WithStack(err)
 	}
 	return nil
-}
-
-func (cp *ArangoSearchConsolidationPolicyBytesAccum) Type() ArangoSearchConsolidationPolicyType {
-	return ArangoSearchConsolidationPolicyTypeBytesAccum
-}
-
-func (cp *ArangoSearchConsolidationPolicyTier) Type() ArangoSearchConsolidationPolicyType {
-	return ArangoSearchConsolidationPolicyTypeTier
-}
-
-func (cp ArangoSearchConsolidationPolicyBytesAccum) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
-		ArangoSearchConsolidationPolicyBytesAccum
-		Type ArangoSearchConsolidationPolicyType
-	}{
-		ArangoSearchConsolidationPolicyBytesAccum: ArangoSearchConsolidationPolicyBytesAccum(cp),
-		Type: ArangoSearchConsolidationPolicyTypeBytesAccum,
-	})
-}
-
-func (cp ArangoSearchConsolidationPolicyTier) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
-		ArangoSearchConsolidationPolicyTier
-		Type ArangoSearchConsolidationPolicyType
-	}{
-		ArangoSearchConsolidationPolicyTier: ArangoSearchConsolidationPolicyTier(cp),
-		Type: ArangoSearchConsolidationPolicyTypeTier,
-	})
-}
-
-func (p *ArangoSearchViewProperties) UnmarshalJSON(raw []byte) error {
-	type FakeProperties struct {
-		CleanupIntervalStep   *int64            `json:"cleanupIntervalStep,omitempty"`
-		ConsolidationInterval *int64            `json:"consolidationIntervalMsec,omitempty"`
-		WriteBufferIdel       *int64            `json:"writebufferIdle,omitempty"`
-		WriteBufferActive     *int64            `json:"writebufferActive,omitempty"`
-		WriteBufferSizeMax    *int64            `json:"writebufferSizeMax,omitempty"`
-		Links                 ArangoSearchLinks `json:"links,omitempty"`
-		ConsolidationPolicy   json.RawMessage   `json:"consolidationPolicy"`
-	}
-
-	var dec FakeProperties
-	if err := json.Unmarshal(raw, &dec); err != nil {
-		return err
-	}
-
-	p.CleanupIntervalStep = dec.CleanupIntervalStep
-	p.ConsolidationInterval = dec.CleanupIntervalStep
-	p.WriteBufferIdel = dec.WriteBufferIdel
-	p.WriteBufferActive = dec.WriteBufferActive
-	p.WriteBufferSizeMax = dec.WriteBufferSizeMax
-	p.Links = dec.Links
-
-	var typeStruct struct {
-		Type ArangoSearchConsolidationPolicyType `json:"type"`
-	}
-	if err := json.Unmarshal(dec.ConsolidationPolicy, &typeStruct); err != nil {
-		return err
-	}
-
-	switch typeStruct.Type {
-	case ArangoSearchConsolidationPolicyTypeBytesAccum:
-		p.ConsolidationPolicy = &ArangoSearchConsolidationPolicyBytesAccum{}
-	case ArangoSearchConsolidationPolicyTypeTier:
-		p.ConsolidationPolicy = &ArangoSearchConsolidationPolicyTier{}
-	default:
-		return fmt.Errorf("Unknown ConsolidationPolicyType: %s", string(typeStruct.Type))
-	}
-	return json.Unmarshal(dec.ConsolidationPolicy, &p.ConsolidationPolicy)
 }

--- a/view_arangosearch_impl.go
+++ b/view_arangosearch_impl.go
@@ -24,6 +24,8 @@ package driver
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"path"
 )
 
@@ -71,4 +73,73 @@ func (v *viewArangoSearch) SetProperties(ctx context.Context, options ArangoSear
 		return WithStack(err)
 	}
 	return nil
+}
+
+func (cp *ArangoSearchConsolidationPolicyBytesAccum) Type() ArangoSearchConsolidationPolicyType {
+	return ArangoSearchConsolidationPolicyTypeBytesAccum
+}
+
+func (cp *ArangoSearchConsolidationPolicyTier) Type() ArangoSearchConsolidationPolicyType {
+	return ArangoSearchConsolidationPolicyTypeTier
+}
+
+func (cp ArangoSearchConsolidationPolicyBytesAccum) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ArangoSearchConsolidationPolicyBytesAccum
+		Type ArangoSearchConsolidationPolicyType
+	}{
+		ArangoSearchConsolidationPolicyBytesAccum: ArangoSearchConsolidationPolicyBytesAccum(cp),
+		Type: ArangoSearchConsolidationPolicyTypeBytesAccum,
+	})
+}
+
+func (cp ArangoSearchConsolidationPolicyTier) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ArangoSearchConsolidationPolicyTier
+		Type ArangoSearchConsolidationPolicyType
+	}{
+		ArangoSearchConsolidationPolicyTier: ArangoSearchConsolidationPolicyTier(cp),
+		Type: ArangoSearchConsolidationPolicyTypeTier,
+	})
+}
+
+func (p *ArangoSearchViewProperties) UnmarshalJSON(raw []byte) error {
+	type FakeProperties struct {
+		CleanupIntervalStep   *int64            `json:"cleanupIntervalStep,omitempty"`
+		ConsolidationInterval *int64            `json:"consolidationIntervalMsec,omitempty"`
+		WriteBufferIdel       *int64            `json:"writebufferIdle,omitempty"`
+		WriteBufferActive     *int64            `json:"writebufferActive,omitempty"`
+		WriteBufferSizeMax    *int64            `json:"writebufferSizeMax,omitempty"`
+		Links                 ArangoSearchLinks `json:"links,omitempty"`
+		ConsolidationPolicy   json.RawMessage   `json:"consolidationPolicy"`
+	}
+
+	var dec FakeProperties
+	if err := json.Unmarshal(raw, &dec); err != nil {
+		return err
+	}
+
+	p.CleanupIntervalStep = dec.CleanupIntervalStep
+	p.ConsolidationInterval = dec.CleanupIntervalStep
+	p.WriteBufferIdel = dec.WriteBufferIdel
+	p.WriteBufferActive = dec.WriteBufferActive
+	p.WriteBufferSizeMax = dec.WriteBufferSizeMax
+	p.Links = dec.Links
+
+	var typeStruct struct {
+		Type ArangoSearchConsolidationPolicyType `json:"type"`
+	}
+	if err := json.Unmarshal(dec.ConsolidationPolicy, &typeStruct); err != nil {
+		return err
+	}
+
+	switch typeStruct.Type {
+	case ArangoSearchConsolidationPolicyTypeBytesAccum:
+		p.ConsolidationPolicy = &ArangoSearchConsolidationPolicyBytesAccum{}
+	case ArangoSearchConsolidationPolicyTypeTier:
+		p.ConsolidationPolicy = &ArangoSearchConsolidationPolicyTier{}
+	default:
+		return fmt.Errorf("Unknown ConsolidationPolicyType: %s", string(typeStruct.Type))
+	}
+	return json.Unmarshal(dec.ConsolidationPolicy, &p.ConsolidationPolicy)
 }


### PR DESCRIPTION
According to the new specification some json fields changes and became optional.

In order to prevent the go driver from inserting `0` values at places that have a non-zero default value, I changes the types to pointer types. Hence they will be set to `nil` if not set.

API may changes again due to inconsistent naming of fields.