### PR TITLE
Add support for StoredValues in View SetProperties

### DIFF
--- a/test/view_test.go
+++ b/test/view_test.go
@@ -30,6 +30,7 @@ import (
 
 	driver "github.com/arangodb/go-driver"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -515,6 +516,8 @@ func TestArangoSearchViewProperties35(t *testing.T) {
 	sortDir := driver.ArangoSearchSortDirectionDesc
 	name := "test_get_asview_35"
 	sortField := "foo"
+	storedValuesFields := []string{"now", "is", "the", "time"}
+	storedValuesCompression := "none"
 	opts := &driver.ArangoSearchViewProperties{
 		Links: driver.ArangoSearchLinks{
 			"someCol": driver.ArangoSearchElementProperties{},
@@ -523,6 +526,10 @@ func TestArangoSearchViewProperties35(t *testing.T) {
 		PrimarySort: []driver.ArangoSearchPrimarySortEntry{{
 			Field:     sortField,
 			Direction: &sortDir,
+		}},
+		StoredValues: []driver.ArangoSearchStoredValuesEntry{{
+			Fields:      storedValuesFields,
+			Compression: storedValuesCompression,
 		}},
 	}
 	if _, err := db.CreateArangoSearchView(ctx, name, opts); err != nil {
@@ -551,6 +558,16 @@ func TestArangoSearchViewProperties35(t *testing.T) {
 		ps := p.PrimarySort[0]
 		if ps.Field != sortField {
 			t.Errorf("Primary Sort field is wrong: %s, expected %s", ps.Field, sortField)
+		}
+	}
+	if len(p.StoredValues) != 1 {
+		t.Fatalf("StoredValues expected length: %d, found %d", 1, len(p.StoredValues))
+	} else {
+		sv := p.StoredValues[0]
+		if !assert.Equal(t, sv.Fields, storedValuesFields) {
+			t.Errorf("StoredValues field is wrong: %s, expected %s", sv.Fields, storedValuesFields)
+		} else if sv.Compression != storedValuesCompression {
+			t.Errorf("StoredValues Compression is wrong: %s, expected %s", sv.Compression, storedValuesCompression)
 		}
 	}
 }

--- a/view_arangosearch.go
+++ b/view_arangosearch.go
@@ -183,6 +183,10 @@ type ArangoSearchViewProperties struct {
 
 	// PrimarySort describes how individual fields are sorted
 	PrimarySort []ArangoSearchPrimarySortEntry `json:"primarySort,omitempty"`
+
+	// StoredValues is an array of objects to describe which document attributes to store in the
+	// View index.
+	StoredValues []ArangoSearchStoredValuesEntry `json:"storedValues,omitempty"`
 }
 
 // ArangoSearchSortDirection describes the sorting direction
@@ -303,3 +307,13 @@ const (
 	// information about value presence, to allow use of the EXISTS() function.
 	ArangoSearchStoreValuesID ArangoSearchStoreValues = "id"
 )
+
+type ArangoSearchStoredValuesEntry struct {
+	// Fields is an array of strings with one or more document attribute paths.
+	Fields []string `json:"fields,omitempty"`
+	// Compression defines the compression type used for the internal column-store, which can be
+	// "lz4" (LZ4 fast compression, default) or "none".
+	// NOTE: While "lz4" is documented, specifying it in the API is not currently supported.
+	// (2020.09.30)
+	Compression string `json:"compression,omitempty"`
+}


### PR DESCRIPTION
Supports the new StoredValues View parameter.

I noticed that contrary to the documentation, a compression value of "lz4" is not supported, at least as of Enterprise 3.7.2.
