### PR TITLE
Correct typo; remove dead code that used to handle ReturnOld

### DIFF
--- a/edge_collection_documents_impl.go
+++ b/edge_collection_documents_impl.go
@@ -486,7 +486,7 @@ func (c *edgeCollection) removeDocument(ctx context.Context, key string) (Docume
 	}
 	cs := applyContextSettings(ctx, req)
 	if cs.ReturnOld != nil {
-		return DocumentMeta{}, contextSettings{}, WithStack(InvalidArgumentError{Message: "ReturnOld is not support when removing edges"})
+		return DocumentMeta{}, contextSettings{}, WithStack(InvalidArgumentError{Message: "ReturnOld is not supported when removing edges"})
 	}
 	resp, err := c.conn.Do(ctx, req)
 	if err != nil {
@@ -503,12 +503,6 @@ func (c *edgeCollection) removeDocument(ctx context.Context, key string) (Docume
 	var meta DocumentMeta
 	if err := resp.ParseBody("edge", &meta); err != nil {
 		return DocumentMeta{}, cs, WithStack(err)
-	}
-	// Parse returnOld (if needed)
-	if cs.ReturnOld != nil {
-		if err := resp.ParseBody("old", cs.ReturnOld); err != nil {
-			return meta, cs, WithStack(err)
-		}
 	}
 	return meta, cs, nil
 }

--- a/vertex_collection_documents_impl.go
+++ b/vertex_collection_documents_impl.go
@@ -485,7 +485,7 @@ func (c *vertexCollection) removeDocument(ctx context.Context, key string) (Docu
 	}
 	cs := applyContextSettings(ctx, req)
 	if cs.ReturnOld != nil {
-		return DocumentMeta{}, contextSettings{}, WithStack(InvalidArgumentError{Message: "ReturnOld is not support when removing vertices"})
+		return DocumentMeta{}, contextSettings{}, WithStack(InvalidArgumentError{Message: "ReturnOld is not supported when removing vertices"})
 	}
 	resp, err := c.conn.Do(ctx, req)
 	if err != nil {
@@ -502,12 +502,6 @@ func (c *vertexCollection) removeDocument(ctx context.Context, key string) (Docu
 	var meta DocumentMeta
 	if err := resp.ParseBody("vertex", &meta); err != nil {
 		return DocumentMeta{}, cs, WithStack(err)
-	}
-	// Parse returnOld (if needed)
-	if cs.ReturnOld != nil {
-		if err := resp.ParseBody("old", cs.ReturnOld); err != nil {
-			return meta, cs, WithStack(err)
-		}
 	}
 	return meta, cs, nil
 }


### PR DESCRIPTION
I happened to notice this when A) receiving the message, and B) investigating the code path while looking into graph-aware ReadDocument performance.

run-tests passes.