### PR TITLE
collection.properties - support cacheEnabled

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -123,6 +123,8 @@ type CollectionProperties struct {
 	// This attribute specifies the name of the sharding strategy to use for the collection.
 	// Can not be changed after creation.
 	ShardingStrategy ShardingStrategy `json:"shardingStrategy,omitempty"`
+	// CacheEnabled enables in-memory caching of documents and primary index entries when using RocksDB. Check SetCollectionPropertiesOptions.CacheEnabled for more details.
+	CacheEnabled bool `json:"cacheEnabled,omitempty"`
 }
 
 const (
@@ -144,6 +146,8 @@ type SetCollectionPropertiesOptions struct {
 	// ReplicationFactor contains how many copies of each shard are kept on different DBServers.
 	// Only available in cluster setup.
 	ReplicationFactor int `json:"replicationFactor,omitempty"`
+	// CacheEnabled enables in-memory caching of documents and primary index entries when using RocksDB. This can potentially speed up point-lookups significantly, especially if collection have a subset of frequently accessed documents.
+	CacheEnabled bool `json:"cacheEnabled,omitempty"`
 }
 
 // CollectionStatus indicates the status of a collection.

--- a/test/collection_test.go
+++ b/test/collection_test.go
@@ -359,9 +359,12 @@ func TestCollectionSetProperties(t *testing.T) {
 		t.Fatalf("Failed to create collection '%s': %s", name, describe(err))
 	}
 
-	// Set WaitForSync to false
+	// Set WaitForSync to false and CacheEnabled to true
 	waitForSync := false
-	if err := col.SetProperties(nil, driver.SetCollectionPropertiesOptions{WaitForSync: &waitForSync}); err != nil {
+	if err := col.SetProperties(nil, driver.SetCollectionPropertiesOptions{
+		WaitForSync:  &waitForSync,
+		CacheEnabled: true,
+	}); err != nil {
 		t.Fatalf("Failed to set properties: %s", describe(err))
 	}
 	if p, err := col.Properties(nil); err != nil {
@@ -369,6 +372,9 @@ func TestCollectionSetProperties(t *testing.T) {
 	} else {
 		if p.WaitForSync != waitForSync {
 			t.Errorf("Expected WaitForSync %v, got %v", waitForSync, p.WaitForSync)
+		}
+		if p.CacheEnabled != true {
+			t.Error("Expected CacheEnabled to be true")
 		}
 	}
 


### PR DESCRIPTION
Updates `SetCollectionPropertiesOptions` and `CollectionProperties`
to support the new `cacheEnabled` property:
https://docs.arangodb.com/devel/Manual/ReleaseNotes/NewFeatures34.html#optional-caching-for-documents-and-primary-index-values