### PR TITLE
Version/Engine Cluster Health

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -75,6 +75,8 @@ type ServerHealth struct {
 	Status              ServerStatus `json:"Status"`
 	CanBeDeleted        bool         `json:"CanBeDeleted"`
 	HostID              string       `json:"Host,omitempty"`
+	Version             Version      `json:"Version,omitempty"`
+	Engine              EngineType   `json:"Engine,omitempty"`
 }
 
 // ServerStatus describes the health status of a server

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -52,14 +52,12 @@ func TestClusterHealth(t *testing.T) {
 		coordinators := 0
 		for _, sh := range h.Health {
 
-			if sh.Role == driver.ServerRoleDBServer || sh.Role == driver.ServerRoleCoordinator {
-				if v, err := c.Version(nil); err == nil {
-					if v.Version.CompareTo(sh.Version) != 0 {
-						t.Errorf("Server version differs from `_api/version`, got `%s` and `%s`", v.Version, sh.Version)
-					}
-				} else {
-					t.Errorf("Version failed: %s", describe(err))
+			if v, err := c.Version(nil); err == nil {
+				if v.Version.CompareTo(sh.Version) != 0 {
+					t.Logf("Server version differs from `_api/version`, got `%s` and `%s`", v.Version, sh.Version)
 				}
+			} else {
+				t.Errorf("Version failed: %s", describe(err))
 			}
 
 			switch sh.Role {

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -51,6 +51,17 @@ func TestClusterHealth(t *testing.T) {
 		dbservers := 0
 		coordinators := 0
 		for _, sh := range h.Health {
+
+			if sh.Role == driver.ServerRoleDBServer || sh.Role == driver.ServerRoleCoordinator {
+				if v, err := c.Version(nil); err == nil {
+					if v.Version.CompareTo(sh.Version) != 0 {
+						t.Errorf("Server version differs from `_api/version`, got `%s` and `%s`", v.Version, sh.Version)
+					}
+				} else {
+					t.Errorf("Version failed: %s", describe(err))
+				}
+			}
+
 			switch sh.Role {
 			case driver.ServerRoleAgent:
 				agents++


### PR DESCRIPTION
Added Version and Engine to cluster health record.
This works does not work for 3.3.19 or rc 5.