### PR TITLE
[BUGFIX] [V2] don't escape the path twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
 - [V2] Add support for streaming the response body by the caller.
+- [V2] Bugfix with escaping the URL path twice.
 
 ## [1.2.1](https://github.com/arangodb/go-driver/tree/v1.2.1) (2021-09-21)
 - Add support for fetching shards' info by the given collection name.

--- a/v2/connection/call.go
+++ b/v2/connection/call.go
@@ -27,7 +27,6 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"net/url"
 	"path"
 )
 
@@ -96,11 +95,8 @@ func WithBody(i interface{}) RequestModifier {
 	}
 }
 
+// NewUrl returns the path in the URL.
 func NewUrl(parts ...string) string {
-	s := make([]string, len(parts))
-	for id, part := range parts {
-		s[id] = url.PathEscape(part)
-	}
-
-	return path.Join(s...)
+	// The path will be escaped when request is created.
+	return path.Join(parts...)
 }


### PR DESCRIPTION
the `url.PathEscape` is used twice.

When the path in the URL is created `func NewUrl(parts ...string)` .
And when the request is created `func (j *httpRequest) URL() string` .

