### PR TITLE
Use WriteConcern instead of MinReplicationFactor

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -201,12 +201,15 @@ type InventoryCollectionParameters struct {
 		AllowUserKeys bool   `json:"allowUserKeys,omitempty"`
 		LastValue     int64  `json:"lastValue,omitempty"`
 	} `json:"keyOptions"`
-	Name                 string                 `json:"name,omitempty"`
-	NumberOfShards       int                    `json:"numberOfShards,omitempty"`
-	Path                 string                 `json:"path,omitempty"`
-	PlanID               string                 `json:"planId,omitempty"`
-	ReplicationFactor    int                    `json:"replicationFactor,omitempty"`
-	MinReplicationFactor int                    `json:"minReplicationFactor,omitempty"`
+	Name              string `json:"name,omitempty"`
+	NumberOfShards    int    `json:"numberOfShards,omitempty"`
+	Path              string `json:"path,omitempty"`
+	PlanID            string `json:"planId,omitempty"`
+	ReplicationFactor int    `json:"replicationFactor,omitempty"`
+	// Deprecated: use 'WriteConcern' instead
+	MinReplicationFactor int `json:"minReplicationFactor,omitempty"`
+	// Available from 3.6 arangod version.
+	WriteConcern         int                    `json:"writeConcern,omitempty"`
 	ShardKeys            []string               `json:"shardKeys,omitempty"`
 	Shards               map[ShardID][]ServerID `json:"shards,omitempty"`
 	Status               CollectionStatus       `json:"status,omitempty"`

--- a/cluster_impl.go
+++ b/cluster_impl.go
@@ -274,12 +274,15 @@ type inventoryCollectionParametersInternal struct {
 		AllowUserKeys bool   `json:"allowUserKeys,omitempty"`
 		LastValue     int64  `json:"lastValue,omitempty"`
 	} `json:"keyOptions"`
-	Name                 string                 `json:"name,omitempty"`
-	NumberOfShards       int                    `json:"numberOfShards,omitempty"`
-	Path                 string                 `json:"path,omitempty"`
-	PlanID               string                 `json:"planId,omitempty"`
-	ReplicationFactor    replicationFactor      `json:"replicationFactor,omitempty"`
-	MinReplicationFactor int                    `json:"minReplicationFactor,omitempty"`
+	Name              string            `json:"name,omitempty"`
+	NumberOfShards    int               `json:"numberOfShards,omitempty"`
+	Path              string            `json:"path,omitempty"`
+	PlanID            string            `json:"planId,omitempty"`
+	ReplicationFactor replicationFactor `json:"replicationFactor,omitempty"`
+	// Deprecated: use 'WriteConcern' instead
+	MinReplicationFactor int `json:"minReplicationFactor,omitempty"`
+	// Available from 3.6 arangod version.
+	WriteConcern         int                    `json:"writeConcern,omitempty"`
 	ShardKeys            []string               `json:"shardKeys,omitempty"`
 	Shards               map[ShardID][]ServerID `json:"shards,omitempty"`
 	Status               CollectionStatus       `json:"status,omitempty"`
@@ -309,6 +312,7 @@ func (p *InventoryCollectionParameters) asInternal() inventoryCollectionParamete
 		PlanID:               p.PlanID,
 		ReplicationFactor:    replicationFactor(p.ReplicationFactor),
 		MinReplicationFactor: p.MinReplicationFactor,
+		WriteConcern:         p.WriteConcern,
 		ShardKeys:            p.ShardKeys,
 		Shards:               p.Shards,
 		Status:               p.Status,
@@ -343,6 +347,7 @@ func (p *inventoryCollectionParametersInternal) asExternal() InventoryCollection
 		PlanID:               p.PlanID,
 		ReplicationFactor:    int(p.ReplicationFactor),
 		MinReplicationFactor: p.MinReplicationFactor,
+		WriteConcern:         p.WriteConcern,
 		ShardKeys:            p.ShardKeys,
 		Shards:               p.Shards,
 		Status:               p.Status,

--- a/collection.go
+++ b/collection.go
@@ -116,10 +116,13 @@ type CollectionProperties struct {
 	// ReplicationFactor contains how many copies of each shard are kept on different DBServers.
 	// Only available in cluster setup.
 	ReplicationFactor int `json:"replicationFactor,omitempty"`
-	// MinReplicationFactor contains how many copies must be available before a collection can be written.
-	// It is required that 1 <= MinReplicationFactor <= ReplicationFactor.
-	// Default is 1. Not available for satellite collections.
+	// Deprecated: use 'WriteConcern' instead
 	MinReplicationFactor int `json:"minReplicationFactor,omitempty"`
+	// WriteConcern contains how many copies must be available before a collection can be written.
+	// It is required that 1 <= WriteConcern <= ReplicationFactor.
+	// Default is 1. Not available for satellite collections.
+	// Available from 3.6 arangod version.
+	WriteConcern int `json:"writeConcern,omitempty"`
 	// SmartJoinAttribute
 	// See documentation for smart joins.
 	// This requires ArangoDB Enterprise Edition.
@@ -148,8 +151,11 @@ type SetCollectionPropertiesOptions struct {
 	// ReplicationFactor contains how many copies of each shard are kept on different DBServers.
 	// Only available in cluster setup.
 	ReplicationFactor int `json:"replicationFactor,omitempty"`
-	// MinReplicationFactor contains how many copies must be available before a collection can be written.
+	// Deprecated: use 'WriteConcern' instead
 	MinReplicationFactor int `json:"minReplicationFactor,omitempty"`
+	// WriteConcern contains how many copies must be available before a collection can be written.
+	// Available from 3.6 arangod version.
+	WriteConcern int `json:"writeConcern,omitempty"`
 }
 
 // CollectionStatus indicates the status of a collection.

--- a/collection_impl.go
+++ b/collection_impl.go
@@ -274,12 +274,15 @@ type collectionPropertiesInternal struct {
 		Type          KeyGeneratorType `json:"type,omitempty"`
 		AllowUserKeys bool             `json:"allowUserKeys,omitempty"`
 	} `json:"keyOptions,omitempty"`
-	NumberOfShards       int               `json:"numberOfShards,omitempty"`
-	ShardKeys            []string          `json:"shardKeys,omitempty"`
-	ReplicationFactor    replicationFactor `json:"replicationFactor,omitempty"`
-	MinReplicationFactor int               `json:"minReplicationFactor,omitempty"`
-	SmartJoinAttribute   string            `json:"smartJoinAttribute,omitempty"`
-	ShardingStrategy     ShardingStrategy  `json:"shardingStrategy,omitempty"`
+	NumberOfShards    int               `json:"numberOfShards,omitempty"`
+	ShardKeys         []string          `json:"shardKeys,omitempty"`
+	ReplicationFactor replicationFactor `json:"replicationFactor,omitempty"`
+	// Deprecated: use 'WriteConcern' instead
+	MinReplicationFactor int `json:"minReplicationFactor,omitempty"`
+	// Available from 3.6 arangod version.
+	WriteConcern       int              `json:"writeConcern,omitempty"`
+	SmartJoinAttribute string           `json:"smartJoinAttribute,omitempty"`
+	ShardingStrategy   ShardingStrategy `json:"shardingStrategy,omitempty"`
 }
 
 func (p *collectionPropertiesInternal) asExternal() CollectionProperties {
@@ -293,6 +296,7 @@ func (p *collectionPropertiesInternal) asExternal() CollectionProperties {
 		ShardKeys:            p.ShardKeys,
 		ReplicationFactor:    int(p.ReplicationFactor),
 		MinReplicationFactor: p.MinReplicationFactor,
+		WriteConcern:         p.WriteConcern,
 		SmartJoinAttribute:   p.SmartJoinAttribute,
 		ShardingStrategy:     p.ShardingStrategy,
 	}
@@ -309,6 +313,7 @@ func (p *CollectionProperties) asInternal() collectionPropertiesInternal {
 		ShardKeys:            p.ShardKeys,
 		ReplicationFactor:    replicationFactor(p.ReplicationFactor),
 		MinReplicationFactor: p.MinReplicationFactor,
+		WriteConcern:         p.WriteConcern,
 		SmartJoinAttribute:   p.SmartJoinAttribute,
 		ShardingStrategy:     p.ShardingStrategy,
 	}
@@ -324,6 +329,7 @@ func (p *CollectionProperties) fromInternal(i *collectionPropertiesInternal) {
 	p.ShardKeys = i.ShardKeys
 	p.ReplicationFactor = int(i.ReplicationFactor)
 	p.MinReplicationFactor = i.MinReplicationFactor
+	p.WriteConcern = i.WriteConcern
 	p.SmartJoinAttribute = i.SmartJoinAttribute
 	p.ShardingStrategy = i.ShardingStrategy
 }
@@ -345,10 +351,13 @@ func (p *CollectionProperties) UnmarshalJSON(d []byte) error {
 }
 
 type setCollectionPropertiesOptionsInternal struct {
-	WaitForSync          *bool             `json:"waitForSync,omitempty"`
-	JournalSize          int64             `json:"journalSize,omitempty"`
-	ReplicationFactor    replicationFactor `json:"replicationFactor,omitempty"`
-	MinReplicationFactor int               `json:"minReplicationFactor,omitempty"`
+	WaitForSync       *bool             `json:"waitForSync,omitempty"`
+	JournalSize       int64             `json:"journalSize,omitempty"`
+	ReplicationFactor replicationFactor `json:"replicationFactor,omitempty"`
+	// Deprecated: use 'WriteConcern' instead
+	MinReplicationFactor int `json:"minReplicationFactor,omitempty"`
+	// Available from 3.6 arangod version.
+	WriteConcern int `json:"writeConcern,omitempty"`
 }
 
 func (p *SetCollectionPropertiesOptions) asInternal() setCollectionPropertiesOptionsInternal {
@@ -357,6 +366,7 @@ func (p *SetCollectionPropertiesOptions) asInternal() setCollectionPropertiesOpt
 		JournalSize:          p.JournalSize,
 		ReplicationFactor:    replicationFactor(p.ReplicationFactor),
 		MinReplicationFactor: p.MinReplicationFactor,
+		WriteConcern:         p.WriteConcern,
 	}
 }
 
@@ -365,6 +375,7 @@ func (p *SetCollectionPropertiesOptions) fromInternal(i *setCollectionProperties
 	p.JournalSize = i.JournalSize
 	p.ReplicationFactor = int(i.ReplicationFactor)
 	p.MinReplicationFactor = i.MinReplicationFactor
+	p.WriteConcern = i.WriteConcern
 }
 
 // MarshalJSON converts SetCollectionPropertiesOptions into json

--- a/database_collections.go
+++ b/database_collections.go
@@ -52,10 +52,13 @@ type CreateCollectionOptions struct {
 	// before the write operation is reported successful. If a server fails, this is detected automatically
 	// and one of the servers holding copies take over, usually without an error being reported.
 	ReplicationFactor int `json:"replicationFactor,omitempty"`
-	// MinReplicationFactor contains how many copies must be available before a collection can be written.
-	// It is required that 1 <= MinReplicationFactor <= ReplicationFactor.
-	// Default is 1. Not available for satellite collections.
+	// Deprecated: use 'WriteConcern' instead
 	MinReplicationFactor int `json:"minReplicationFactor,omitempty"`
+	// WriteConcern contains how many copies must be available before a collection can be written.
+	// It is required that 1 <= WriteConcern <= ReplicationFactor.
+	// Default is 1. Not available for satellite collections.
+	// Available from 3.6 arangod version.
+	WriteConcern int `json:"writeConcern,omitempty"`
 	// If true then the data is synchronized to disk before returning from a document create, update, replace or removal operation. (default: false)
 	WaitForSync bool `json:"waitForSync,omitempty"`
 	// Whether or not the collection will be compacted (default is true)

--- a/database_collections_impl.go
+++ b/database_collections_impl.go
@@ -102,9 +102,11 @@ func (d *database) Collections(ctx context.Context) ([]Collection, error) {
 }
 
 type createCollectionOptionsInternal struct {
-	JournalSize          int                   `json:"journalSize,omitempty"`
-	ReplicationFactor    replicationFactor     `json:"replicationFactor,omitempty"`
+	JournalSize       int               `json:"journalSize,omitempty"`
+	ReplicationFactor replicationFactor `json:"replicationFactor,omitempty"`
+	// Deprecated: use 'WriteConcern' instead
 	MinReplicationFactor int                   `json:"minReplicationFactor,omitempty"`
+	WriteConcern         int                   `json:"writeConcern,omitempty"`
 	WaitForSync          bool                  `json:"waitForSync,omitempty"`
 	DoCompact            *bool                 `json:"doCompact,omitempty"`
 	IsVolatile           bool                  `json:"isVolatile,omitempty"`
@@ -176,6 +178,7 @@ func (p *createCollectionOptionsInternal) fromExternal(i *CreateCollectionOption
 	p.JournalSize = i.JournalSize
 	p.ReplicationFactor = replicationFactor(i.ReplicationFactor)
 	p.MinReplicationFactor = i.MinReplicationFactor
+	p.WriteConcern = i.WriteConcern
 	p.WaitForSync = i.WaitForSync
 	p.DoCompact = i.DoCompact
 	p.IsVolatile = i.IsVolatile

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/arangodb/go-velocypack v0.0.0-20190129082528-7896a965b4ad
 	github.com/coreos/go-iptables v0.4.3
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/stretchr/testify v1.2.2
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.2.2
 )

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -51,7 +51,7 @@ var (
 
 // skipBelowVersion skips the test if the current server version is less than
 // the given version.
-func skipBelowVersion(c driver.Client, version driver.Version, t *testing.T) {
+func skipBelowVersion(c driver.Client, version driver.Version, t *testing.T) driver.VersionInfo {
 	x, err := c.Version(nil)
 	if err != nil {
 		t.Fatalf("Failed to get version info: %s", describe(err))
@@ -59,6 +59,7 @@ func skipBelowVersion(c driver.Client, version driver.Version, t *testing.T) {
 	if x.Version.CompareTo(version) < 0 {
 		t.Skipf("Skipping below version '%s', got version '%s'", version, x.Version)
 	}
+	return x
 }
 
 // getEndpointsFromEnv returns the endpoints specified in the TEST_ENDPOINTS
@@ -108,7 +109,7 @@ func createAuthenticationFromEnv(t testEnv) driver.Authentication {
 		if len(parts) != 2 {
 			t.Fatalf("Expected 'super' and jwt secret")
 		}
-    header, err := jwt.CreateArangodJwtAuthorizationHeader(parts[1], "arangodb")
+		header, err := jwt.CreateArangodJwtAuthorizationHeader(parts[1], "arangodb")
 		if err != nil {
 			t.Fatalf("Could not create JWT authentication header: %s", describe(err))
 		}

--- a/test/collection_test.go
+++ b/test/collection_test.go
@@ -867,6 +867,6 @@ func TestCollectionWriteConcernSetPropInvalid(t *testing.T) {
 
 	prop, err = col.Properties(nil)
 	require.Nilf(t, err, "Failed to get properties: %s", describe(err))
-	assert.Equalf(t, minRepl, prop.WriteConcern, "MinReplicationFactor not updated, expected %d, found %d",
+	assert.Equalf(t, defaultWriteConcern, prop.WriteConcern, "MinReplicationFactor not updated, expected %d, found %d",
 		minRepl, prop.WriteConcern)
 }


### PR DESCRIPTION
Collection creation API
POST /_api/collection

The attribute minReplicationFactor has been renamed writeConcern. Using minReplicationFactor still works, but should be avoided in the future.
Collection properties API
GET /_api/collection/<name>/properties
PUT /_api/collection/<name>/properties

The attribute minReplicationFactor has been renamed writeConcern. Using minReplicationFactor still works, but should be avoided in the future.