### PR TITLE
Add maxRutime field to cursor query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
+#Go packages
 .gobuild
+
+#Temporary tests files
+.tmp
+
+#IDE's files
+.idea

--- a/context.go
+++ b/context.go
@@ -140,7 +140,7 @@ func WithWaitForSync(parent context.Context, value ...bool) context.Context {
 }
 
 // WithAllowDirtyReads is used in an active failover deployment to allow reads from the follower.
-// You can pass a reference to a boolean that will set according to wether a potentially dirty read
+// You can pass a reference to a boolean that will set according to whether a potentially dirty read
 // happened or not. nil is allowed.
 // This is valid for document reads, aql queries, gharial vertex and edge reads.
 func WithAllowDirtyReads(parent context.Context, wasDirtyRead *bool) context.Context {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/arangodb/go-velocypack v0.0.0-20190129082528-7896a965b4ad
 	github.com/coreos/go-iptables v0.4.3
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/stretchr/testify v1.2.2
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.2.2
 )

--- a/test/cursor_test.go
+++ b/test/cursor_test.go
@@ -29,22 +29,57 @@ import (
 	"time"
 
 	driver "github.com/arangodb/go-driver"
+	"github.com/stretchr/testify/require"
 )
 
-type queryTest struct {
-	Query             string
-	BindVars          map[string]interface{}
-	ExpectSuccess     bool
-	ExpectedDocuments []interface{}
-	DocumentType      reflect.Type
-	HasFullCount      bool
-	ExpectedFullCount int64
-}
+func TestCreateCursorWithMaxRuntime(t *testing.T) {
+	// Arrange
+	collectionName := "cursor_max_retry_test"
+	c := createClientFromEnv(t, true)
+	skipBelowVersion(c, "3.6", t)
+	db := ensureDatabase(context.Background(), c, "cursor_test", nil, t)
+	ensureCollection(context.Background(), db, collectionName, nil, t)
 
-type queryTestContext struct {
-	Context         context.Context
-	ExpectCount     bool
-	ExpectFullCount bool
+	tests := []struct {
+		Name          string
+		SleepQuery    string
+		MaxRuntime    float64
+		ExpectedError string
+	}{
+		{
+			Name:          "Too long query interrupted",
+			SleepQuery:    "1",
+			MaxRuntime:    0.01,
+			ExpectedError: "query killed (while executing)",
+		},
+		{
+			Name:       "Query passed before max runtime",
+			SleepQuery: "0.01",
+			MaxRuntime: 20.0,
+		},
+		{
+			Name:       "Query passed without max runtime",
+			SleepQuery: "0.01",
+			MaxRuntime: 0.0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			// Act
+			ctx := driver.WithQueryMaxRuntime(nil, test.MaxRuntime)
+			_, err := db.Query(ctx, "LET y = SLEEP("+test.SleepQuery+") INSERT {t:''} INTO "+collectionName, nil)
+
+			// Assert
+			if test.ExpectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.ExpectedError)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
 }
 
 // TestCreateCursor creates several cursors.
@@ -55,7 +90,7 @@ func TestCreateCursor(t *testing.T) {
 
 	// Create data set
 	collectionData := map[string][]interface{}{
-		"books": []interface{}{
+		"books": {
 			Book{Title: "Book 01"},
 			Book{Title: "Book 02"},
 			Book{Title: "Book 03"},
@@ -77,7 +112,7 @@ func TestCreateCursor(t *testing.T) {
 			Book{Title: "Book 19"},
 			Book{Title: "Book 20"},
 		},
-		"users": []interface{}{
+		"users": {
 			UserDoc{Name: "John", Age: 13},
 			UserDoc{Name: "Jake", Age: 25},
 			UserDoc{Name: "Clair", Age: 12},
@@ -94,62 +129,74 @@ func TestCreateCursor(t *testing.T) {
 	}
 
 	// Setup tests
-	tests := []queryTest{
-		queryTest{
+	tests := []struct {
+		Query             string
+		BindVars          map[string]interface{}
+		ExpectSuccess     bool
+		ExpectedDocuments []interface{}
+		DocumentType      reflect.Type
+		HasFullCount      bool
+		ExpectedFullCount int64
+	}{
+		{
 			Query:             "FOR d IN books SORT d.Title RETURN d",
 			ExpectSuccess:     true,
 			ExpectedDocuments: collectionData["books"],
 			DocumentType:      reflect.TypeOf(Book{}),
 		},
-		queryTest{
+		{
 			Query:             "FOR d IN books FILTER d.Title==@title SORT d.Title RETURN d",
 			BindVars:          map[string]interface{}{"title": "Book 02"},
 			ExpectSuccess:     true,
 			ExpectedDocuments: []interface{}{collectionData["books"][1]},
 			DocumentType:      reflect.TypeOf(Book{}),
 		},
-		queryTest{
+		{
 			Query:         "FOR d IN books FILTER d.Title==@title SORT d.Title RETURN d",
 			BindVars:      map[string]interface{}{"somethingelse": "Book 02"},
 			ExpectSuccess: false, // Unknown `@title`
 		},
-		queryTest{
+		{
 			Query:             "FOR u IN users FILTER u.age>100 SORT u.name RETURN u",
 			ExpectSuccess:     true,
 			ExpectedDocuments: []interface{}{},
 			DocumentType:      reflect.TypeOf(UserDoc{}),
 		},
-		queryTest{
-			Query:             "FOR u IN users FILTER u.age<@maxAge SORT u.name RETURN u",
-			BindVars:          map[string]interface{}{"maxAge": 20},
-			ExpectSuccess:     true,
-			ExpectedDocuments: []interface{}{collectionData["users"][2], collectionData["users"][0], collectionData["users"][5]},
-			DocumentType:      reflect.TypeOf(UserDoc{}),
+		{
+			Query:         "FOR u IN users FILTER u.age<@maxAge SORT u.name RETURN u",
+			BindVars:      map[string]interface{}{"maxAge": 20},
+			ExpectSuccess: true,
+			ExpectedDocuments: []interface{}{
+				collectionData["users"][2],
+				collectionData["users"][0],
+				collectionData["users"][5],
+			},
+			DocumentType: reflect.TypeOf(UserDoc{}),
 		},
-		queryTest{
+		{
 			Query:         "FOR u IN users FILTER u.age<@maxAge SORT u.name RETURN u",
 			BindVars:      map[string]interface{}{"maxage": 20},
 			ExpectSuccess: false, // `@maxage` versus `@maxAge`
 		},
-		queryTest{
+		{
 			Query:             "FOR u IN users SORT u.age RETURN u.age",
 			ExpectedDocuments: []interface{}{12, 12, 13, 25, 42, 67},
 			DocumentType:      reflect.TypeOf(12),
 			ExpectSuccess:     true,
 		},
-		queryTest{
+		{
 			Query:             "FOR p IN users COLLECT a = p.age WITH COUNT INTO c SORT a RETURN [a, c]",
 			ExpectedDocuments: []interface{}{[]int{12, 2}, []int{13, 1}, []int{25, 1}, []int{42, 1}, []int{67, 1}},
 			DocumentType:      reflect.TypeOf([]int{}),
 			ExpectSuccess:     true,
 		},
-		queryTest{
+		{
 			Query:             "FOR u IN users SORT u.name RETURN u.name",
 			ExpectedDocuments: []interface{}{"Blair", "Clair", "Jake", "John", "Johnny", "Zz"},
 			DocumentType:      reflect.TypeOf("foo"),
 			ExpectSuccess:     true,
 		},
-		queryTest{
+		{
 			Query:             "FOR d IN books SORT d.Title LIMIT 1, 1 RETURN d",
 			ExpectSuccess:     true,
 			ExpectedDocuments: []interface{}{collectionData["books"][1]},
@@ -160,21 +207,28 @@ func TestCreateCursor(t *testing.T) {
 	}
 
 	// Setup context alternatives
-	contexts := []queryTestContext{
-		queryTestContext{Context: nil},
-		queryTestContext{Context: context.Background()},
-		queryTestContext{Context: driver.WithQueryCount(nil), ExpectCount: true},
-		queryTestContext{Context: driver.WithQueryCount(nil, true), ExpectCount: true},
-		queryTestContext{Context: driver.WithQueryCount(nil, false)},
-		queryTestContext{Context: driver.WithQueryBatchSize(nil, 1)},
-		queryTestContext{Context: driver.WithQueryCache(nil)},
-		queryTestContext{Context: driver.WithQueryCache(nil, true)},
-		queryTestContext{Context: driver.WithQueryCache(nil, false)},
-		queryTestContext{Context: driver.WithQueryMemoryLimit(nil, 60000)},
-		queryTestContext{Context: driver.WithQueryTTL(nil, time.Minute)},
-		queryTestContext{Context: driver.WithQueryBatchSize(driver.WithQueryCount(nil), 1), ExpectCount: true},
-		queryTestContext{Context: driver.WithQueryCache(driver.WithQueryCount(driver.WithQueryBatchSize(nil, 2))), ExpectCount: true},
-		queryTestContext{Context: driver.WithQueryFullCount(nil, true), ExpectFullCount: true},
+	contexts := []struct {
+		Context         context.Context
+		ExpectCount     bool
+		ExpectFullCount bool
+	}{
+		{Context: nil},
+		{Context: context.Background()},
+		{Context: driver.WithQueryCount(nil), ExpectCount: true},
+		{Context: driver.WithQueryCount(nil, true), ExpectCount: true},
+		{Context: driver.WithQueryCount(nil, false)},
+		{Context: driver.WithQueryBatchSize(nil, 1)},
+		{Context: driver.WithQueryCache(nil)},
+		{Context: driver.WithQueryCache(nil, true)},
+		{Context: driver.WithQueryCache(nil, false)},
+		{Context: driver.WithQueryMemoryLimit(nil, 60000)},
+		{Context: driver.WithQueryTTL(nil, time.Minute)},
+		{Context: driver.WithQueryBatchSize(driver.WithQueryCount(nil), 1), ExpectCount: true},
+		{
+			Context:     driver.WithQueryCache(driver.WithQueryCount(driver.WithQueryBatchSize(nil, 2))),
+			ExpectCount: true,
+		},
+		{Context: driver.WithQueryFullCount(nil, true), ExpectFullCount: true},
 	}
 
 	// Run tests for every context alternative

--- a/test/server_statistics_test.go
+++ b/test/server_statistics_test.go
@@ -47,13 +47,13 @@ func doSomeWrites(t *testing.T, ctx context.Context, c driver.Client) {
 	db := ensureDatabase(ctx, c, "statistics_test", nil, t)
 	col := ensureCollection(ctx, db, "statistics_test", nil, t)
 	doc := UserDoc{
-	  "Max",
+		"Max",
 		50,
-  }
+	}
 	for i := 0; i < 1000; i++ {
 		_, err := col.CreateDocument(ctx, doc)
 		if err != nil {
-		  t.Fatalf("Failed to create new document: %s", describe(err))
+			t.Fatalf("Failed to create new document: %s", describe(err))
 		}
 	}
 }
@@ -73,23 +73,22 @@ func TestServerStatisticsWorks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cannot marshal statistics to JSON: %s", describe(err))
 	}
-  //t.Logf("Statistics: %s", string(b))
+	//t.Logf("Statistics: %s", string(b))
 }
 
 type source int
 
 const (
 	user source = iota
-	all source  = iota
+	all  source = iota
 )
 
 type limits struct {
 	Recv      float64
-  Sent        float64
+	Sent      float64
 	RecvCount int64
 	SentCount int64
 }
-
 
 // checkTrafficAtLeast compares stats before and after some operation and
 // checks that at least some amount of traffic has happened.
@@ -103,28 +102,28 @@ func checkTrafficAtLeast(t *testing.T, statsBefore *driver.ServerStatistics, sta
 		name = "ClientUser"
 	} else {
 		before = &statsBefore.Client
-    after = &statsAfter.Client
+		after = &statsAfter.Client
 		name = "Client"
 	}
 	diff := after.BytesReceived.Sum - before.BytesReceived.Sum
 	if diff < lim.Recv {
-			t.Errorf("%s: Difference in %s.BytesReceived.Sum is too small (< %f): %f",
-		           label, name, lim.Recv, diff)
+		t.Errorf("%s: Difference in %s.BytesReceived.Sum is too small (< %f): %f",
+			label, name, lim.Recv, diff)
 	}
 	diff = after.BytesSent.Sum - before.BytesSent.Sum
 	if diff < lim.Sent {
-			t.Errorf("%s: Difference in %s.BytesSent.Sum is too small (< %f): %f",
-		           label, name, lim.Sent, diff)
+		t.Errorf("%s: Difference in %s.BytesSent.Sum is too small (< %f): %f",
+			label, name, lim.Sent, diff)
 	}
 	intDiff := after.BytesReceived.Count - before.BytesReceived.Count
 	if intDiff < lim.RecvCount {
-			t.Errorf("%s: Difference in %s.BytesReceived.Count is too small (< %d): %d",
-		           label, name, lim.RecvCount, intDiff)
+		t.Errorf("%s: Difference in %s.BytesReceived.Count is too small (< %d): %d",
+			label, name, lim.RecvCount, intDiff)
 	}
 	intDiff = after.BytesSent.Count - before.BytesSent.Count
 	if intDiff < lim.SentCount {
-			t.Errorf("%s: Difference in %s.BytesSent.Count is too small (< %d): %d",
-		           label, name, lim.SentCount, intDiff)
+		t.Errorf("%s: Difference in %s.BytesSent.Count is too small (< %d): %d",
+			label, name, lim.SentCount, intDiff)
 	}
 }
 
@@ -140,28 +139,28 @@ func checkTrafficAtMost(t *testing.T, statsBefore *driver.ServerStatistics, stat
 		name = "ClientUser"
 	} else {
 		before = &statsBefore.Client
-    after = &statsAfter.Client
+		after = &statsAfter.Client
 		name = "Client"
 	}
 	diff := after.BytesReceived.Sum - before.BytesReceived.Sum
 	if diff > lim.Recv {
-			t.Errorf("%s: Difference in %s.BytesReceived.Sum is too large (> %f): %f",
-		           label, name, lim.Recv, diff)
+		t.Errorf("%s: Difference in %s.BytesReceived.Sum is too large (> %f): %f",
+			label, name, lim.Recv, diff)
 	}
 	diff = after.BytesSent.Sum - before.BytesSent.Sum
 	if diff > lim.Sent {
-			t.Errorf("%s: Difference in %s.BytesSent.Sum is too large (> %f): %f",
-		           label, name, lim.Sent, diff)
+		t.Errorf("%s: Difference in %s.BytesSent.Sum is too large (> %f): %f",
+			label, name, lim.Sent, diff)
 	}
 	intDiff := after.BytesReceived.Count - before.BytesReceived.Count
 	if intDiff > lim.RecvCount {
-			t.Errorf("%s: Difference in %s.BytesReceived.Count is too large (> %d): %d",
-		           label, name, lim.RecvCount, intDiff)
+		t.Errorf("%s: Difference in %s.BytesReceived.Count is too large (> %d): %d",
+			label, name, lim.RecvCount, intDiff)
 	}
 	intDiff = after.BytesSent.Count - before.BytesSent.Count
 	if intDiff > lim.SentCount {
-			t.Errorf("%s: Difference in %s.BytesSent.Count is too large (> %d): %d",
-		           label, name, lim.SentCount, intDiff)
+		t.Errorf("%s: Difference in %s.BytesSent.Count is too large (> %d): %d",
+			label, name, lim.SentCount, intDiff)
 	}
 }
 
@@ -180,7 +179,7 @@ func TestServerStatisticsTraffic(t *testing.T) {
 
 	doSomeWrites(t, nil, c)
 
-	time.Sleep(time.Second)  // Wait until statistics updated
+	time.Sleep(time.Second) // Wait until statistics updated
 
 	statsAfter, err := c.Statistics(ctx)
 	if err != nil {
@@ -188,27 +187,27 @@ func TestServerStatisticsTraffic(t *testing.T) {
 	}
 
 	checkTrafficAtLeast(t, &statsBefore, &statsAfter, all,
-											&limits{Sent: 100000.0, Recv: 40000.0,
-															SentCount: 1000, RecvCount: 1000}, "Banana");
+		&limits{Sent: 100000.0, Recv: 40000.0,
+			SentCount: 1000, RecvCount: 1000}, "Banana")
 
 	// Now check if user only stats are there and see if they should have increased:
-  if statsBefore.ClientUser.BytesReceived.Counts != nil {
-	  t.Logf("New user only statistics API is present, testing...")
+	if statsBefore.ClientUser.BytesReceived.Counts != nil {
+		t.Logf("New user only statistics API is present, testing...")
 		auth := os.Getenv("TEST_AUTHENTICATION")
 		if auth == "super:testing" {
 			t.Logf("Authentication %s is jwt superuser, expecting no user traffic...", auth)
-	    // Traffic is superuser, so nothing should be counted in ClientUser,
+			// Traffic is superuser, so nothing should be counted in ClientUser,
 			// not even the statistics calls.
 			checkTrafficAtMost(t, &statsBefore, &statsAfter, user,
-												 &limits{Sent: 0.1, Recv: 0.1,
-												         SentCount: 0, RecvCount: 0}, "Cherry");
+				&limits{Sent: 0.1, Recv: 0.1,
+					SentCount: 0, RecvCount: 0}, "Cherry")
 		} else {
 			t.Logf("Authentication %s is not jwt superuser, expecting to see user traffic...", auth)
 			// Traffic is either unauthenticated or with password, so there should
 			// be traffic in ClientUser
 			checkTrafficAtLeast(t, &statsBefore, &statsAfter, user,
-												  &limits{Sent: 100000.0, Recv: 40000.0,
-												          SentCount: 1000, RecvCount: 1000}, "Apple");
+				&limits{Sent: 100000.0, Recv: 40000.0,
+					SentCount: 1000, RecvCount: 1000}, "Apple")
 		}
 	} else {
 		t.Log("Skipping ClientUser tests for statistics, since API is not present.")
@@ -217,8 +216,8 @@ func TestServerStatisticsTraffic(t *testing.T) {
 
 // myQueryRequest is used below for a special query test for forwarding.
 type myQueryRequest struct {
-  Query string  `json:"query"`
-	BatchSize int `json:"batchSize,omitempty"`
+	Query     string `json:"query"`
+	BatchSize int    `json:"batchSize,omitempty"`
 }
 
 // cursorData is used to dig out the ID of the cursor
@@ -256,7 +255,7 @@ func TestServerStatisticsForwarding(t *testing.T) {
 	ctx1 := driver.WithEndpoint(context.Background(), endpoints[0])
 	ctx2 := driver.WithEndpoint(context.Background(), endpoints[1])
 
-	time.Sleep(time.Second)  // wait for statistics to settle
+	time.Sleep(time.Second) // wait for statistics to settle
 
 	statsBefore, err := c.Statistics(ctx2)
 	if err != nil {
@@ -270,7 +269,7 @@ func TestServerStatisticsForwarding(t *testing.T) {
 	doSomeWrites(t, ctx1, c)
 	doSomeWrites(t, ctx1, c)
 
-	time.Sleep(time.Second)  // wait for statistics to settle
+	time.Sleep(time.Second) // wait for statistics to settle
 
 	statsAfter, err := c.Statistics(ctx2)
 	if err != nil {
@@ -278,11 +277,11 @@ func TestServerStatisticsForwarding(t *testing.T) {
 	}
 
 	// No traffic on second coordinator (besides statistics calls):
-  checkTrafficAtMost(t, &statsBefore, &statsAfter, all,
-	                   &limits{Recv: 400, Sent: 4000,
-								             RecvCount: 2, SentCount: 2}, "Pear")
+	checkTrafficAtMost(t, &statsBefore, &statsAfter, all,
+		&limits{Recv: 400, Sent: 4000,
+			RecvCount: 2, SentCount: 2}, "Pear")
 
-  	if statsAfter.ClientUser.BytesReceived.Counts == nil {
+	if statsAfter.ClientUser.BytesReceived.Counts == nil {
 		t.Skip("Skipping ClientUser tests for statistics, since API is not present.")
 	}
 
@@ -292,7 +291,7 @@ func TestServerStatisticsForwarding(t *testing.T) {
 		t.Fatalf("Error in NewRequest call for cursor: %s", describe(err))
 	}
 	query := myQueryRequest{
-	  Query: "FOR x IN statistics_test RETURN x",
+		Query:     "FOR x IN statistics_test RETURN x",
 		BatchSize: 1000,
 	}
 	if _, err := req.SetBody(query); err != nil {
@@ -320,7 +319,7 @@ func TestServerStatisticsForwarding(t *testing.T) {
 	}
 
 	// Now issue a cursor continuation call to the second coordinator:
-	req, err = conn.NewRequest("PUT", "_db/statistics_test/_api/cursor/" + cursorBody.ID)
+	req, err = conn.NewRequest("PUT", "_db/statistics_test/_api/cursor/"+cursorBody.ID)
 	if err != nil {
 		t.Fatalf("Error in NewRequest call for cursor cont: %s", describe(err))
 	}
@@ -329,7 +328,7 @@ func TestServerStatisticsForwarding(t *testing.T) {
 		t.Fatalf("Error in Do call for cursor cont: %s", describe(err))
 	}
 
-	time.Sleep(time.Second)  // wait until statistics settled
+	time.Sleep(time.Second) // wait until statistics settled
 
 	statsAfter1, err := c.Statistics(ctx1)
 	if err != nil {
@@ -344,26 +343,25 @@ func TestServerStatisticsForwarding(t *testing.T) {
 	// the statistics calls):
 	t.Logf("Checking user traffic on coordinator2...")
 	checkTrafficAtMost(t, &statsBefore2, &statsAfter2, user,
-										 &limits{Recv: 400, Sent: 4000,
-														 RecvCount: 2, SentCount: 2}, "Apricot")
+		&limits{Recv: 400, Sent: 4000,
+			RecvCount: 2, SentCount: 2}, "Apricot")
 	// However, first coordinator should have counted the user traffic,
 	// note: it was just a single request with nearly no upload but quite
 	// some download:
 	auth := os.Getenv("TEST_AUTHENTICATION")
 	if auth != "super:testing" {
-	  t.Logf("Checking user traffic on coordinator1...")
+		t.Logf("Checking user traffic on coordinator1...")
 		t.Logf("statsBefore1: %v\nstatsAfter1: %v", statsBefore1.ClientUser.BytesSent, statsAfter1.ClientUser.BytesSent)
 		checkTrafficAtLeast(t, &statsBefore1, &statsAfter1, user,
-												&limits{Recv: 0, Sent: 40000,
-																RecvCount: 1, SentCount: 1}, "Jackfruit")
+			&limits{Recv: 0, Sent: 40000,
+				RecvCount: 1, SentCount: 1}, "Jackfruit")
 	} else {
-	  t.Logf("Checking traffic on coordinator1...")
+		t.Logf("Checking traffic on coordinator1...")
 		checkTrafficAtLeast(t, &statsBefore1, &statsAfter1, all,
-												&limits{Recv: 0, Sent: 40000,
-																RecvCount: 1, SentCount: 1}, "Durian")
+			&limits{Recv: 0, Sent: 40000,
+				RecvCount: 1, SentCount: 1}, "Durian")
 		checkTrafficAtMost(t, &statsBefore1, &statsAfter1, user,
-												&limits{Recv: 0.1, Sent: 0.1,
-																RecvCount: 0, SentCount: 0}, "Mango")
+			&limits{Recv: 0.1, Sent: 0.1,
+				RecvCount: 0, SentCount: 0}, "Mango")
 	}
 }
-


### PR DESCRIPTION
The existing API for creating cursors and running AQL queries provides an extra attribute maxRuntime (double) to be used inside its options attribute. The timeout is optional and can be used to kill a query on the server after the specified amount in time. The timeout value is specified in seconds. A value of 0 means no timeout will be enforced. 