### PR TITLE
Fix running test cluster under cgroups v2

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,7 +2,7 @@
 
 - Always preserve backward compatibility
 - Build using `make clean && make`
-- After merging PR, alway run `make changelog` and commit changes
+- After merging PR, always run `make changelog` and commit changes
 - Set ArangoDB docker container (used for testing) using `export ARANGODB=<image-name>`
 - Run tests using:
   - `make run-tests-single`

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -54,8 +54,8 @@ if [ "$CMD" == "start" ]; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
         DOCKERPLATFORMARG="--platform linux/x86_64"
         DOCKERARGS="$DOCKERARGS $DOCKERPLATFORMARG"
-        STARTERARGS="--docker.container=$STARTERCONTAINER"
     fi
+    STARTERARGS="$STARTERARGS --docker.container=$STARTERCONTAINER"
 
     if [ -z "$STARTERPORT" ]; then
         STARTERPORT=7000


### PR DESCRIPTION
Two problems fixed in this PR:
1) on MacOS systems the `STARTERARGS` env variable was always rewritten with static value
2) when using cgroups v2, arangodb-starter fails to automatically discover the container name. Providing `--docker.container` option disable auto discovery. Failing code in starter: https://github.com/arangodb-helper/arangodb/blob/60de446c4634218d81054bc754af6b2fb2f27413/docker.go#L58