### PR TITLE
Fix tests, add one field in CollectionProperties.

### DIFF
--- a/client_impl.go
+++ b/client_impl.go
@@ -85,7 +85,8 @@ func (c *client) SynchronizeEndpoints2(ctx context.Context, dbname string) error
 	cep, err := c.clusterEndpoints(ctx, dbname)
 	if err != nil {
 		// ignore Forbidden: automatic failover is not enabled errors
-		if !IsArangoErrorWithErrorNum(err, 403, 0, 11) { // 3.2 returns no error code, thus check for 0
+		if !IsArangoErrorWithErrorNum(err, 403, 501, 0, 11) { // 3.2 returns no error code, thus check for 0
+			// 501 is in there since 3.7 for some time returned this in a single server
 			return WithStack(err)
 		}
 

--- a/client_impl.go
+++ b/client_impl.go
@@ -85,8 +85,8 @@ func (c *client) SynchronizeEndpoints2(ctx context.Context, dbname string) error
 	cep, err := c.clusterEndpoints(ctx, dbname)
 	if err != nil {
 		// ignore Forbidden: automatic failover is not enabled errors
-		if !IsArangoErrorWithErrorNum(err, 403, 501, 0, 11) { // 3.2 returns no error code, thus check for 0
-			// 501 is in there since 3.7 for some time returned this in a single server
+		if !IsArangoErrorWithErrorNum(err, 403, 501, 0, 9, 11) { // 3.2 returns no error code, thus check for 0
+			// 501 with ErrorNum 9 is in there since 3.7, earlier versions returned 403 and ErrorNum 11.
 			return WithStack(err)
 		}
 

--- a/collection.go
+++ b/collection.go
@@ -132,6 +132,9 @@ type CollectionProperties struct {
 	// This attribute specifies the name of the sharding strategy to use for the collection.
 	// Can not be changed after creation.
 	ShardingStrategy ShardingStrategy `json:"shardingStrategy,omitempty"`
+	// This attribute specifies that the sharding of a collection follows that of another
+	// one.
+	DistributeShardsLike string `json:"distributeShardsLike,omitempty"`
 }
 
 const (


### PR DESCRIPTION
I need one additional field in the CollectionProperties. This is added.

Furthermore, I noticed that ArangoDB > 3.6 returns a different error code on `/_api/cluster/endpoints` in case of a single server. This is tolerated now and fixes some tests.