### PR TITLE
[Feature] Return and use Cursor ID

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -54,6 +54,8 @@ type QueryStatistics interface {
 type Cursor interface {
 	io.Closer
 
+	ID() string
+
 	// HasMore returns true if the next call to ReadDocument does not return a NoMoreDocuments error.
 	HasMore() bool
 

--- a/cursor_impl.go
+++ b/cursor_impl.go
@@ -90,6 +90,10 @@ func (c *cursor) relPath() string {
 	return path.Join(c.db.relPath(), "_api", "cursor")
 }
 
+func (c *cursor) ID() string {
+	return c.cursorData.ID
+}
+
 // Name returns the name of the collection.
 func (c *cursor) HasMore() bool {
 	return c.resultIndex < len(c.Result) || c.cursorData.HasMore

--- a/database_impl.go
+++ b/database_impl.go
@@ -24,7 +24,6 @@ package driver
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"path"
 )
@@ -129,15 +128,14 @@ func (d *database) Remove(ctx context.Context) error {
 // Query performs an AQL query, returning a cursor used to iterate over the returned documents.
 func (d *database) Query(ctx context.Context, query string, bindVars map[string]interface{}) (Cursor, error) {
 	method := "POST"
-	loc := "_api/cursor"
+	location := "_api/cursor"
 	if cursorID, ok := ctx.Value(keyQueryCursorID).(string); ok {
 		if cursorID != "" {
 			method = "PUT"
-			loc += "/" + cursorID
+			location += "/" + cursorID
 		}
 	}
-	fmt.Printf("%v\n", loc)
-	req, err := d.conn.NewRequest(method, path.Join(d.relPath(), loc))
+	req, err := d.conn.NewRequest(method, path.Join(d.relPath(), location))
 	if err != nil {
 		return nil, WithStack(err)
 	}


### PR DESCRIPTION
## PR
This PR adds the `driver.WithQueryCursorID` method that allow to run queries using an Cursor ID as shown in [docs](https://www.arangodb.com/docs/stable/http/aql-query-cursor-accessing-cursors.html)

In addition, it also implements a method called `ID` in the `Cursor` struct, which allows obtaining the cursor ID during a query with a defined batch size

## Context
This is very useful for doing a cursor pagination