### PR TITLE
Fix order of variable substitution in error

### DIFF
--- a/edge_collection_documents_impl.go
+++ b/edge_collection_documents_impl.go
@@ -101,7 +101,7 @@ func (c *edgeCollection) ReadDocuments(ctx context.Context, keys []string, resul
 	}
 	resultCount := resultsVal.Len()
 	if len(keys) != resultCount {
-		return nil, nil, WithStack(InvalidArgumentError{Message: fmt.Sprintf("expected %d keys, got %d", resultCount, len(keys))})
+		return nil, nil, WithStack(InvalidArgumentError{Message: fmt.Sprintf("expected %d keys, got %d", len(keys), resultCount)})
 	}
 	for _, key := range keys {
 		if err := validateKey(key); err != nil {


### PR DESCRIPTION
I was very confused when I got an error stating "expected 0 keys, got 1" when I was clearly passing in a key (otherwise, how could I get a result if I *didn't* provide a key).  It turns out the message just had the values reversed.