### PR TITLE
Add job waiters in move shards tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .gobuild
+.idea
+.tmp

--- a/Makefile
+++ b/Makefile
@@ -61,14 +61,17 @@ TEST_ENDPOINTS := http://localhost:7001
 TESTS := $(REPOPATH)/test
 ifeq ("$(TEST_AUTH)", "rootpw")
 	CLUSTERENV := JWTSECRET=testing
+	TEST_JWTSECRET := testing
 	TEST_AUTHENTICATION := basic:root:
 endif
 ifeq ("$(TEST_AUTH)", "jwt")
 	CLUSTERENV := JWTSECRET=testing
+	TEST_JWTSECRET := testing
 	TEST_AUTHENTICATION := jwt:root:
 endif
 ifeq ("$(TEST_AUTH)", "jwtsuper")
 	CLUSTERENV := JWTSECRET=testing
+	TEST_JWTSECRET := testing
 	TEST_AUTHENTICATION := super:testing
 endif
 ifeq ("$(TEST_SSL)", "auto")
@@ -323,6 +326,7 @@ __test_go_test:
 		-v "${ROOTDIR}":/usr/code \
 		-e TEST_ENDPOINTS=$(TEST_ENDPOINTS) \
 		-e TEST_AUTHENTICATION=$(TEST_AUTHENTICATION) \
+		-e TEST_JWTSECRET=$(TEST_JWTSECRET) \
 		-e TEST_CONNECTION=$(TEST_CONNECTION) \
 		-e TEST_CVERSION=$(TEST_CVERSION) \
 		-e TEST_CONTENT_TYPE=$(TEST_CONTENT_TYPE) \

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -25,8 +25,8 @@ if [ "$CMD" == "start" ]; then
     # Create volumes
     docker volume create ${STARTERVOLUME} &> /dev/null
 
-    # Setup args 
-    if [ -n "$JWTSECRET" ]; then 
+    # Setup args
+    if [ -n "$JWTSECRET" ]; then
         if [ -z "$TMPDIR" ]; then 
             echo "TMPDIR environment variable must be set"
             exit 1 

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -292,9 +292,12 @@ func TestClusterMoveShard(t *testing.T) {
 					if dbServers[0] != targetServerID {
 						movedShards++
 						var rawResponse []byte
-						if err := cl.MoveShard(driver.WithRawResponse(ctx, &rawResponse), col, shardID, dbServers[0], targetServerID); err != nil {
+						var jobID string
+						jobCtx := driver.WithJobIDResponse(driver.WithRawResponse(ctx, &rawResponse), &jobID)
+						if err := cl.MoveShard(jobCtx, col, shardID, dbServers[0], targetServerID); err != nil {
 							t.Errorf("MoveShard for shard %s in collection %s failed: %s (raw response '%s' %x)", shardID, col.Name(), describe(err), string(rawResponse), rawResponse)
 						}
+						defer waitForJob(t, jobID, c)()
 					}
 				}
 			}
@@ -375,9 +378,13 @@ func TestClusterResignLeadership(t *testing.T) {
 				for _, dbServers := range colInv.Parameters.Shards {
 					targetServerID = dbServers[0]
 
-					if err := cl.ResignServer(context.Background(), string(targetServerID)); err != nil {
+					var jobID string
+					jobCtx := driver.WithJobIDResponse(context.Background(), &jobID)
+
+					if err := cl.ResignServer(jobCtx, string(targetServerID)); err != nil {
 						t.Errorf("ResignLeadership for %s failed: %s", targetServerID, describe(err))
 					}
+					defer waitForJob(t, jobID, c)()
 
 					break collectionLoop
 				}
@@ -481,9 +488,12 @@ func TestClusterMoveShardWithViews(t *testing.T) {
 					if dbServers[0] != targetServerID {
 						movedShards++
 						var rawResponse []byte
-						if err := cl.MoveShard(driver.WithRawResponse(ctx, &rawResponse), col, shardID, dbServers[0], targetServerID); err != nil {
+						var jobID string
+						jobCtx := driver.WithJobIDResponse(driver.WithRawResponse(ctx, &rawResponse), &jobID)
+						if err := cl.MoveShard(jobCtx, col, shardID, dbServers[0], targetServerID); err != nil {
 							t.Errorf("MoveShard for shard %s in collection %s failed: %s (raw response '%s' %x)", shardID, col.Name(), describe(err), string(rawResponse), rawResponse)
 						}
+						defer waitForJob(t, jobID, c)()
 					}
 				}
 			}

--- a/test/job_utils_test.go
+++ b/test/job_utils_test.go
@@ -1,0 +1,115 @@
+//
+// DISCLAIMER
+//
+// Copyright 2019 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Author Adam Janikowski
+//
+
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arangodb/go-driver"
+	"github.com/arangodb/go-driver/agency"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	agencyJobStateKeyPrefixes = [][]string{
+		{"arango", "Target", "ToDo"},
+		{"arango", "Target", "Pending"},
+		{"arango", "Target", "Finished"},
+		{"arango", "Target", "Failed"},
+	}
+)
+
+type agencyJob struct {
+	Reason string `json:"reason,omitempty"`
+	Server string `json:"server,omitempty"`
+	JobID  string `json:"jobId,omitempty"`
+	Type   string `json:"type,omitempty"`
+}
+
+type jobStatus int
+
+const (
+	JobNotFound jobStatus = 0
+	JobToDo     jobStatus = 1
+	JobPending  jobStatus = 2
+	JobFinished jobStatus = 3
+	JobFailed   jobStatus = 4
+)
+
+func fetchJobStatus(t *testing.T, jobID string, client driver.Client) jobStatus {
+	ctx, c := context.WithTimeout(context.Background(), 5*time.Second)
+	defer c()
+
+	a, err := getHttpAuthAgencyConnection(ctx, t, client)
+	require.NoError(t, err)
+
+	for _, keyPrefix := range agencyJobStateKeyPrefixes {
+		key := append(keyPrefix, jobID)
+		var job agencyJob
+		if err := a.ReadKey(ctx, key, &job); err == nil {
+			switch keyPrefix[len(keyPrefix)-1] {
+			case "ToDo":
+				return JobToDo
+			case "Pending":
+				return JobPending
+			case "Finished":
+				return JobFinished
+			case "Failed":
+				return JobFailed
+			}
+		} else if agency.IsKeyNotFound(err) {
+			continue
+		} else {
+			require.NoError(t, err)
+		}
+	}
+
+	return JobNotFound
+}
+
+// waitForJob will check if job exists and return function which will wait for job to finish (desired to use with defer)
+func waitForJob(t *testing.T, jobID string, client driver.Client) func() {
+	require.NotEqual(t, JobNotFound, fetchJobStatus(t, jobID, client))
+
+	t.Logf("waiting for job %s before test end", jobID)
+
+	return func() {
+		t.Logf("waiting for job %s to finish", jobID)
+		err := retry(125*time.Millisecond, time.Minute, func() error {
+			result := fetchJobStatus(t, jobID, client)
+
+			require.NotEqual(t, JobFailed, result, "job failed")
+
+			if result == JobFinished {
+				return interrupt{}
+			}
+
+			t.Logf("job %s not yet finished", jobID)
+
+			return nil
+		})
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
Allow waiting for a job to finish.

For that, we need to open a connection to the agency with proper auth and protocol