### PR TITLE
Adjust test for dynamic revision tree depth in arangod

### DIFF
--- a/test/revisions_test.go
+++ b/test/revisions_test.go
@@ -76,13 +76,13 @@ func TestRevisionTree(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	noOfLeafs := 299593
+	noOfLeafs := 37449
 	require.NotEmpty(t, tree.Version)
 	require.NotEmpty(t, tree.RangeMin)
 	require.NotEmpty(t, tree.RangeMax)
 	require.NotEmpty(t, tree.Nodes)
 	require.Equal(t, noOfLeafs, len(tree.Nodes))
-	require.Equal(t, 6, tree.MaxDepth)
+	require.Equal(t, 5, tree.MaxDepth)
 
 	getRanges := func() driver.Revisions {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute)


### PR DESCRIPTION
A recent PR introduced dynamic-depth revision trees in arangod: https://github.com/arangodb/arangodb/pull/12716. The tree depth is now dependent on the collection size. This PR adjusts a test to account for a shallower tree than previously expected.