### PR TITLE
Change many entries in agency within one transaction

### DIFF
--- a/agency/agency.go
+++ b/agency/agency.go
@@ -41,7 +41,7 @@ type Agency interface {
 	// WriteTransaction performs transaction in the agency.
 	// Transaction can have list of operations to perform like e.g. delete, set, observe...
 	// Transaction can have preconditions which must be fulfilled to perform transaction.
-	WriteTransaction(ctx context.Context, transactions Transaction, transient ...bool) error
+	WriteTransaction(ctx context.Context, transaction Transaction) error
 
 	// WriteKey writes the given value with the given key with a given TTL (unless TTL is zero).
 	// If you pass a condition (only 1 allowed), this condition has to be true,

--- a/agency/agency_impl.go
+++ b/agency/agency_impl.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// Copyright 2020 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 // Copyright holder is ArangoDB GmbH, Cologne, Germany
 //
 // Author Ewout Prangsma
+// Author Tomasz Mielech <tomasz@arangodb.com>
 //
 
 package agency
@@ -26,10 +27,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/arangodb/go-driver"
 	"strings"
 	"time"
-
-	"github.com/arangodb/go-driver"
 )
 
 var (
@@ -138,13 +138,13 @@ type writeCondition struct {
 	IsArray  *bool       `json:"isArray,omitempty"`  // Require old value to be array
 }
 
-type writeTransaction []map[string]interface{}
-type writeTransactions []writeTransaction
+type writeTransaction []interface{}
 
 type writeResult struct {
 	Results []int64 `json:"results"`
 }
 
+// Deprecated: use 'WriteTransaction' instead
 // WriteKey writes the given value with the given key with a given TTL (unless TTL is zero).
 // If you pass a condition (only 1 allowed), this condition has to be true,
 // otherwise the write will fail with a ConditionFailed error.
@@ -158,56 +158,90 @@ func (c *agency) WriteKey(ctx context.Context, key []string, value interface{}, 
 	default:
 		return driver.WithStack(fmt.Errorf("too many conditions"))
 	}
-	if err := c.write(ctx, "set", key, value, cond, ttl); err != nil {
+
+	transaction := NewTransaction("")
+	transaction.AddKey(NewKeySet(key, value, ttl))
+	conditions := ConvertWriteCondition(cond)
+	transaction.SetConditions(conditions)
+
+	if err := c.WriteTransaction(ctx, transaction); err != nil {
 		return driver.WithStack(err)
 	}
+
 	return nil
 }
 
+// Deprecated: use 'WriteTransaction' instead
 // WriteKeyIfEmpty writes the given value with the given key only if the key was empty before.
 func (c *agency) WriteKeyIfEmpty(ctx context.Context, key []string, value interface{}, ttl time.Duration) error {
-	var cond WriteCondition
-	cond = cond.IfEmpty(key)
-	if err := c.write(ctx, "set", key, value, cond, ttl); err != nil {
+	transaction := NewTransaction("")
+	transaction.AddKey(NewKeySet(key, value, ttl))
+	transaction.AddCondition(key, NewConditionOldEmpty(true))
+
+	if err := c.WriteTransaction(ctx, transaction); err != nil {
 		return driver.WithStack(err)
 	}
+
 	return nil
 }
 
+// Deprecated: use 'WriteTransaction' instead
 // WriteKeyIfEqualTo writes the given new value with the given key only if the existing value for that key equals
 // to the given old value.
 func (c *agency) WriteKeyIfEqualTo(ctx context.Context, key []string, newValue, oldValue interface{}, ttl time.Duration) error {
-	var cond WriteCondition
-	cond = cond.IfEqualTo(key, oldValue)
-	if err := c.write(ctx, "set", key, newValue, cond, ttl); err != nil {
+	transaction := NewTransaction("")
+	transaction.AddKey(NewKeySet(key, newValue, ttl))
+	transaction.AddCondition(key, NewConditionIfEqual(oldValue))
+
+	if err := c.WriteTransaction(ctx, transaction); err != nil {
 		return driver.WithStack(err)
 	}
+
 	return nil
 }
 
-// write writes the given value with the given key only if the given condition is fullfilled.
-func (c *agency) write(ctx context.Context, operation string, key []string, value interface{}, condition WriteCondition, ttl time.Duration) error {
+// WriteTransaction performs transaction in the agency.
+// Transaction can have list of operations to perform like e.g. delete, set, observe...
+// Transaction can have preconditions which must be fulfilled to perform transaction.
+func (c *agency) WriteTransaction(ctx context.Context, transaction Transaction, transient ...bool) error {
 	conn := c.conn
-	req, err := conn.NewRequest("POST", "_api/agency/write")
+
+	var path string
+	if len(transient) > 0 && transient[0] == true {
+		path = "_api/agency/transient"
+	} else {
+		path = "_api/agency/write"
+	}
+
+	req, err := conn.NewRequest("POST", path)
 	if err != nil {
 		return driver.WithStack(err)
 	}
 
-	fullKey := createFullKey(key)
-	writeTxs := writeTransactions{
-		writeTransaction{
-			// Update
-			map[string]interface{}{
-				fullKey: writeUpdate{
-					Operation: operation,
-					New:       value,
-					TTL:       int64(ttl.Seconds()),
-				},
-			},
-			// Condition
-			condition.toMap(),
-		},
+	writeTxs := make([]writeTransaction, 0, 1)
+	f := make(writeTransaction, 0, 3)
+	keysToChange := make(map[string]interface{})
+	for _, v := range transaction.keys {
+		keysToChange[v.GetKey()] = writeUpdate{
+			Operation: v.GetOperation(),
+			New:       v.GetValue(),
+			TTL:       int64(v.GetTTL().Seconds()),
+			URL:       v.GetURL(),
+		}
 	}
+
+	conditions := make(map[string]interface{})
+	if transaction.conditions != nil {
+		for key, condition := range transaction.conditions {
+			conditions[key] = map[string]interface{}{
+				condition.GetName(): condition.GetValue(),
+			}
+		}
+	}
+
+	f = append(f, keysToChange, conditions, transaction.clientID)
+	writeTxs = append(writeTxs, f)
+
 	req, err = req.SetBody(writeTxs)
 	if err != nil {
 		return driver.WithStack(err)
@@ -221,16 +255,15 @@ func (c *agency) write(ctx context.Context, operation string, key []string, valu
 	if err := resp.CheckStatus(200, 201, 202); err != nil {
 		return driver.WithStack(err)
 	}
+
 	if err := resp.ParseBody("", &result); err != nil {
 		return driver.WithStack(err)
 	}
 
-	// "results" should be 1 long
 	if len(result.Results) != 1 {
-		return driver.WithStack(fmt.Errorf("Expected results of 1 long, got %d", len(result.Results)))
+		return driver.WithStack(fmt.Errorf("expected results of 1 long, got %d", len(result.Results)))
 	}
 
-	// If results[0] == 0, condition failed, otherwise success
 	if result.Results[0] == 0 {
 		// Condition failed
 		return driver.WithStack(preconditionFailedError)
@@ -240,6 +273,7 @@ func (c *agency) write(ctx context.Context, operation string, key []string, valu
 	return nil
 }
 
+// Deprecated: use 'WriteTransaction' instead
 // RemoveKey removes the given key.
 // If you pass a condition (only 1 allowed), this condition has to be true,
 // otherwise the remove will fail with a ConditionFailed error.
@@ -253,111 +287,56 @@ func (c *agency) RemoveKey(ctx context.Context, key []string, condition ...Write
 	default:
 		return driver.WithStack(fmt.Errorf("too many conditions"))
 	}
-	if err := c.write(ctx, "delete", key, nil, cond, 0); err != nil {
+
+	transaction := NewTransaction("")
+	transaction.AddKey(NewKeyDelete(key))
+	conditions := ConvertWriteCondition(cond)
+	transaction.SetConditions(conditions)
+
+	if err := c.WriteTransaction(ctx, transaction); err != nil {
 		return driver.WithStack(err)
 	}
+
 	return nil
 }
 
+// Deprecated: use 'WriteTransaction' instead
 // RemoveKeyIfEqualTo removes the given key only if the existing value for that key equals
 // to the given old value.
 func (c *agency) RemoveKeyIfEqualTo(ctx context.Context, key []string, oldValue interface{}) error {
-	var cond WriteCondition
-	cond = cond.IfEqualTo(key, oldValue)
-	if err := c.write(ctx, "delete", key, nil, cond, 0); err != nil {
+	transaction := NewTransaction("")
+	transaction.AddKey(NewKeyDelete(key))
+	transaction.AddCondition(key, NewConditionIfEqual(oldValue))
+
+	if err := c.WriteTransaction(ctx, transaction); err != nil {
 		return driver.WithStack(err)
 	}
+
 	return nil
 }
 
+// Deprecated: use 'WriteTransaction' instead
 // Register a URL to receive notification callbacks when the value of the given key changes
 func (c *agency) RegisterChangeCallback(ctx context.Context, key []string, cbURL string) error {
-	conn := c.conn
-	req, err := conn.NewRequest("POST", "_api/agency/write")
-	if err != nil {
+	transaction := NewTransaction("")
+	transaction.AddKey(NewKeyObserve(key, cbURL, true))
+
+	if err := c.WriteTransaction(ctx, transaction); err != nil {
 		return driver.WithStack(err)
 	}
 
-	fullKey := createFullKey(key)
-	writeTxs := writeTransactions{
-		writeTransaction{
-			// Update
-			map[string]interface{}{
-				fullKey: writeUpdate{
-					Operation: "observe",
-					URL:       cbURL,
-				},
-			},
-		},
-	}
-
-	req, err = req.SetBody(writeTxs)
-	if err != nil {
-		return driver.WithStack(err)
-	}
-	resp, err := conn.Do(ctx, req)
-	if err != nil {
-		return driver.WithStack(err)
-	}
-
-	var result writeResult
-	if err := resp.CheckStatus(200, 201, 202); err != nil {
-		return driver.WithStack(err)
-	}
-	if err := resp.ParseBody("", &result); err != nil {
-		return driver.WithStack(err)
-	}
-
-	// "results" should be 1 long
-	if len(result.Results) != 1 {
-		return driver.WithStack(fmt.Errorf("Expected results of 1 long, got %d", len(result.Results)))
-	}
-
-	// Success
 	return nil
 }
 
+// Deprecated: use 'WriteTransaction' instead
 // Register a URL to receive notification callbacks when the value of the given key changes
 func (c *agency) UnregisterChangeCallback(ctx context.Context, key []string, cbURL string) error {
-	conn := c.conn
-	req, err := conn.NewRequest("POST", "_api/agency/write")
-	if err != nil {
-		return driver.WithStack(err)
-	}
 
-	fullKey := createFullKey(key)
-	writeTxs := writeTransactions{
-		writeTransaction{
-			// Update
-			map[string]interface{}{
-				fullKey: writeUpdate{
-					Operation: "unobserve",
-					URL:       cbURL,
-				},
-			},
-		},
-	}
+	transaction := NewTransaction("")
+	transaction.AddKey(NewKeyObserve(key, cbURL, false))
 
-	req, err = req.SetBody(writeTxs)
-	if err != nil {
+	if err := c.WriteTransaction(ctx, transaction); err != nil {
 		return driver.WithStack(err)
-	}
-	resp, err := conn.Do(ctx, req)
-	if err != nil {
-		return driver.WithStack(err)
-	}
-
-	var result writeResult
-	if err := resp.CheckStatus(200, 201, 202); err != nil {
-		return driver.WithStack(err)
-	}
-	if err := resp.ParseBody("", &result); err != nil {
-		return driver.WithStack(err)
-	}
-
-	// "results" should be 1 long
-	if len(result.Results) != 1 {
-		return driver.WithStack(fmt.Errorf("Expected results of 1 long, got %d", len(result.Results)))
 	}
 
 	// Success

--- a/agency/agency_impl.go
+++ b/agency/agency_impl.go
@@ -204,11 +204,11 @@ func (c *agency) WriteKeyIfEqualTo(ctx context.Context, key []string, newValue, 
 // WriteTransaction performs transaction in the agency.
 // Transaction can have list of operations to perform like e.g. delete, set, observe...
 // Transaction can have preconditions which must be fulfilled to perform transaction.
-func (c *agency) WriteTransaction(ctx context.Context, transaction Transaction, transient ...bool) error {
+func (c *agency) WriteTransaction(ctx context.Context, transaction Transaction) error {
 	conn := c.conn
 
 	var path string
-	if len(transient) > 0 && transient[0] == true {
+	if transaction.options.Transient {
 		path = "_api/agency/transient"
 	} else {
 		path = "_api/agency/write"

--- a/agency/condition.go
+++ b/agency/condition.go
@@ -1,0 +1,126 @@
+//
+// DISCLAIMER
+//
+// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Tomasz Mielech <tomasz@arangodb.com>
+//
+
+package agency
+
+// KeyConditioner describes conditions to check before it writes something to the agency
+type KeyConditioner interface {
+	// GetName returns the name of condition e.g.: old, oldNot, oldEmpty, isArray
+	GetName() string
+	// GetValue returns the value for which condition must be met
+	GetValue() interface{}
+}
+
+type ConditionsMap map[string]KeyConditioner
+
+// ConvertWriteCondition creates new conditions to the transaction using deprecated structure 'WriteCondition'
+func ConvertWriteCondition(cond WriteCondition) ConditionsMap {
+	keyConditions := make(ConditionsMap)
+
+	for key, v := range cond.conditions {
+		if v.Old != nil {
+			keyConditions[key] = NewConditionIfEqual(v.Old)
+		} else if v.OldEmpty != nil {
+			keyConditions[key] = NewConditionOldEmpty(*v.OldEmpty)
+		} else if v.IsArray != nil {
+			keyConditions[key] = NewConditionIsArray(*v.IsArray)
+		}
+	}
+
+	return keyConditions
+}
+
+// NewConditionIfEqual creates condition where value must equal to a value which is written in the agency
+func NewConditionIfEqual(value interface{}) KeyConditioner {
+	return &keyConditionIfEqual{
+		value: value,
+	}
+}
+
+// NewConditionIfNotEqual creates condition where value must not equal to a value which is written in the agency
+func NewConditionIfNotEqual(value interface{}) KeyConditioner {
+	return &keyConditionIfNotEqual{
+		value: value,
+	}
+}
+
+// NewConditionOldEmpty creates condition where value must be empty before it is written
+func NewConditionOldEmpty(value bool) KeyConditioner {
+	return &keyConditionOldEmpty{
+		value: value,
+	}
+}
+
+// NewConditionIsArray creates condition where value must be an array before it is written
+func NewConditionIsArray(value bool) KeyConditioner {
+	return &keyConditionIsArray{
+		value: value,
+	}
+}
+
+type keyConditionIfEqual struct {
+	value interface{}
+}
+
+type keyConditionIfNotEqual struct {
+	value interface{}
+}
+
+type keyConditionOldEmpty struct {
+	value bool
+}
+
+type keyConditionIsArray struct {
+	value bool
+}
+
+func (k *keyConditionIfEqual) GetName() string {
+	return "old"
+}
+
+func (k *keyConditionIfEqual) GetValue() interface{} {
+	return k.value
+}
+
+func (k *keyConditionIfNotEqual) GetName() string {
+	return "oldNot"
+}
+
+func (k *keyConditionIfNotEqual) GetValue() interface{} {
+	return k.value
+}
+
+func (k *keyConditionOldEmpty) GetName() string {
+	return "oldEmpty"
+}
+
+func (k *keyConditionOldEmpty) GetValue() interface{} {
+	return k.value
+}
+
+func (k *keyConditionIsArray) GetName() string {
+	return "isArray"
+}
+
+func (k *keyConditionIsArray) GetValue() interface{} {
+	return k.value
+}

--- a/agency/operation.go
+++ b/agency/operation.go
@@ -1,0 +1,147 @@
+//
+// DISCLAIMER
+//
+// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Tomasz Mielech <tomasz@arangodb.com>
+//
+
+package agency
+
+import "time"
+
+// KeyChanger describes how operation should be performed on a key in the agency
+type KeyChanger interface {
+	// GetKey returns which key must be changed
+	GetKey() string
+	// GetOperation returns what type of operation must be performed on a key
+	GetOperation() string
+	// GetTTL returns how long (in seconds) a key will live in the agency
+	GetTTL() time.Duration
+	// GetURL returns URL address where must be sent callback in case of some changes on key
+	GetURL() string
+	// GetValue returns new value for a key in the agency
+	GetValue() interface{}
+}
+
+type keyCommon struct {
+	key []string
+}
+
+func (k *keyCommon) GetKey() string {
+	return createFullKey(k.key)
+}
+
+type keyDelete struct {
+	keyCommon
+}
+
+type keySet struct {
+	keyCommon
+	TTL   time.Duration
+	value interface{}
+}
+
+type keyObserve struct {
+	keyCommon
+	URL     string
+	observe bool
+}
+
+// NewKeyDelete returns a new key operation which must be removed from the agency
+func NewKeyDelete(key []string) KeyChanger {
+	return &keyDelete{
+		keyCommon{
+			key: key,
+		},
+	}
+}
+
+// NewKeySet returns a new key operation which must be set in the agency
+func NewKeySet(key []string, value interface{}, TTL time.Duration) KeyChanger {
+	return &keySet{
+		keyCommon: keyCommon{
+			key: key,
+		},
+		TTL:   TTL,
+		value: value,
+	}
+}
+
+// NewKeyObserve returns a new key callback operation which must be written in the agency.
+// URL parameter describes where callback must be sent in case of changes on a key.
+// When 'observe' is false then we want to stop observing a key.
+func NewKeyObserve(key []string, URL string, observe bool) KeyChanger {
+	return &keyObserve{
+		keyCommon: keyCommon{
+			key: key,
+		},
+		URL:     URL,
+		observe: observe,
+	}
+}
+
+func (k *keyDelete) GetOperation() string {
+	return "delete"
+}
+
+func (k *keyDelete) GetTTL() time.Duration {
+	return 0
+}
+
+func (k *keyDelete) GetValue() interface{} {
+	return nil
+}
+
+func (k *keyDelete) GetURL() string {
+	return ""
+}
+
+func (k *keySet) GetOperation() string {
+	return "set"
+}
+
+func (k *keySet) GetTTL() time.Duration {
+	return k.TTL
+}
+
+func (k *keySet) GetValue() interface{} {
+	return k.value
+}
+
+func (k *keySet) GetURL() string {
+	return ""
+}
+
+func (k *keyObserve) GetOperation() string {
+	if k.observe {
+		return "observe"
+	}
+	return "unobserve"
+}
+
+func (k *keyObserve) GetTTL() time.Duration {
+	return 0
+}
+
+func (k *keyObserve) GetValue() interface{} {
+	return nil
+}
+
+func (k *keyObserve) GetURL() string {
+	return k.URL
+}

--- a/agency/transaction.go
+++ b/agency/transaction.go
@@ -1,0 +1,73 @@
+//
+// DISCLAIMER
+//
+// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+// Tomasz Mielech <tomasz@arangodb.com>
+//
+
+package agency
+
+import (
+	"fmt"
+	"github.com/arangodb/go-driver"
+	"github.com/dchest/uniuri"
+)
+
+// Transaction stores information about operations which must be performed for particular keys with some conditions
+type Transaction struct {
+	keys       []KeyChanger
+	conditions ConditionsMap
+	clientID   string
+}
+
+// NewTransaction creates new transaction
+func NewTransaction(clientID string) Transaction {
+	if len(clientID) == 0 {
+		clientID = uniuri.New()
+	}
+
+	return Transaction{
+		clientID: clientID,
+	}
+}
+
+// SetConditions sets new conditions for the transaction
+func (k *Transaction) SetConditions(conditions ConditionsMap) {
+	k.conditions = conditions
+}
+
+// AddCondition adds new condition to the list of keys which must be changed in one transaction
+func (k *Transaction) AddCondition(key []string, condition KeyConditioner) error {
+	if k.conditions == nil {
+		k.conditions = make(map[string]KeyConditioner)
+	}
+
+	fullKey := createFullKey(key)
+	if _, ok := k.conditions[fullKey]; ok {
+		// For the time being one key can have only one condition. It is a limitation in agency
+		return driver.WithStack(fmt.Errorf("too many conditions"))
+	}
+
+	k.conditions[fullKey] = condition
+	return nil
+}
+
+// AddKey adds new key which must be changed in one transaction
+func (k *Transaction) AddKey(key KeyChanger) {
+	k.keys = append(k.keys, key)
+}

--- a/agency/transaction.go
+++ b/agency/transaction.go
@@ -28,7 +28,9 @@ import (
 )
 
 // TransactionOptions defines options how transaction should behave.
-type TransactionOptions struct{}
+type TransactionOptions struct {
+	Transient bool
+}
 
 // Transaction stores information about operations which must be performed for particular keys with some conditions
 type Transaction struct {

--- a/test/agency_test.go
+++ b/test/agency_test.go
@@ -769,7 +769,7 @@ func writeTransaction(t *testing.T, transient bool) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			for _, requestTest := range testCase.requests {
-				transaction := agency.NewTransaction("")
+				transaction := agency.NewTransaction("", agency.TransactionOptions{})
 				for _, v := range requestTest.transaction.keys {
 					transaction.AddKey(v)
 				}
@@ -804,7 +804,7 @@ func writeTransaction(t *testing.T, transient bool) {
 				assert.Equal(t, testCase.expectedResult[rootKeyAgency], result)
 			}
 
-			cleanUpTransaction := agency.NewTransaction("")
+			cleanUpTransaction := agency.NewTransaction("", agency.TransactionOptions{})
 			cleanUpTransaction.AddKey(agency.NewKeyDelete([]string{rootKeyAgency}))
 			err := a.WriteTransaction(ctx, cleanUpTransaction, transient)
 			require.NoError(t, err)

--- a/test/agency_test.go
+++ b/test/agency_test.go
@@ -769,7 +769,7 @@ func writeTransaction(t *testing.T, transient bool) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			for _, requestTest := range testCase.requests {
-				transaction := agency.NewTransaction("", agency.TransactionOptions{})
+				transaction := agency.NewTransaction("", agency.TransactionOptions{Transient: transient})
 				for _, v := range requestTest.transaction.keys {
 					transaction.AddKey(v)
 				}
@@ -780,7 +780,7 @@ func writeTransaction(t *testing.T, transient bool) {
 					}
 				}
 
-				err := a.WriteTransaction(ctx, transaction, transient)
+				err := a.WriteTransaction(ctx, transaction)
 				if requestTest.expectedError != nil {
 					require.EqualError(t, err, requestTest.expectedError.Error())
 				} else {
@@ -804,9 +804,9 @@ func writeTransaction(t *testing.T, transient bool) {
 				assert.Equal(t, testCase.expectedResult[rootKeyAgency], result)
 			}
 
-			cleanUpTransaction := agency.NewTransaction("", agency.TransactionOptions{})
+			cleanUpTransaction := agency.NewTransaction("", agency.TransactionOptions{Transient: transient})
 			cleanUpTransaction.AddKey(agency.NewKeyDelete([]string{rootKeyAgency}))
-			err := a.WriteTransaction(ctx, cleanUpTransaction, transient)
+			err := a.WriteTransaction(ctx, cleanUpTransaction)
 			require.NoError(t, err)
 		})
 	}


### PR DESCRIPTION
**Warning**
Unfortunately, the transient endpoint is not handled by this PR because this endpoint returns response like `[true]` (it is []interface{}) and it can not be parsed by functions like `ParseBody` (it is map[string]interface{}) or `ParseArrayBody` (it is []map[string]interface{}.

We should have only one function which can parse a response exactly the same pattern is used in `func Unmarshal(data []byte, v interface{}) error` but this is out of my scope of my PR


**Commits before rebase:**
Write many transaction to the agency
Finish implementation for operation and conditions
Add integration tests for writing Transactions
Add integration tests using agency conditions
Remove transient key
Change functions' name
Avoid sending many transactions in one request