### PR TITLE
added support for shardIds query option for APM-292

### DIFF
--- a/query.go
+++ b/query.go
@@ -144,8 +144,6 @@ type queryRequest struct {
 	// Calculating the "count" attribute might have a performance impact for some queries in the future so this option is
 	// turned off by default, and "count" is only returned when requested.
 	Count bool `json:"count,omitempty"`
-	// ShardId query option
-	ShardIds []string `json:"shardIds,omitempty"`
 	// maximum number of result documents to be transferred from the server to the client in one roundtrip.
 	// If this attribute is not set, a server-controlled default value will be used. A batchSize value of 0 is disallowed.
 	BatchSize int `json:"batchSize,omitempty"`
@@ -165,6 +163,8 @@ type queryRequest struct {
 	// key/value pairs representing the bind parameters.
 	BindVars map[string]interface{} `json:"bindVars,omitempty"`
 	Options  struct {
+		// ShardId query option
+		ShardIds []string `json:"shardIds,omitempty"`
 		// Profile If set to true or 1, then the additional query profiling information will be returned in the sub-attribute profile of the extra return attribute,
 		// if the query result is not served from the query cache. Set to 2 the query will include execution stats per query plan node in
 		// sub-attribute stats.nodes of the extra return attribute. Additionally the query plan is returned in the sub-attribute extra.plan.

--- a/query.go
+++ b/query.go
@@ -39,6 +39,7 @@ const (
 	keyQueryOptStream                   = "arangodb-query-opt-stream"
 	keyQueryOptProfile                  = "arangodb-query-opt-profile"
 	keyQueryOptMaxRuntime               = "arangodb-query-opt-maxRuntime"
+	keyQueryShardIds                    = "arangodb-query-opt-shardIds"
 )
 
 // WithQueryCount is used to configure a context that will set the Count of a query request,
@@ -54,6 +55,11 @@ func WithQueryCount(parent context.Context, value ...bool) context.Context {
 // WithQueryBatchSize is used to configure a context that will set the BatchSize of a query request,
 func WithQueryBatchSize(parent context.Context, value int) context.Context {
 	return context.WithValue(contextOrBackground(parent), keyQueryBatchSize, value)
+}
+
+// WithQuerySharIds is used to configure a context that will set the ShardIds of a query request,
+func WithQueryShardIds(parent context.Context, value []string) context.Context {
+	return context.WithValue(contextOrBackground(parent), keyQueryShardIds, value)
 }
 
 // WithQueryCache is used to configure a context that will set the Cache of a query request,
@@ -138,6 +144,8 @@ type queryRequest struct {
 	// Calculating the "count" attribute might have a performance impact for some queries in the future so this option is
 	// turned off by default, and "count" is only returned when requested.
 	Count bool `json:"count,omitempty"`
+	// ShardId query option
+	ShardIds []string `json:"shardIds,omitempty"`
 	// maximum number of result documents to be transferred from the server to the client in one roundtrip.
 	// If this attribute is not set, a server-controlled default value will be used. A batchSize value of 0 is disallowed.
 	BatchSize int `json:"batchSize,omitempty"`
@@ -204,6 +212,11 @@ func (q *queryRequest) applyContextSettings(ctx context.Context) {
 	if rawValue := ctx.Value(keyQueryBatchSize); rawValue != nil {
 		if value, ok := rawValue.(int); ok {
 			q.BatchSize = value
+		}
+	}
+	if rawValue := ctx.Value(keyQueryShardIds); rawValue != nil {
+		if value, ok := rawValue.([]string); ok {
+			q.ShardIds = value
 		}
 	}
 	if rawValue := ctx.Value(keyQueryCache); rawValue != nil {

--- a/query.go
+++ b/query.go
@@ -216,7 +216,7 @@ func (q *queryRequest) applyContextSettings(ctx context.Context) {
 	}
 	if rawValue := ctx.Value(keyQueryShardIds); rawValue != nil {
 		if value, ok := rawValue.([]string); ok {
-			q.ShardIds = value
+			q.Options.ShardIds = value
 		}
 	}
 	if rawValue := ctx.Value(keyQueryCache); rawValue != nil {

--- a/test/cursor_test.go
+++ b/test/cursor_test.go
@@ -211,7 +211,6 @@ func TestCreateCursor(t *testing.T) {
 		Context         context.Context
 		ExpectCount     bool
 		ExpectFullCount bool
-		ExpectEmpty     bool
 	}{
 		{Context: nil},
 		{Context: context.Background()},
@@ -230,7 +229,6 @@ func TestCreateCursor(t *testing.T) {
 			ExpectCount: true,
 		},
 		{Context: driver.WithQueryFullCount(nil, true), ExpectFullCount: true},
-		{Context: driver.WithQueryShardIds(nil, []string{"s1"}), ExpectEmpty: true},
 	}
 
 	// Run tests for every context alternative
@@ -261,12 +259,6 @@ func TestCreateCursor(t *testing.T) {
 					stat := cursor.Statistics()
 					if stat.FullCount() != test.ExpectedFullCount {
 						t.Errorf("Expected full count of %d, got %d in query %d (%s)", test.ExpectedFullCount, stat.FullCount(), i, test.Query)
-					}
-				}
-				if qctx.ExpectEmpty {
-					stat := cursor.Statistics()
-					if stat.FullCount() != 0 {
-						t.Errorf("Expected empty cursor, got %d in query %d (%s)", stat.FullCount(), i, test.Query)
 					}
 				}
 				var result []interface{}

--- a/test/cursor_test.go
+++ b/test/cursor_test.go
@@ -229,6 +229,7 @@ func TestCreateCursor(t *testing.T) {
 			ExpectCount: true,
 		},
 		{Context: driver.WithQueryFullCount(nil, true), ExpectFullCount: true},
+		{Context: driver.WithQueryShardIds(nil, []string{"s1"})},
 	}
 
 	// Run tests for every context alternative

--- a/test/cursor_test.go
+++ b/test/cursor_test.go
@@ -211,6 +211,7 @@ func TestCreateCursor(t *testing.T) {
 		Context         context.Context
 		ExpectCount     bool
 		ExpectFullCount bool
+		ExpectEmpty     bool
 	}{
 		{Context: nil},
 		{Context: context.Background()},
@@ -229,7 +230,7 @@ func TestCreateCursor(t *testing.T) {
 			ExpectCount: true,
 		},
 		{Context: driver.WithQueryFullCount(nil, true), ExpectFullCount: true},
-		{Context: driver.WithQueryShardIds(nil, []string{"s1"})},
+		{Context: driver.WithQueryShardIds(nil, []string{"s1"}), ExpectEmpty: true},
 	}
 
 	// Run tests for every context alternative
@@ -260,6 +261,12 @@ func TestCreateCursor(t *testing.T) {
 					stat := cursor.Statistics()
 					if stat.FullCount() != test.ExpectedFullCount {
 						t.Errorf("Expected full count of %d, got %d in query %d (%s)", test.ExpectedFullCount, stat.FullCount(), i, test.Query)
+					}
+				}
+				if qctx.ExpectEmpty {
+					stat := cursor.Statistics()
+					if stat.FullCount() != 0 {
+						t.Errorf("Expected empty cursor, got %d in query %d (%s)", stat.FullCount(), i, test.Query)
 					}
 				}
 				var result []interface{}

--- a/test/query_test.go
+++ b/test/query_test.go
@@ -140,18 +140,32 @@ func TestValidateQuery(t *testing.T) {
 func TestValidateQueryOptionShardIds(t *testing.T) {
 	ctx := context.Background()
 	c := createClientFromEnv(t, true)
-	db := ensureDatabase(ctx, c, "validate_query_options_test", nil, t)
-	col := ensureCollection(ctx, db, "c", nil, t)
+	_, err := c.Cluster(ctx)
 
-	db, clean := prepareQueryDatabase(t, ctx, c, "validate_query_options_test")
-	defer clean(t)
+	if driver.IsPreconditionFailed(err) {
+		t.Skip("Not a cluster")
+	} else {
+		db := ensureDatabase(ctx, c, "validate_query_options_test", nil, t)
+		col := ensureCollection(ctx, db, "c", nil, t)
 
-	t.Run(fmt.Sprintf("Run"), func(t *testing.T) {
-		props, err := col.Properties(ctx)
-		driver.WithQueryShardIds(ctx, props.ShardKeys)
-		_, err = db.Query(ctx, "FOR doc in c RETURN c", map[string]interface{}{})
-		require.NoError(t, err)
-	})
+		db, clean := prepareQueryDatabase(t, ctx, c, "validate_query_options_test")
+		defer clean(t)
+
+		t.Run(fmt.Sprintf("Real shards"), func(t *testing.T) {
+			shards, err := col.Shards(ctx, true)
+			for sk := range shards.Shards {
+				ctx = driver.WithQueryShardIds(nil, []string{string(sk)})
+				_, err = db.Query(ctx, "FOR doc in c RETURN c", map[string]interface{}{})
+				require.NoError(t, err)
+			}
+		})
+
+		t.Run(fmt.Sprintf("Fake shards"), func(t *testing.T) {
+			ctx = driver.WithQueryShardIds(nil, []string{"s1"})
+			_, err = db.Query(ctx, "FOR doc in c RETURN c", map[string]interface{}{})
+			require.NotNil(t, err)
+		})
+	}
 
 	return
 

--- a/test/query_test.go
+++ b/test/query_test.go
@@ -136,6 +136,27 @@ func TestValidateQuery(t *testing.T) {
 	}
 }
 
+// TestValidateQuery validates several AQL queries.
+func TestValidateQueryOptionShardIds(t *testing.T) {
+	ctx := context.Background()
+	c := createClientFromEnv(t, true)
+	db := ensureDatabase(ctx, c, "validate_query_options_test", nil, t)
+	col := ensureCollection(ctx, db, "c", nil, t)
+
+	db, clean := prepareQueryDatabase(t, ctx, c, "validate_query_options_test")
+	defer clean(t)
+
+	t.Run(fmt.Sprintf("Run"), func(t *testing.T) {
+		props, err := col.Properties(ctx)
+		driver.WithQueryShardIds(ctx, props.ShardKeys)
+		_, err = db.Query(ctx, "FOR doc in c RETURN c", map[string]interface{}{})
+		require.NoError(t, err)
+	})
+
+	return
+
+}
+
 // TestProfileQuery profile several AQL queries.
 func TestProfileQuery(t *testing.T) {
 	ctx := context.Background()

--- a/v2/arangodb/database_query.go
+++ b/v2/arangodb/database_query.go
@@ -36,6 +36,8 @@ type DatabaseQuery interface {
 }
 
 type QuerySubOptions struct {
+	// ShardId query option
+	ShardIds []string `json:"shardIds,omitempty"`
 	// If set to true, then the additional query profiling information will be returned in the sub-attribute profile of the
 	// extra return attribute if the query result is not served from the query cache.
 	Profile bool `json:"profile,omitempty"`
@@ -66,8 +68,6 @@ type QuerySubOptions struct {
 }
 
 type QueryOptions struct {
-	// ShardId query option
-	ShardIds []string `json:"shardIds,omitempty"`
 	// indicates whether the number of documents in the result set should be returned in the "count" attribute of the result.
 	// Calculating the "count" attribute might have a performance impact for some queries in the future so this option is
 	// turned off by default, and "count" is only returned when requested.

--- a/v2/arangodb/database_query.go
+++ b/v2/arangodb/database_query.go
@@ -66,6 +66,8 @@ type QuerySubOptions struct {
 }
 
 type QueryOptions struct {
+	// ShardId query option
+	ShardIds []string `json:"shardIds,omitempty"`
 	// indicates whether the number of documents in the result set should be returned in the "count" attribute of the result.
 	// Calculating the "count" attribute might have a performance impact for some queries in the future so this option is
 	// turned off by default, and "count" is only returned when requested.

--- a/v2/arangodb/meta.go
+++ b/v2/arangodb/meta.go
@@ -36,7 +36,7 @@ type ServerID string
 
 type DocumentID string
 
-// DocumentMeta contains all meta data used to identifier a document.
+// DocumentMeta contains all meta data used to identify a document.
 type DocumentMeta struct {
 	Key string     `json:"_key,omitempty"`
 	ID  DocumentID `json:"_id,omitempty"`

--- a/v2/tests/database_collection_operations_test.go
+++ b/v2/tests/database_collection_operations_test.go
@@ -190,6 +190,29 @@ func Test_DatabaseCollectionOperations(t *testing.T) {
 					}
 				})
 
+				t.Run("Cursor - shardIds", func(t *testing.T) {
+					//nd := docs
+
+					query := fmt.Sprintf("FOR doc IN `%s` RETURN doc", col.Name())
+
+					q, err := db.Query(ctx, query, &arangodb.QueryOptions{
+						ShardIds: []string{"s1"},
+					})
+					require.NoError(t, err)
+
+					for {
+						var doc document
+						_, err := q.ReadDocument(ctx, &doc)
+						if shared.IsNoMoreDocuments(err) {
+							break
+						}
+
+						require.NoError(t, err)
+
+						//require.True(t, len(nd) == 0)
+					}
+				})
+
 				t.Run("Cursor - close", func(t *testing.T) {
 					query := fmt.Sprintf("FOR doc IN `%s` RETURN doc", col.Name())
 

--- a/v2/tests/database_collection_operations_test.go
+++ b/v2/tests/database_collection_operations_test.go
@@ -191,6 +191,7 @@ func Test_DatabaseCollectionOperations(t *testing.T) {
 				})
 
 				t.Run("Cursor - shardIds", func(t *testing.T) {
+					requireClusterMode(t)
 
 					query := fmt.Sprintf("FOR doc IN `%s` RETURN doc", col.Name())
 

--- a/v2/tests/database_collection_operations_test.go
+++ b/v2/tests/database_collection_operations_test.go
@@ -191,26 +191,54 @@ func Test_DatabaseCollectionOperations(t *testing.T) {
 				})
 
 				t.Run("Cursor - shardIds", func(t *testing.T) {
-					//nd := docs
 
 					query := fmt.Sprintf("FOR doc IN `%s` RETURN doc", col.Name())
 
-					q, err := db.Query(ctx, query, &arangodb.QueryOptions{
-						ShardIds: []string{"s1"},
-					})
+					q, err := db.Query(ctx, query, &arangodb.QueryOptions{})
 					require.NoError(t, err)
-
+					i := 0
 					for {
 						var doc document
 						_, err := q.ReadDocument(ctx, &doc)
 						if shared.IsNoMoreDocuments(err) {
 							break
 						}
+						require.NoError(t, err)
+						i++
+					}
 
+					// Non existing shard should error
+					q, err = db.Query(ctx, query, &arangodb.QueryOptions{
+						Options: arangodb.QuerySubOptions{
+							ShardIds: []string{"ss1"},
+						},
+					})
+					require.NotNil(t, err)
+
+					// collect all docs from all shards
+					s, err := col.Shards(context.Background(), true)
+					j := 0
+					for sk := range s.Shards {
+						shardIds := []string{string(sk)}
+						q, err = db.Query(ctx, query, &arangodb.QueryOptions{
+							Options: arangodb.QuerySubOptions{
+								ShardIds: shardIds,
+							},
+						})
 						require.NoError(t, err)
 
-						//require.True(t, len(nd) == 0)
+						for {
+							var doc document
+							_, err := q.ReadDocument(ctx, &doc)
+							if shared.IsNoMoreDocuments(err) {
+								break
+							}
+							require.NoError(t, err)
+							j++
+						}
 					}
+					require.Equal(t, i, j)
+
 				})
 
 				t.Run("Cursor - close", func(t *testing.T) {


### PR DESCRIPTION
Added support for query option `shardIds` [APM-292]

[APM-292]: https://arangodb.atlassian.net/browse/APM-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ