### PR TITLE
Add additional cursor.ReadDocumentOnly method that does not marshal DocumentMeta

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -64,6 +64,11 @@ type Cursor interface {
 	//       then the returned DocumentMeta will be empty.
 	ReadDocument(ctx context.Context, result interface{}) (DocumentMeta, error)
 
+	// ReadDocumentOnly reads the next document from the cursor.
+	// The document data is stored into result.
+	// If the cursor has no more documents, a NoMoreDocuments error is returned.
+	ReadDocumentOnly(ctx context.Context, result interface{}) error
+
 	// Count returns the total number of result documents available.
 	// A valid return value is only available when the cursor has been created with a context that was
 	// prepared with `WithQueryCount` and not with `WithQueryStream`.

--- a/test/cursor_test.go
+++ b/test/cursor_test.go
@@ -322,6 +322,27 @@ func TestCreateCursorReturnNull(t *testing.T) {
 	}
 }
 
+// TestCreateCursorDocumentOnlyReturnNull creates a cursor with a `RETURN NULL` query and ReadDocumentOnly.
+func TestCreateCursorDocumentOnlyReturnNull(t *testing.T) {
+	ctx := context.Background()
+	c := createClientFromEnv(t, true)
+	db := ensureDatabase(ctx, c, "cursor_test", nil, t)
+
+	var result interface{}
+	query := "return null"
+	cursor, err := db.Query(ctx, query, nil)
+	if err != nil {
+		t.Fatalf("Query(return null) failed: %s", describe(err))
+	}
+	defer cursor.Close()
+	if err := cursor.ReadDocumentOnly(ctx, &result); err != nil {
+		t.Fatalf("ReadDocument failed: %s", describe(err))
+	}
+	if result != nil {
+		t.Errorf("Expected result to be nil, got %#v", result)
+	}
+}
+
 // Test stream query cursors. The goroutines are technically only
 // relevant for the MMFiles engine, but don't hurt on rocksdb either
 func TestCreateStreamCursor(t *testing.T) {

--- a/v2/arangodb/cursor.go
+++ b/v2/arangodb/cursor.go
@@ -42,6 +42,13 @@ type Cursor interface {
 	//       then the returned DocumentMeta will be empty.
 	ReadDocument(ctx context.Context, result interface{}) (DocumentMeta, error)
 
+	// ReadDocumentOnly reads the next document from the cursor.
+	// The document data is stored into result, the document meta data is returned.
+	// If the cursor has no more documents, a NoMoreDocuments error is returned.
+	// Note: If the query (resulting in this cursor) does not return documents,
+	//       then the returned DocumentMeta will be empty.
+	ReadDocumentOnly(ctx context.Context, result interface{}) error
+
 	// Count returns the total number of result documents available.
 	// A valid return value is only available when the cursor has been created with `Count` and not with `Stream`.
 	Count() int64


### PR DESCRIPTION
In cases where the Document returned by ReadDocument is small (<=500B) the Marshal of DocumentMeta increases the execution time of ReadDocument by ~40%. Even with larger Document sizes, this extra Marshal is a significant portion of execution time (10-20% for even multi-KiB Documents).

Given that the vast majority of use cases that I've seen for cursor.ReadDocument() (and 100% of my use cases over the last couple of years) the meta data isn't used—`_, err := cursor.ReadDocument(...)`

This change adds a parallel method called ReadDocumentOnly that does not Marshal and return the Meta data, decreasing execution time. For a single call, the difference is in single-digit microseconds, but for hundreds or thousands of returned Documents, the execution time adds up IME.

The method naming could obviously change based on convention or preference of the maintainers. I've also updated v2, though I didn't see relevant v2 unit tests.

Thanks!