### PR TITLE
Bugfix/collection params missing fields

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -200,6 +200,8 @@ type InventoryCollectionParameters struct {
 	// Deprecated since 3.7 version. It is related only to MMFiles.
 	IndexBuckets int              `json:"indexBuckets,omitempty"`
 	Indexes      []InventoryIndex `json:"indexes,omitempty"`
+	// Available from 3.9 ArangoD version.
+	InternalValidatorType int `json:"internalValidatorType,omitempty"`
 	// Available from 3.7 ArangoD version.
 	IsDisjoint bool `json:"isDisjoint,omitempty"`
 	IsSmart    bool `json:"isSmart,omitempty"`
@@ -220,12 +222,15 @@ type InventoryCollectionParameters struct {
 	Name                 string `json:"name,omitempty"`
 	NumberOfShards       int    `json:"numberOfShards,omitempty"`
 	// Deprecated since 3.7 ArangoD version.
-	Path              string                 `json:"path,omitempty"`
-	PlanID            string                 `json:"planId,omitempty"`
-	ReplicationFactor int                    `json:"replicationFactor,omitempty"`
-	ShardingStrategy  ShardingStrategy       `json:"shardingStrategy,omitempty"`
-	ShardKeys         []string               `json:"shardKeys,omitempty"`
-	Shards            map[ShardID][]ServerID `json:"shards,omitempty"`
+	Path              string `json:"path,omitempty"`
+	PlanID            string `json:"planId,omitempty"`
+	ReplicationFactor int    `json:"replicationFactor,omitempty"`
+	// Schema for collection validation.
+	Schema            *CollectionSchemaOptions `json:"schema,omitempty"`
+	ShadowCollections []int                    `json:"shadowCollections,omitempty"`
+	ShardingStrategy  ShardingStrategy         `json:"shardingStrategy,omitempty"`
+	ShardKeys         []string                 `json:"shardKeys,omitempty"`
+	Shards            map[ShardID][]ServerID   `json:"shards,omitempty"`
 	// Optional only for some collections.
 	SmartGraphAttribute string `json:"smartGraphAttribute,omitempty"`
 	// Optional only for some collections.

--- a/cluster.go
+++ b/cluster.go
@@ -192,12 +192,12 @@ type InventoryCollectionParameters struct {
 	CacheEnabled         bool   `json:"cacheEnabled,omitempty"`
 	Deleted              bool   `json:"deleted,omitempty"`
 	DistributeShardsLike string `json:"distributeShardsLike,omitempty"`
-	// Deprecated since 3.7 version. It is related only to MMFiles.
+	// Deprecated: since 3.7 version. It is related only to MMFiles.
 	DoCompact bool `json:"doCompact,omitempty"`
 	// Available from 3.7 ArangoD version.
 	GloballyUniqueId string `json:"globallyUniqueId,omitempty"`
 	ID               string `json:"id,omitempty"`
-	// Deprecated since 3.7 version. It is related only to MMFiles.
+	// Deprecated: since 3.7 version. It is related only to MMFiles.
 	IndexBuckets int              `json:"indexBuckets,omitempty"`
 	Indexes      []InventoryIndex `json:"indexes,omitempty"`
 	// Available from 3.9 ArangoD version.
@@ -208,9 +208,9 @@ type InventoryCollectionParameters struct {
 	// Available from 3.7 ArangoD version.
 	IsSmartChild bool `json:"isSmartChild,omitempty"`
 	IsSystem     bool `json:"isSystem,omitempty"`
-	// Deprecated since 3.7 version. It is related only to MMFiles.
+	// Deprecated: since 3.7 version. It is related only to MMFiles.
 	IsVolatile bool `json:"isVolatile,omitempty"`
-	// Deprecated since 3.7 version. It is related only to MMFiles.
+	// Deprecated: since 3.7 version. It is related only to MMFiles.
 	JournalSize int64 `json:"journalSize,omitempty"`
 	KeyOptions  struct {
 		AllowUserKeys bool   `json:"allowUserKeys,omitempty"`
@@ -221,7 +221,7 @@ type InventoryCollectionParameters struct {
 	MinReplicationFactor int    `json:"minReplicationFactor,omitempty"`
 	Name                 string `json:"name,omitempty"`
 	NumberOfShards       int    `json:"numberOfShards,omitempty"`
-	// Deprecated since 3.7 ArangoD version.
+	// Deprecated: since 3.7 ArangoD version.
 	Path              string `json:"path,omitempty"`
 	PlanID            string `json:"planId,omitempty"`
 	ReplicationFactor int    `json:"replicationFactor,omitempty"`

--- a/cluster.go
+++ b/cluster.go
@@ -188,42 +188,57 @@ func (i InventoryCollection) IndexByFieldsAndType(fields []string, indexType str
 
 // InventoryCollectionParameters contains all configuration parameters of a collection in a database inventory.
 type InventoryCollectionParameters struct {
-	Deleted             bool             `json:"deleted,omitempty"`
-	DoCompact           bool             `json:"doCompact,omitempty"`
-	ID                  string           `json:"id,omitempty"`
-	IndexBuckets        int              `json:"indexBuckets,omitempty"`
-	Indexes             []InventoryIndex `json:"indexes,omitempty"`
-	IsSmart             bool             `json:"isSmart,omitempty"`
-	SmartGraphAttribute string           `json:"smartGraphAttribute,omitempty"`
-	IsSystem            bool             `json:"isSystem,omitempty"`
-	IsVolatile          bool             `json:"isVolatile,omitempty"`
-	JournalSize         int64            `json:"journalSize,omitempty"`
-	KeyOptions          struct {
-		Type          string `json:"type,omitempty"`
+	// Available from 3.7 ArangoD version.
+	CacheEnabled         bool   `json:"cacheEnabled,omitempty"`
+	Deleted              bool   `json:"deleted,omitempty"`
+	DistributeShardsLike string `json:"distributeShardsLike,omitempty"`
+	// Deprecated since 3.7 version. It is related only to MMFiles.
+	DoCompact bool `json:"doCompact,omitempty"`
+	// Available from 3.7 ArangoD version.
+	GloballyUniqueId string `json:"globallyUniqueId,omitempty"`
+	ID               string `json:"id,omitempty"`
+	// Deprecated since 3.7 version. It is related only to MMFiles.
+	IndexBuckets int              `json:"indexBuckets,omitempty"`
+	Indexes      []InventoryIndex `json:"indexes,omitempty"`
+	// Available from 3.7 ArangoD version.
+	IsDisjoint bool `json:"isDisjoint,omitempty"`
+	IsSmart    bool `json:"isSmart,omitempty"`
+	// Available from 3.7 ArangoD version.
+	IsSmartChild bool `json:"isSmartChild,omitempty"`
+	IsSystem     bool `json:"isSystem,omitempty"`
+	// Deprecated since 3.7 version. It is related only to MMFiles.
+	IsVolatile bool `json:"isVolatile,omitempty"`
+	// Deprecated since 3.7 version. It is related only to MMFiles.
+	JournalSize int64 `json:"journalSize,omitempty"`
+	KeyOptions  struct {
 		AllowUserKeys bool   `json:"allowUserKeys,omitempty"`
 		LastValue     int64  `json:"lastValue,omitempty"`
+		Type          string `json:"type,omitempty"`
 	} `json:"keyOptions"`
-	Name              string `json:"name,omitempty"`
-	NumberOfShards    int    `json:"numberOfShards,omitempty"`
-	Path              string `json:"path,omitempty"`
-	PlanID            string `json:"planId,omitempty"`
-	ReplicationFactor int    `json:"replicationFactor,omitempty"`
-	// Deprecated: use 'WriteConcern' instead
-	MinReplicationFactor int `json:"minReplicationFactor,omitempty"`
-	// Available from 3.6 arangod version.
-	WriteConcern         int                    `json:"writeConcern,omitempty"`
-	ShardKeys            []string               `json:"shardKeys,omitempty"`
-	Shards               map[ShardID][]ServerID `json:"shards,omitempty"`
-	Status               CollectionStatus       `json:"status,omitempty"`
-	Type                 CollectionType         `json:"type,omitempty"`
-	WaitForSync          bool                   `json:"waitForSync,omitempty"`
-	DistributeShardsLike string                 `json:"distributeShardsLike,omitempty"`
-	SmartJoinAttribute   string                 `json:"smartJoinAttribute,omitempty"`
-	ShardingStrategy     ShardingStrategy       `json:"shardingStrategy,omitempty"`
-	// Available from 3.7 arangod version
+	// Deprecated: use 'WriteConcern' instead.
+	MinReplicationFactor int    `json:"minReplicationFactor,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	NumberOfShards       int    `json:"numberOfShards,omitempty"`
+	// Deprecated since 3.7 ArangoD version.
+	Path              string                 `json:"path,omitempty"`
+	PlanID            string                 `json:"planId,omitempty"`
+	ReplicationFactor int                    `json:"replicationFactor,omitempty"`
+	ShardingStrategy  ShardingStrategy       `json:"shardingStrategy,omitempty"`
+	ShardKeys         []string               `json:"shardKeys,omitempty"`
+	Shards            map[ShardID][]ServerID `json:"shards,omitempty"`
+	// Optional only for some collections.
+	SmartGraphAttribute string `json:"smartGraphAttribute,omitempty"`
+	// Optional only for some collections.
+	SmartJoinAttribute string           `json:"smartJoinAttribute,omitempty"`
+	Status             CollectionStatus `json:"status,omitempty"`
+	// Available from 3.7 ArangoD version.
+	SyncByRevision bool           `json:"syncByRevision,omitempty"`
+	Type           CollectionType `json:"type,omitempty"`
+	// Available from 3.7 ArangoD version.
 	UsesRevisionsAsDocumentIds bool `json:"usesRevisionsAsDocumentIds,omitempty"`
-	// Available from 3.7 arangod version
-	SyncByRevision bool `json:"syncByRevision,omitempty"`
+	WaitForSync                bool `json:"waitForSync,omitempty"`
+	// Available from 3.6 ArangoD version.
+	WriteConcern int `json:"writeConcern,omitempty"`
 }
 
 // IsSatellite returns true if the collection is a satellite collection

--- a/cluster_impl.go
+++ b/cluster_impl.go
@@ -276,6 +276,8 @@ type inventoryCollectionParametersInternal struct {
 	ID               string           `json:"id,omitempty"`
 	IndexBuckets     int              `json:"indexBuckets,omitempty"`
 	Indexes          []InventoryIndex `json:"indexes,omitempty"`
+	// Available from 3.9 ArangoD version.
+	InternalValidatorType int `json:"internalValidatorType,omitempty"`
 	// Available from 3.7 ArangoD version.
 	IsDisjoint bool `json:"isDisjoint,omitempty"`
 	IsSmart    bool `json:"isSmart,omitempty"`
@@ -292,15 +294,18 @@ type inventoryCollectionParametersInternal struct {
 		Type          string `json:"type,omitempty"`
 	} `json:"keyOptions"`
 	// Deprecated: use 'WriteConcern' instead
-	MinReplicationFactor int                    `json:"minReplicationFactor,omitempty"`
-	Name                 string                 `json:"name,omitempty"`
-	NumberOfShards       int                    `json:"numberOfShards,omitempty"`
-	Path                 string                 `json:"path,omitempty"`
-	PlanID               string                 `json:"planId,omitempty"`
-	ReplicationFactor    replicationFactor      `json:"replicationFactor,omitempty"`
-	ShardingStrategy     ShardingStrategy       `json:"shardingStrategy,omitempty"`
-	ShardKeys            []string               `json:"shardKeys,omitempty"`
-	Shards               map[ShardID][]ServerID `json:"shards,omitempty"`
+	MinReplicationFactor int               `json:"minReplicationFactor,omitempty"`
+	Name                 string            `json:"name,omitempty"`
+	NumberOfShards       int               `json:"numberOfShards,omitempty"`
+	Path                 string            `json:"path,omitempty"`
+	PlanID               string            `json:"planId,omitempty"`
+	ReplicationFactor    replicationFactor `json:"replicationFactor,omitempty"`
+	// Schema for collection validation
+	Schema            *CollectionSchemaOptions `json:"schema,omitempty"`
+	ShadowCollections []int                    `json:"shadowCollections,omitempty"`
+	ShardingStrategy  ShardingStrategy         `json:"shardingStrategy,omitempty"`
+	ShardKeys         []string                 `json:"shardKeys,omitempty"`
+	Shards            map[ShardID][]ServerID   `json:"shards,omitempty"`
 	// Optional only for some collections.
 	SmartGraphAttribute string `json:"smartGraphAttribute,omitempty"`
 	// Optional only for some collections.
@@ -326,6 +331,7 @@ func (p *InventoryCollectionParameters) asInternal() inventoryCollectionParamete
 		ID:                         p.ID,
 		IndexBuckets:               p.IndexBuckets,
 		Indexes:                    p.Indexes,
+		InternalValidatorType:      p.InternalValidatorType,
 		IsDisjoint:                 p.IsDisjoint,
 		IsSmart:                    p.IsSmart,
 		IsSmartChild:               p.IsSmartChild,
@@ -339,6 +345,8 @@ func (p *InventoryCollectionParameters) asInternal() inventoryCollectionParamete
 		Path:                       p.Path,
 		PlanID:                     p.PlanID,
 		ReplicationFactor:          replicationFactor(p.ReplicationFactor),
+		Schema:                     p.Schema,
+		ShadowCollections:          p.ShadowCollections,
 		ShardingStrategy:           p.ShardingStrategy,
 		ShardKeys:                  p.ShardKeys,
 		Shards:                     p.Shards,
@@ -367,6 +375,7 @@ func (p *inventoryCollectionParametersInternal) asExternal() InventoryCollection
 		ID:                         p.ID,
 		IndexBuckets:               p.IndexBuckets,
 		Indexes:                    p.Indexes,
+		InternalValidatorType:      p.InternalValidatorType,
 		IsDisjoint:                 p.IsDisjoint,
 		IsSmart:                    p.IsSmart,
 		IsSmartChild:               p.IsSmartChild,
@@ -380,6 +389,8 @@ func (p *inventoryCollectionParametersInternal) asExternal() InventoryCollection
 		Path:                       p.Path,
 		PlanID:                     p.PlanID,
 		ReplicationFactor:          int(p.ReplicationFactor),
+		Schema:                     p.Schema,
+		ShadowCollections:          p.ShadowCollections,
 		ShardingStrategy:           p.ShardingStrategy,
 		ShardKeys:                  p.ShardKeys,
 		Shards:                     p.Shards,

--- a/cluster_impl.go
+++ b/cluster_impl.go
@@ -284,9 +284,9 @@ type inventoryCollectionParametersInternal struct {
 	// Available from 3.7 ArangoD version.
 	IsSmartChild bool `json:"isSmartChild,omitempty"`
 	IsSystem     bool `json:"isSystem,omitempty"`
-	// Deprecated since 3.7 version. It is related only to MMFiles.
+	// Deprecated: since 3.7 version. It is related only to MMFiles.
 	IsVolatile bool `json:"isVolatile,omitempty"`
-	// Deprecated since 3.7 version. It is related only to MMFiles.
+	// Deprecated: since 3.7 version. It is related only to MMFiles.
 	JournalSize int64 `json:"journalSize,omitempty"`
 	KeyOptions  struct {
 		AllowUserKeys bool   `json:"allowUserKeys,omitempty"`
@@ -311,13 +311,13 @@ type inventoryCollectionParametersInternal struct {
 	// Optional only for some collections.
 	SmartJoinAttribute string           `json:"smartJoinAttribute,omitempty"`
 	Status             CollectionStatus `json:"status,omitempty"`
-	// Available from 3.7 arangod version
+	// Available from 3.7 ArangoD version
 	SyncByRevision bool           `json:"syncByRevision,omitempty"`
 	Type           CollectionType `json:"type,omitempty"`
-	// Available from 3.7 arangod version
+	// Available from 3.7 ArangoD version
 	UsesRevisionsAsDocumentIds bool `json:"usesRevisionsAsDocumentIds,omitempty"`
 	WaitForSync                bool `json:"waitForSync,omitempty"`
-	// Available from 3.6 arangod version.
+	// Available from 3.6 ArangoD version.
 	WriteConcern int `json:"writeConcern,omitempty"`
 }
 

--- a/cluster_impl.go
+++ b/cluster_impl.go
@@ -266,74 +266,90 @@ func (c *cluster) RemoveServer(ctx context.Context, serverID ServerID) error {
 type replicationFactor int
 
 type inventoryCollectionParametersInternal struct {
-	Deleted             bool             `json:"deleted,omitempty"`
-	DoCompact           bool             `json:"doCompact,omitempty"`
-	ID                  string           `json:"id,omitempty"`
-	IndexBuckets        int              `json:"indexBuckets,omitempty"`
-	Indexes             []InventoryIndex `json:"indexes,omitempty"`
-	IsSmart             bool             `json:"isSmart,omitempty"`
-	SmartGraphAttribute string           `json:"smartGraphAttribute,omitempty"`
-	IsSystem            bool             `json:"isSystem,omitempty"`
-	IsVolatile          bool             `json:"isVolatile,omitempty"`
-	JournalSize         int64            `json:"journalSize,omitempty"`
-	KeyOptions          struct {
-		Type          string `json:"type,omitempty"`
+	// Available from 3.7 ArangoD version.
+	CacheEnabled         bool   `json:"cacheEnabled,omitempty"`
+	Deleted              bool   `json:"deleted,omitempty"`
+	DistributeShardsLike string `json:"distributeShardsLike,omitempty"`
+	DoCompact            bool   `json:"doCompact,omitempty"`
+	// Available from 3.7 ArangoD version.
+	GloballyUniqueId string           `json:"globallyUniqueId,omitempty"`
+	ID               string           `json:"id,omitempty"`
+	IndexBuckets     int              `json:"indexBuckets,omitempty"`
+	Indexes          []InventoryIndex `json:"indexes,omitempty"`
+	// Available from 3.7 ArangoD version.
+	IsDisjoint bool `json:"isDisjoint,omitempty"`
+	IsSmart    bool `json:"isSmart,omitempty"`
+	// Available from 3.7 ArangoD version.
+	IsSmartChild bool `json:"isSmartChild,omitempty"`
+	IsSystem     bool `json:"isSystem,omitempty"`
+	// Deprecated since 3.7 version. It is related only to MMFiles.
+	IsVolatile bool `json:"isVolatile,omitempty"`
+	// Deprecated since 3.7 version. It is related only to MMFiles.
+	JournalSize int64 `json:"journalSize,omitempty"`
+	KeyOptions  struct {
 		AllowUserKeys bool   `json:"allowUserKeys,omitempty"`
 		LastValue     int64  `json:"lastValue,omitempty"`
+		Type          string `json:"type,omitempty"`
 	} `json:"keyOptions"`
-	Name              string            `json:"name,omitempty"`
-	NumberOfShards    int               `json:"numberOfShards,omitempty"`
-	Path              string            `json:"path,omitempty"`
-	PlanID            string            `json:"planId,omitempty"`
-	ReplicationFactor replicationFactor `json:"replicationFactor,omitempty"`
 	// Deprecated: use 'WriteConcern' instead
-	MinReplicationFactor int `json:"minReplicationFactor,omitempty"`
-	// Available from 3.6 arangod version.
-	WriteConcern         int                    `json:"writeConcern,omitempty"`
+	MinReplicationFactor int                    `json:"minReplicationFactor,omitempty"`
+	Name                 string                 `json:"name,omitempty"`
+	NumberOfShards       int                    `json:"numberOfShards,omitempty"`
+	Path                 string                 `json:"path,omitempty"`
+	PlanID               string                 `json:"planId,omitempty"`
+	ReplicationFactor    replicationFactor      `json:"replicationFactor,omitempty"`
+	ShardingStrategy     ShardingStrategy       `json:"shardingStrategy,omitempty"`
 	ShardKeys            []string               `json:"shardKeys,omitempty"`
 	Shards               map[ShardID][]ServerID `json:"shards,omitempty"`
-	Status               CollectionStatus       `json:"status,omitempty"`
-	Type                 CollectionType         `json:"type,omitempty"`
-	WaitForSync          bool                   `json:"waitForSync,omitempty"`
-	DistributeShardsLike string                 `json:"distributeShardsLike,omitempty"`
-	SmartJoinAttribute   string                 `json:"smartJoinAttribute,omitempty"`
-	ShardingStrategy     ShardingStrategy       `json:"shardingStrategy,omitempty"`
+	// Optional only for some collections.
+	SmartGraphAttribute string `json:"smartGraphAttribute,omitempty"`
+	// Optional only for some collections.
+	SmartJoinAttribute string           `json:"smartJoinAttribute,omitempty"`
+	Status             CollectionStatus `json:"status,omitempty"`
+	// Available from 3.7 arangod version
+	SyncByRevision bool           `json:"syncByRevision,omitempty"`
+	Type           CollectionType `json:"type,omitempty"`
 	// Available from 3.7 arangod version
 	UsesRevisionsAsDocumentIds bool `json:"usesRevisionsAsDocumentIds,omitempty"`
-	// Available from 3.7 arangod version
-	SyncByRevision bool `json:"syncByRevision,omitempty"`
+	WaitForSync                bool `json:"waitForSync,omitempty"`
+	// Available from 3.6 arangod version.
+	WriteConcern int `json:"writeConcern,omitempty"`
 }
 
 func (p *InventoryCollectionParameters) asInternal() inventoryCollectionParametersInternal {
 	return inventoryCollectionParametersInternal{
+		CacheEnabled:               p.CacheEnabled,
 		Deleted:                    p.Deleted,
+		DistributeShardsLike:       p.DistributeShardsLike,
 		DoCompact:                  p.DoCompact,
+		GloballyUniqueId:           p.GloballyUniqueId,
 		ID:                         p.ID,
 		IndexBuckets:               p.IndexBuckets,
 		Indexes:                    p.Indexes,
+		IsDisjoint:                 p.IsDisjoint,
 		IsSmart:                    p.IsSmart,
-		SmartGraphAttribute:        p.SmartGraphAttribute,
+		IsSmartChild:               p.IsSmartChild,
 		IsSystem:                   p.IsSystem,
 		IsVolatile:                 p.IsVolatile,
 		JournalSize:                p.JournalSize,
 		KeyOptions:                 p.KeyOptions,
+		MinReplicationFactor:       p.MinReplicationFactor,
 		Name:                       p.Name,
 		NumberOfShards:             p.NumberOfShards,
 		Path:                       p.Path,
 		PlanID:                     p.PlanID,
 		ReplicationFactor:          replicationFactor(p.ReplicationFactor),
-		MinReplicationFactor:       p.MinReplicationFactor,
-		WriteConcern:               p.WriteConcern,
+		ShardingStrategy:           p.ShardingStrategy,
 		ShardKeys:                  p.ShardKeys,
 		Shards:                     p.Shards,
-		Status:                     p.Status,
-		Type:                       p.Type,
-		WaitForSync:                p.WaitForSync,
-		DistributeShardsLike:       p.DistributeShardsLike,
+		SmartGraphAttribute:        p.SmartGraphAttribute,
 		SmartJoinAttribute:         p.SmartJoinAttribute,
-		ShardingStrategy:           p.ShardingStrategy,
-		UsesRevisionsAsDocumentIds: p.UsesRevisionsAsDocumentIds,
+		Status:                     p.Status,
 		SyncByRevision:             p.SyncByRevision,
+		Type:                       p.Type,
+		UsesRevisionsAsDocumentIds: p.UsesRevisionsAsDocumentIds,
+		WaitForSync:                p.WaitForSync,
+		WriteConcern:               p.WriteConcern,
 	}
 }
 
@@ -343,34 +359,38 @@ func (p *InventoryCollectionParameters) fromInternal(i inventoryCollectionParame
 
 func (p *inventoryCollectionParametersInternal) asExternal() InventoryCollectionParameters {
 	return InventoryCollectionParameters{
+		CacheEnabled:               p.CacheEnabled,
 		Deleted:                    p.Deleted,
+		DistributeShardsLike:       p.DistributeShardsLike,
 		DoCompact:                  p.DoCompact,
+		GloballyUniqueId:           p.GloballyUniqueId,
 		ID:                         p.ID,
 		IndexBuckets:               p.IndexBuckets,
 		Indexes:                    p.Indexes,
+		IsDisjoint:                 p.IsDisjoint,
 		IsSmart:                    p.IsSmart,
-		SmartGraphAttribute:        p.SmartGraphAttribute,
+		IsSmartChild:               p.IsSmartChild,
 		IsSystem:                   p.IsSystem,
 		IsVolatile:                 p.IsVolatile,
 		JournalSize:                p.JournalSize,
 		KeyOptions:                 p.KeyOptions,
+		MinReplicationFactor:       p.MinReplicationFactor,
 		Name:                       p.Name,
 		NumberOfShards:             p.NumberOfShards,
 		Path:                       p.Path,
 		PlanID:                     p.PlanID,
 		ReplicationFactor:          int(p.ReplicationFactor),
-		MinReplicationFactor:       p.MinReplicationFactor,
-		WriteConcern:               p.WriteConcern,
+		ShardingStrategy:           p.ShardingStrategy,
 		ShardKeys:                  p.ShardKeys,
 		Shards:                     p.Shards,
-		Status:                     p.Status,
-		Type:                       p.Type,
-		WaitForSync:                p.WaitForSync,
-		DistributeShardsLike:       p.DistributeShardsLike,
+		SmartGraphAttribute:        p.SmartGraphAttribute,
 		SmartJoinAttribute:         p.SmartJoinAttribute,
-		ShardingStrategy:           p.ShardingStrategy,
-		UsesRevisionsAsDocumentIds: p.UsesRevisionsAsDocumentIds,
+		Status:                     p.Status,
 		SyncByRevision:             p.SyncByRevision,
+		Type:                       p.Type,
+		UsesRevisionsAsDocumentIds: p.UsesRevisionsAsDocumentIds,
+		WaitForSync:                p.WaitForSync,
+		WriteConcern:               p.WriteConcern,
 	}
 }
 

--- a/database_collections.go
+++ b/database_collections.go
@@ -80,6 +80,8 @@ type CreateCollectionOptions struct {
 	ShardKeys []string `json:"shardKeys,omitempty"`
 	// In a cluster, this value determines the number of shards to create for the collection. In a single server setup, this option is meaningless. (default is 1)
 	NumberOfShards int `json:"numberOfShards,omitempty"`
+	// IsDisjoint set isDisjoint flag for Graph. Required ArangoDB 3.7+
+	IsDisjoint bool `json:"isDisjoint,omitempty"`
 	// If true, create a system collection. In this case collection-name should start with an underscore.
 	// End users should normally create non-system collections only. API implementors may be required to create system
 	// collections in very special occasions, but normally a regular collection will do. (The default is false)

--- a/database_collections.go
+++ b/database_collections.go
@@ -56,8 +56,6 @@ type CreateCollectionOptions struct {
 	// Currently, only the edge index respects this value, but other index types might follow in future ArangoDB versions.
 	// Changes are applied when the collection is loaded the next time.
 	IndexBuckets int `json:"indexBuckets,omitempty"`
-	// The indices of the collection.
-	Indexes []InventoryIndex `json:"indexes,omitempty"`
 	// Available from 3.9 ArangoD version.
 	InternalValidatorType int `json:"internalValidatorType,omitempty"`
 	// IsDisjoint set isDisjoint flag for Graph. Required ArangoDB 3.7+
@@ -65,8 +63,6 @@ type CreateCollectionOptions struct {
 	// Set to create a smart edge or vertex collection.
 	// This requires ArangoDB Enterprise Edition.
 	IsSmart bool `json:"isSmart,omitempty"`
-	// Available from 3.7 ArangoD version.
-	IsSmartChild bool `json:"isSmartChild,omitempty"`
 	// If true, create a system collection. In this case collection-name should start with an underscore.
 	// End users should normally create non-system collections only. API implementors may be required to create system
 	// collections in very special occasions, but normally a regular collection will do. (The default is false)
@@ -118,8 +114,6 @@ type CreateCollectionOptions struct {
 	SyncByRevision bool `json:"syncByRevision,omitempty"`
 	// The type of the collection to create. (default is CollectionTypeDocument)
 	Type CollectionType `json:"type,omitempty"`
-	// Available from 3.7 ArangoDB version
-	UsesRevisionsAsDocumentIds bool `json:"usesRevisionsAsDocumentIds,omitempty"`
 	// If true then the data is synchronized to disk before returning from a document create, update, replace or removal operation. (default: false)
 	WaitForSync bool `json:"waitForSync,omitempty"`
 	// WriteConcern contains how many copies must be available before a collection can be written.

--- a/database_collections.go
+++ b/database_collections.go
@@ -43,51 +43,12 @@ type DatabaseCollections interface {
 
 // CreateCollectionOptions contains options that customize the creating of a collection.
 type CreateCollectionOptions struct {
-	// The maximal size of a journal or datafile in bytes. The value must be at least 1048576 (1 MiB). (The default is a configuration parameter)
-	JournalSize int `json:"journalSize,omitempty"`
-	// ReplicationFactor in a cluster (default is 1), this attribute determines how many copies of each shard are kept on different DBServers.
-	// The value 1 means that only one copy (no synchronous replication) is kept.
-	// A value of k means that k-1 replicas are kept. Any two copies reside on different DBServers.
-	// Replication between them is synchronous, that is, every write operation to the "leader" copy will be replicated to all "follower" replicas,
-	// before the write operation is reported successful. If a server fails, this is detected automatically
-	// and one of the servers holding copies take over, usually without an error being reported.
-	ReplicationFactor int `json:"replicationFactor,omitempty"`
-	// Deprecated: use 'WriteConcern' instead
-	MinReplicationFactor int `json:"minReplicationFactor,omitempty"`
-	// WriteConcern contains how many copies must be available before a collection can be written.
-	// It is required that 1 <= WriteConcern <= ReplicationFactor.
-	// Default is 1. Not available for satellite collections.
-	// Available from 3.6 arangod version.
-	WriteConcern int `json:"writeConcern,omitempty"`
-	// If true then the data is synchronized to disk before returning from a document create, update, replace or removal operation. (default: false)
-	WaitForSync bool `json:"waitForSync,omitempty"`
-	// Whether or not the collection will be compacted (default is true)
-	DoCompact *bool `json:"doCompact,omitempty"`
 	// CacheEnabled set cacheEnabled option in collection properties
 	CacheEnabled *bool `json:"cacheEnabled,omitempty"`
-	// If true then the collection data is kept in-memory only and not made persistent.
-	// Unloading the collection will cause the collection data to be discarded. Stopping or re-starting the server will also
-	// cause full loss of data in the collection. Setting this option will make the resulting collection be slightly faster
-	// than regular collections because ArangoDB does not enforce any synchronization to disk and does not calculate any
-	// CRC checksums for datafiles (as there are no datafiles). This option should therefore be used for cache-type collections only,
-	// and not for data that cannot be re-created otherwise. (The default is false)
-	IsVolatile bool `json:"isVolatile,omitempty"`
-	// In a cluster, this attribute determines which document attributes are used to
-	// determine the target shard for documents. Documents are sent to shards based on the values of their shard key attributes.
-	// The values of all shard key attributes in a document are hashed, and the hash value is used to determine the target shard.
-	// Note: Values of shard key attributes cannot be changed once set. This option is meaningless in a single server setup.
-	// The default is []string{"_key"}.
-	ShardKeys []string `json:"shardKeys,omitempty"`
-	// In a cluster, this value determines the number of shards to create for the collection. In a single server setup, this option is meaningless. (default is 1)
-	NumberOfShards int `json:"numberOfShards,omitempty"`
-	// IsDisjoint set isDisjoint flag for Graph. Required ArangoDB 3.7+
-	IsDisjoint bool `json:"isDisjoint,omitempty"`
-	// If true, create a system collection. In this case collection-name should start with an underscore.
-	// End users should normally create non-system collections only. API implementors may be required to create system
-	// collections in very special occasions, but normally a regular collection will do. (The default is false)
-	IsSystem bool `json:"isSystem,omitempty"`
-	// The type of the collection to create. (default is CollectionTypeDocument)
-	Type CollectionType `json:"type,omitempty"`
+	// This field is used for internal purposes only. DO NOT USE.
+	DistributeShardsLike string `json:"distributeShardsLike,omitempty"`
+	// DoCompact checks if the collection will be compacted (default is true)
+	DoCompact *bool `json:"doCompact,omitempty"`
 	// The number of buckets into which indexes using a hash table are split. The default is 16 and this number has to be a power
 	// of 2 and less than or equal to 1024. For very large collections one should increase this to avoid long pauses when the hash
 	// table has to be initially built or resized, since buckets are resized individually and can be initially built in parallel.
@@ -95,13 +56,54 @@ type CreateCollectionOptions struct {
 	// Currently, only the edge index respects this value, but other index types might follow in future ArangoDB versions.
 	// Changes are applied when the collection is loaded the next time.
 	IndexBuckets int `json:"indexBuckets,omitempty"`
-	// Specifies how keys in the collection are created.
-	KeyOptions *CollectionKeyOptions `json:"keyOptions,omitempty"`
-	// This field is used for internal purposes only. DO NOT USE.
-	DistributeShardsLike string `json:"distributeShardsLike,omitempty"`
+	// The indices of the collection.
+	Indexes []InventoryIndex `json:"indexes,omitempty"`
+	// Available from 3.9 ArangoD version.
+	InternalValidatorType int `json:"internalValidatorType,omitempty"`
+	// IsDisjoint set isDisjoint flag for Graph. Required ArangoDB 3.7+
+	IsDisjoint bool `json:"isDisjoint,omitempty"`
 	// Set to create a smart edge or vertex collection.
 	// This requires ArangoDB Enterprise Edition.
 	IsSmart bool `json:"isSmart,omitempty"`
+	// Available from 3.7 ArangoD version.
+	IsSmartChild bool `json:"isSmartChild,omitempty"`
+	// If true, create a system collection. In this case collection-name should start with an underscore.
+	// End users should normally create non-system collections only. API implementors may be required to create system
+	// collections in very special occasions, but normally a regular collection will do. (The default is false)
+	IsSystem bool `json:"isSystem,omitempty"`
+	// If true then the collection data is kept in-memory only and not made persistent.
+	// Unloading the collection will cause the collection data to be discarded. Stopping or re-starting the server will also
+	// cause full loss of data in the collection. Setting this option will make the resulting collection be slightly faster
+	// than regular collections because ArangoDB does not enforce any synchronization to disk and does not calculate any
+	// CRC checksums for datafiles (as there are no datafiles). This option should therefore be used for cache-type collections only,
+	// and not for data that cannot be re-created otherwise. (The default is false)
+	IsVolatile bool `json:"isVolatile,omitempty"`
+	// The maximal size of a journal or datafile in bytes. The value must be at least 1048576 (1 MiB). (The default is a configuration parameter)
+	JournalSize int `json:"journalSize,omitempty"`
+	// Specifies how keys in the collection are created.
+	KeyOptions *CollectionKeyOptions `json:"keyOptions,omitempty"`
+	// Deprecated: use 'WriteConcern' instead
+	MinReplicationFactor int `json:"minReplicationFactor,omitempty"`
+	// In a cluster, this value determines the number of shards to create for the collection. In a single server setup, this option is meaningless. (default is 1)
+	NumberOfShards int `json:"numberOfShards,omitempty"`
+	// ReplicationFactor in a cluster (default is 1), this attribute determines how many copies of each shard are kept on different DBServers.
+	// The value 1 means that only one copy (no synchronous replication) is kept.
+	// A value of k means that k-1 replicas are kept. Any two copies reside on different DBServers.
+	// Replication between them is synchronous, that is, every write operation to the "leader" copy will be replicated to all "follower" replicas,
+	// before the write operation is reported successful. If a server fails, this is detected automatically
+	// and one of the servers holding copies take over, usually without an error being reported.
+	ReplicationFactor int `json:"replicationFactor,omitempty"`
+	// Schema for collection validation
+	Schema *CollectionSchemaOptions `json:"schema,omitempty"`
+	// This attribute specifies the name of the sharding strategy to use for the collection.
+	// Must be one of ShardingStrategy* values.
+	ShardingStrategy ShardingStrategy `json:"shardingStrategy,omitempty"`
+	// In a cluster, this attribute determines which document attributes are used to
+	// determine the target shard for documents. Documents are sent to shards based on the values of their shard key attributes.
+	// The values of all shard key attributes in a document are hashed, and the hash value is used to determine the target shard.
+	// Note: Values of shard key attributes cannot be changed once set. This option is meaningless in a single server setup.
+	// The default is []string{"_key"}.
+	ShardKeys []string `json:"shardKeys,omitempty"`
 	// This field must be set to the attribute that will be used for sharding or smart graphs.
 	// All vertices are required to have this attribute set. Edges derive the attribute from their connected vertices.
 	// This requires ArangoDB Enterprise Edition.
@@ -112,11 +114,19 @@ type CreateCollectionOptions struct {
 	// See documentation for smart joins.
 	// This requires ArangoDB Enterprise Edition.
 	SmartJoinAttribute string `json:"smartJoinAttribute,omitempty"`
-	// This attribute specifies the name of the sharding strategy to use for the collection.
-	// Must be one of ShardingStrategy* values.
-	ShardingStrategy ShardingStrategy `json:"shardingStrategy,omitempty"`
-	// Schema for collection validation
-	Schema *CollectionSchemaOptions `json:"schema,omitempty"`
+	// Available from 3.7 ArangoDB version
+	SyncByRevision bool `json:"syncByRevision,omitempty"`
+	// The type of the collection to create. (default is CollectionTypeDocument)
+	Type CollectionType `json:"type,omitempty"`
+	// Available from 3.7 ArangoDB version
+	UsesRevisionsAsDocumentIds bool `json:"usesRevisionsAsDocumentIds,omitempty"`
+	// If true then the data is synchronized to disk before returning from a document create, update, replace or removal operation. (default: false)
+	WaitForSync bool `json:"waitForSync,omitempty"`
+	// WriteConcern contains how many copies must be available before a collection can be written.
+	// It is required that 1 <= WriteConcern <= ReplicationFactor.
+	// Default is 1. Not available for satellite collections.
+	// Available from 3.6 ArangoDB version.
+	WriteConcern int `json:"writeConcern,omitempty"`
 }
 
 // Init translate deprecated fields into current one for backward compatibility

--- a/database_collections_impl.go
+++ b/database_collections_impl.go
@@ -110,6 +110,7 @@ type createCollectionOptionsInternal struct {
 	WriteConcern         int                      `json:"writeConcern,omitempty"`
 	WaitForSync          bool                     `json:"waitForSync,omitempty"`
 	DoCompact            *bool                    `json:"doCompact,omitempty"`
+	IsDisjoint           bool                     `json:"isDisjoint,omitempty"`
 	IsVolatile           bool                     `json:"isVolatile,omitempty"`
 	ShardKeys            []string                 `json:"shardKeys,omitempty"`
 	NumberOfShards       int                      `json:"numberOfShards,omitempty"`
@@ -180,6 +181,7 @@ func (d *database) CreateCollection(ctx context.Context, name string, options *C
 func (p *createCollectionOptionsInternal) fromExternal(i *CreateCollectionOptions) {
 	p.JournalSize = i.JournalSize
 	p.CacheEnabled = i.CacheEnabled
+	p.IsDisjoint = i.IsDisjoint
 	p.ReplicationFactor = replicationFactor(i.ReplicationFactor)
 	p.MinReplicationFactor = i.MinReplicationFactor
 	p.WriteConcern = i.WriteConcern

--- a/database_collections_impl.go
+++ b/database_collections_impl.go
@@ -102,29 +102,33 @@ func (d *database) Collections(ctx context.Context) ([]Collection, error) {
 }
 
 type createCollectionOptionsInternal struct {
-	JournalSize       int               `json:"journalSize,omitempty"`
-	ReplicationFactor replicationFactor `json:"replicationFactor,omitempty"`
-	CacheEnabled      *bool             `json:"cacheEnabled,omitempty"`
+	CacheEnabled          *bool                 `json:"cacheEnabled,omitempty"`
+	DistributeShardsLike  string                `json:"distributeShardsLike,omitempty"`
+	DoCompact             *bool                 `json:"doCompact,omitempty"`
+	IndexBuckets          int                   `json:"indexBuckets,omitempty"`
+	Indexes               []InventoryIndex      `json:"indexes,omitempty"`
+	InternalValidatorType int                   `json:"internalValidatorType,omitempty"`
+	IsDisjoint            bool                  `json:"isDisjoint,omitempty"`
+	IsSmart               bool                  `json:"isSmart,omitempty"`
+	IsSmartChild          bool                  `json:"isSmartChild,omitempty"`
+	IsSystem              bool                  `json:"isSystem,omitempty"`
+	IsVolatile            bool                  `json:"isVolatile,omitempty"`
+	JournalSize           int                   `json:"journalSize,omitempty"`
+	KeyOptions            *CollectionKeyOptions `json:"keyOptions,omitempty"`
 	// Deprecated: use 'WriteConcern' instead
 	MinReplicationFactor int                      `json:"minReplicationFactor,omitempty"`
-	WriteConcern         int                      `json:"writeConcern,omitempty"`
-	WaitForSync          bool                     `json:"waitForSync,omitempty"`
-	DoCompact            *bool                    `json:"doCompact,omitempty"`
-	IsDisjoint           bool                     `json:"isDisjoint,omitempty"`
-	IsVolatile           bool                     `json:"isVolatile,omitempty"`
-	ShardKeys            []string                 `json:"shardKeys,omitempty"`
-	NumberOfShards       int                      `json:"numberOfShards,omitempty"`
-	IsSystem             bool                     `json:"isSystem,omitempty"`
-	Type                 CollectionType           `json:"type,omitempty"`
-	IndexBuckets         int                      `json:"indexBuckets,omitempty"`
-	KeyOptions           *CollectionKeyOptions    `json:"keyOptions,omitempty"`
-	DistributeShardsLike string                   `json:"distributeShardsLike,omitempty"`
-	IsSmart              bool                     `json:"isSmart,omitempty"`
-	SmartGraphAttribute  string                   `json:"smartGraphAttribute,omitempty"`
 	Name                 string                   `json:"name"`
-	SmartJoinAttribute   string                   `json:"smartJoinAttribute,omitempty"`
-	ShardingStrategy     ShardingStrategy         `json:"shardingStrategy,omitempty"`
+	NumberOfShards       int                      `json:"numberOfShards,omitempty"`
+	ReplicationFactor    replicationFactor        `json:"replicationFactor,omitempty"`
 	Schema               *CollectionSchemaOptions `json:"schema,omitempty"`
+	ShardingStrategy     ShardingStrategy         `json:"shardingStrategy,omitempty"`
+	ShardKeys            []string                 `json:"shardKeys,omitempty"`
+	SmartGraphAttribute  string                   `json:"smartGraphAttribute,omitempty"`
+	SmartJoinAttribute   string                   `json:"smartJoinAttribute,omitempty"`
+	SyncByRevision       bool                     `json:"syncByRevision,omitempty"`
+	Type                 CollectionType           `json:"type,omitempty"`
+	WaitForSync          bool                     `json:"waitForSync,omitempty"`
+	WriteConcern         int                      `json:"writeConcern,omitempty"`
 }
 
 // CreateCollection creates a new collection with given name and options, and opens a connection to it.
@@ -179,27 +183,31 @@ func (d *database) CreateCollection(ctx context.Context, name string, options *C
 // }
 
 func (p *createCollectionOptionsInternal) fromExternal(i *CreateCollectionOptions) {
-	p.JournalSize = i.JournalSize
 	p.CacheEnabled = i.CacheEnabled
-	p.IsDisjoint = i.IsDisjoint
-	p.ReplicationFactor = replicationFactor(i.ReplicationFactor)
-	p.MinReplicationFactor = i.MinReplicationFactor
-	p.WriteConcern = i.WriteConcern
-	p.WaitForSync = i.WaitForSync
-	p.DoCompact = i.DoCompact
-	p.IsVolatile = i.IsVolatile
-	p.ShardKeys = i.ShardKeys
-	p.NumberOfShards = i.NumberOfShards
-	p.IsSystem = i.IsSystem
-	p.Type = i.Type
-	p.IndexBuckets = i.IndexBuckets
-	p.KeyOptions = i.KeyOptions
 	p.DistributeShardsLike = i.DistributeShardsLike
+	p.DoCompact = i.DoCompact
+	p.IndexBuckets = i.IndexBuckets
+	p.Indexes = i.Indexes
+	p.InternalValidatorType = i.InternalValidatorType
+	p.IsDisjoint = i.IsDisjoint
 	p.IsSmart = i.IsSmart
+	p.IsSmartChild = i.IsSmartChild
+	p.IsSystem = i.IsSystem
+	p.IsVolatile = i.IsVolatile
+	p.JournalSize = i.JournalSize
+	p.KeyOptions = i.KeyOptions
+	p.MinReplicationFactor = i.MinReplicationFactor
+	p.NumberOfShards = i.NumberOfShards
+	p.ReplicationFactor = replicationFactor(i.ReplicationFactor)
+	p.Schema = i.Schema
+	p.ShardingStrategy = i.ShardingStrategy
+	p.ShardKeys = i.ShardKeys
 	p.SmartGraphAttribute = i.SmartGraphAttribute
 	p.SmartJoinAttribute = i.SmartJoinAttribute
-	p.ShardingStrategy = i.ShardingStrategy
-	p.Schema = i.Schema
+	p.SyncByRevision = i.SyncByRevision
+	p.Type = i.Type
+	p.WaitForSync = i.WaitForSync
+	p.WriteConcern = i.WriteConcern
 }
 
 // // MarshalJSON converts CreateCollectionOptions into json

--- a/database_collections_impl.go
+++ b/database_collections_impl.go
@@ -106,11 +106,9 @@ type createCollectionOptionsInternal struct {
 	DistributeShardsLike  string                `json:"distributeShardsLike,omitempty"`
 	DoCompact             *bool                 `json:"doCompact,omitempty"`
 	IndexBuckets          int                   `json:"indexBuckets,omitempty"`
-	Indexes               []InventoryIndex      `json:"indexes,omitempty"`
 	InternalValidatorType int                   `json:"internalValidatorType,omitempty"`
 	IsDisjoint            bool                  `json:"isDisjoint,omitempty"`
 	IsSmart               bool                  `json:"isSmart,omitempty"`
-	IsSmartChild          bool                  `json:"isSmartChild,omitempty"`
 	IsSystem              bool                  `json:"isSystem,omitempty"`
 	IsVolatile            bool                  `json:"isVolatile,omitempty"`
 	JournalSize           int                   `json:"journalSize,omitempty"`
@@ -163,35 +161,14 @@ func (d *database) CreateCollection(ctx context.Context, name string, options *C
 	return col, nil
 }
 
-// func (p *CreateCollectionOptions) asInternal() createCollectionOptionsInternal {
-// 	return createCollectionOptionsInternal{
-// 		JournalSize:          p.JournalSize,
-// 		ReplicationFactor:    replicationFactor(p.ReplicationFactor),
-// 		WaitForSync:          p.WaitForSync,
-// 		DoCompact:            p.DoCompact,
-// 		IsVolatile:           p.IsVolatile,
-// 		ShardKeys:            p.ShardKeys,
-// 		NumberOfShards:       p.NumberOfShards,
-// 		IsSystem:             p.IsSystem,
-// 		Type:                 p.Type,
-// 		IndexBuckets:         p.IndexBuckets,
-// 		KeyOptions:           p.KeyOptions,
-// 		DistributeShardsLike: p.DistributeShardsLike,
-// 		IsSmart:              p.IsSmart,
-// 		SmartGraphAttribute:  p.SmartGraphAttribute,
-// 	}
-// }
-
 func (p *createCollectionOptionsInternal) fromExternal(i *CreateCollectionOptions) {
 	p.CacheEnabled = i.CacheEnabled
 	p.DistributeShardsLike = i.DistributeShardsLike
 	p.DoCompact = i.DoCompact
 	p.IndexBuckets = i.IndexBuckets
-	p.Indexes = i.Indexes
 	p.InternalValidatorType = i.InternalValidatorType
 	p.IsDisjoint = i.IsDisjoint
 	p.IsSmart = i.IsSmart
-	p.IsSmartChild = i.IsSmartChild
 	p.IsSystem = i.IsSystem
 	p.IsVolatile = i.IsVolatile
 	p.JournalSize = i.JournalSize
@@ -209,19 +186,3 @@ func (p *createCollectionOptionsInternal) fromExternal(i *CreateCollectionOption
 	p.WaitForSync = i.WaitForSync
 	p.WriteConcern = i.WriteConcern
 }
-
-// // MarshalJSON converts CreateCollectionOptions into json
-// func (p *CreateCollectionOptions) MarshalJSON() ([]byte, error) {
-// 	return json.Marshal(p.asInternal())
-// }
-
-// // UnmarshalJSON loads CreateCollectionOptions from json
-// func (p *CreateCollectionOptions) UnmarshalJSON(d []byte) error {
-// 	var internal createCollectionOptionsInternal
-// 	if err := json.Unmarshal(d, &internal); err != nil {
-// 		return err
-// 	}
-
-// 	p.fromInternal(&internal)
-// 	return nil
-// }

--- a/v2/arangodb/database_collection_opts.go
+++ b/v2/arangodb/database_collection_opts.go
@@ -24,49 +24,12 @@ package arangodb
 
 // CreateCollectionOptions contains options that customize the creating of a collection.
 type CreateCollectionOptions struct {
-	// The maximal size of a journal or datafile in bytes. The value must be at least 1048576 (1 MiB). (The default is a configuration parameter)
-	JournalSize int `json:"journalSize,omitempty"`
-	// ReplicationFactor in a cluster (default is 1), this attribute determines how many copies of each shard are kept on different DBServers.
-	// The value 1 means that only one copy (no synchronous replication) is kept.
-	// A value of k means that k-1 replicas are kept. Any two copies reside on different DBServers.
-	// Replication between them is synchronous, that is, every write operation to the "leader" copy will be replicated to all "follower" replicas,
-	// before the write operation is reported successful. If a server fails, this is detected automatically
-	// and one of the servers holding copies take over, usually without an error being reported.
-	ReplicationFactor ReplicationFactor `json:"replicationFactor,omitempty"`
-	// Deprecated: use 'WriteConcern' instead
-	MinReplicationFactor int `json:"minReplicationFactor,omitempty"`
-	// WriteConcern contains how many copies must be available before a collection can be written.
-	// It is required that 1 <= WriteConcern <= ReplicationFactor.
-	// Default is 1. Not available for satellite collections.
-	// Available from 3.6 arangod version.
-	WriteConcern int `json:"writeConcern,omitempty"`
-	// If true then the data is synchronized to disk before returning from a document create, update, replace or removal operation. (default: false)
-	WaitForSync bool `json:"waitForSync,omitempty"`
-	// Whether or not the collection will be compacted (default is true)
-	DoCompact *bool `json:"doCompact,omitempty"`
 	// CacheEnabled set cacheEnabled option in collection properties
 	CacheEnabled *bool `json:"cacheEnabled,omitempty"`
-	// If true then the collection data is kept in-memory only and not made persistent.
-	// Unloading the collection will cause the collection data to be discarded. Stopping or re-starting the server will also
-	// cause full loss of data in the collection. Setting this option will make the resulting collection be slightly faster
-	// than regular collections because ArangoDB does not enforce any synchronization to disk and does not calculate any
-	// CRC checksums for datafiles (as there are no datafiles). This option should therefore be used for cache-type collections only,
-	// and not for data that cannot be re-created otherwise. (The default is false)
-	IsVolatile bool `json:"isVolatile,omitempty"`
-	// In a cluster, this attribute determines which document attributes are used to
-	// determine the target shard for documents. Documents are sent to shards based on the values of their shard key attributes.
-	// The values of all shard key attributes in a document are hashed, and the hash value is used to determine the target shard.
-	// Note: Values of shard key attributes cannot be changed once set. This option is meaningless in a single server setup.
-	// The default is []string{"_key"}.
-	ShardKeys []string `json:"shardKeys,omitempty"`
-	// In a cluster, this value determines the number of shards to create for the collection. In a single server setup, this option is meaningless. (default is 1)
-	NumberOfShards int `json:"numberOfShards,omitempty"`
-	// If true, create a system collection. In this case collection-name should start with an underscore.
-	// End users should normally create non-system collections only. API implementors may be required to create system
-	// collections in very special occasions, but normally a regular collection will do. (The default is false)
-	IsSystem bool `json:"isSystem,omitempty"`
-	// The type of the collection to create. (default is CollectionTypeDocument)
-	Type CollectionType `json:"type,omitempty"`
+	// This field is used for internal purposes only. DO NOT USE.
+	DistributeShardsLike string `json:"distributeShardsLike,omitempty"`
+	// DoCompact checks if the collection will be compacted (default is true)
+	DoCompact *bool `json:"doCompact,omitempty"`
 	// The number of buckets into which indexes using a hash table are split. The default is 16 and this number has to be a power
 	// of 2 and less than or equal to 1024. For very large collections one should increase this to avoid long pauses when the hash
 	// table has to be initially built or resized, since buckets are resized individually and can be initially built in parallel.
@@ -74,13 +37,50 @@ type CreateCollectionOptions struct {
 	// Currently, only the edge index respects this value, but other index types might follow in future ArangoDB versions.
 	// Changes are applied when the collection is loaded the next time.
 	IndexBuckets int `json:"indexBuckets,omitempty"`
-	// Specifies how keys in the collection are created.
-	KeyOptions *CollectionKeyOptions `json:"keyOptions,omitempty"`
-	// This field is used for internal purposes only. DO NOT USE.
-	DistributeShardsLike string `json:"distributeShardsLike,omitempty"`
+	// Available from 3.9 ArangoD version.
+	InternalValidatorType int `json:"internalValidatorType,omitempty"`
+	// IsDisjoint set isDisjoint flag for Graph. Required ArangoDB 3.7+
+	IsDisjoint bool `json:"isDisjoint,omitempty"`
 	// Set to create a smart edge or vertex collection.
 	// This requires ArangoDB Enterprise Edition.
 	IsSmart bool `json:"isSmart,omitempty"`
+	// If true, create a system collection. In this case collection-name should start with an underscore.
+	// End users should normally create non-system collections only. API implementors may be required to create system
+	// collections in very special occasions, but normally a regular collection will do. (The default is false)
+	IsSystem bool `json:"isSystem,omitempty"`
+	// If true then the collection data is kept in-memory only and not made persistent.
+	// Unloading the collection will cause the collection data to be discarded. Stopping or re-starting the server will also
+	// cause full loss of data in the collection. Setting this option will make the resulting collection be slightly faster
+	// than regular collections because ArangoDB does not enforce any synchronization to disk and does not calculate any
+	// CRC checksums for datafiles (as there are no datafiles). This option should therefore be used for cache-type collections only,
+	// and not for data that cannot be re-created otherwise. (The default is false)
+	IsVolatile bool `json:"isVolatile,omitempty"`
+	// The maximal size of a journal or datafile in bytes. The value must be at least 1048576 (1 MiB). (The default is a configuration parameter)
+	JournalSize int `json:"journalSize,omitempty"`
+	// Specifies how keys in the collection are created.
+	KeyOptions *CollectionKeyOptions `json:"keyOptions,omitempty"`
+	// Deprecated: use 'WriteConcern' instead
+	MinReplicationFactor int `json:"minReplicationFactor,omitempty"`
+	// In a cluster, this value determines the number of shards to create for the collection. In a single server setup, this option is meaningless. (default is 1)
+	NumberOfShards int `json:"numberOfShards,omitempty"`
+	// ReplicationFactor in a cluster (default is 1), this attribute determines how many copies of each shard are kept on different DBServers.
+	// The value 1 means that only one copy (no synchronous replication) is kept.
+	// A value of k means that k-1 replicas are kept. Any two copies reside on different DBServers.
+	// Replication between them is synchronous, that is, every write operation to the "leader" copy will be replicated to all "follower" replicas,
+	// before the write operation is reported successful. If a server fails, this is detected automatically
+	// and one of the servers holding copies take over, usually without an error being reported.
+	ReplicationFactor ReplicationFactor `json:"replicationFactor,omitempty"`
+	// Schema for collection validation
+	Schema *CollectionSchemaOptions `json:"schema,omitempty"`
+	// This attribute specifies the name of the sharding strategy to use for the collection.
+	// Must be one of ShardingStrategy* values.
+	ShardingStrategy ShardingStrategy `json:"shardingStrategy,omitempty"`
+	// In a cluster, this attribute determines which document attributes are used to
+	// determine the target shard for documents. Documents are sent to shards based on the values of their shard key attributes.
+	// The values of all shard key attributes in a document are hashed, and the hash value is used to determine the target shard.
+	// Note: Values of shard key attributes cannot be changed once set. This option is meaningless in a single server setup.
+	// The default is []string{"_key"}.
+	ShardKeys []string `json:"shardKeys,omitempty"`
 	// This field must be set to the attribute that will be used for sharding or smart graphs.
 	// All vertices are required to have this attribute set. Edges derive the attribute from their connected vertices.
 	// This requires ArangoDB Enterprise Edition.
@@ -91,11 +91,17 @@ type CreateCollectionOptions struct {
 	// See documentation for smart joins.
 	// This requires ArangoDB Enterprise Edition.
 	SmartJoinAttribute string `json:"smartJoinAttribute,omitempty"`
-	// This attribute specifies the name of the sharding strategy to use for the collection.
-	// Must be one of ShardingStrategy* values.
-	ShardingStrategy ShardingStrategy `json:"shardingStrategy,omitempty"`
-	// Schema for collection validation
-	Schema *CollectionSchemaOptions `json:"schema,omitempty"`
+	// Available from 3.7 ArangoDB version
+	SyncByRevision bool `json:"syncByRevision,omitempty"`
+	// The type of the collection to create. (default is CollectionTypeDocument)
+	Type CollectionType `json:"type,omitempty"`
+	// If true then the data is synchronized to disk before returning from a document create, update, replace or removal operation. (default: false)
+	WaitForSync bool `json:"waitForSync,omitempty"`
+	// WriteConcern contains how many copies must be available before a collection can be written.
+	// It is required that 1 <= WriteConcern <= ReplicationFactor.
+	// Default is 1. Not available for satellite collections.
+	// Available from 3.6 ArangoDB version.
+	WriteConcern int `json:"writeConcern,omitempty"`
 }
 
 // Init translate deprecated fields into current one for backward compatibility


### PR DESCRIPTION
Add new fields to the public structure `CreateCollectionOptions` (v1 and v2):
```
InternalValidatorType int    `json:"internalValidatorType,omitempty"`
IsDisjoint            bool  
SyncByRevision bool         `json:"syncByRevision,omitempty"`
```

Add new fields to the structure public `InventoryCollectionParameters` (only v1):
```
CacheEnabled bool `json:"cacheEnabled,omitempty"`
GloballyUniqueId string `json:"globallyUniqueId,omitempty"`
InternalValidatorType int `json:"internalValidatorType,omitempty"`
IsDisjoint bool `json:"isDisjoint,omitempty"`
IsSmartChild bool `json:"isSmartChild,omitempty"`
Schema            *CollectionSchemaOptions `json:"schema,omitempty"`
ShadowCollections []int
```

Fields in structures were sorted alphabetically, so that is why we can see many changes.
New fields are required by the arangosync