### PR TITLE
Add new field 'globallyUniqueId' to the collection info

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -87,6 +87,8 @@ type CollectionInfo struct {
 	Type CollectionType `json:"type,omitempty"`
 	// If true then the collection is a system collection.
 	IsSystem bool `json:"isSystem,omitempty"`
+	// Global unique name for the collection
+	GloballyUniqueId string `json:"globallyUniqueId,omitempty"`
 }
 
 // CollectionProperties contains extended information about a collection.

--- a/test/collection_test.go
+++ b/test/collection_test.go
@@ -338,11 +338,21 @@ func TestCollectionProperties(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create collection '%s': %s", name, describe(err))
 	}
+	version, err := c.Version(nil)
+	if err != nil {
+		t.Fatalf("Version failed: %s", describe(err))
+	}
+
 	if p, err := col.Properties(nil); err != nil {
 		t.Errorf("Failed to fetch collection properties: %s", describe(err))
 	} else {
 		if p.ID == "" {
 			t.Errorf("Got empty collection ID")
+		}
+		if version.Version.CompareTo("3.5") >= 0 {
+			if p.GloballyUniqueId == "" {
+				t.Errorf("Got empty collection globallyUniqueId")
+			}
 		}
 		if p.Name != name {
 			t.Errorf("Expected name '%s', got '%s'", name, p.Name)


### PR DESCRIPTION
The field `globallyUniqueId` is required by the Arangosync to improve reading rom the Write ahead log