### PR TITLE
Update README: supported versions and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This project contains the official Go driver for the [ArangoDB database](https://arangodb.com).
 
 [![Build Status](https://travis-ci.org/arangodb/go-driver.svg?branch=master)](https://travis-ci.org/arangodb/go-driver)
-[![GoDoc](https://godoc.org/github.com/arangodb/g-driver?status.svg)](http://godoc.org/github.com/arangodb/go-driver)
+[![GoDoc](https://godoc.org/github.com/arangodb/go-driver?status.svg)](http://godoc.org/github.com/arangodb/go-driver)
 
 
 - [Getting Started](https://www.arangodb.com/docs/stable/drivers/go-getting-started.html)
@@ -15,22 +15,23 @@ This project contains the official Go driver for the [ArangoDB database](https:/
 
 # Supported Go Versions
 
-|                   | Go 1.13 | Go 1.14 | Go 1.16 |
-|-------------------|---------|---------|---------|
-| `1.0.0`           | ✓       | ✓       | ✓       |
-| `1.1.0`           | ✓       | ✓       | ✓       |
-| `master`          | ✓       | ✓       | ✓       |
+|               | Go 1.13 | Go 1.14 | Go 1.16 |
+|---------------|---------|---------|---------|
+| `1.0.0-1.3.0` | ✓       | ✓       | ✓       |
+| `master`      | ✓       | ✓       | ✓       |
 
 # Supported Versions
 
-|                   | < ArangoDB 3.6 | ArangoDB 3.6 | ArangoDB 3.7 |
-|-------------------|----------------|--------------|--------------|
-| `1.0.0`           | ✓              | ✓            | -            |
-| `1.1.0`           | +              | +            | ✓            |
-| `master`          | +              | +            | +            |
+|          | < ArangoDB 3.6 | ArangoDB 3.6 | ArangoDB 3.7 | ArangoDB 3.8 | ArangoDB 3.9 |
+|----------|----------------|--------------|--------------|--------------|--------------|
+| `1.0.0`  | ✓              | ✓            | -            | -            | -            |
+| `1.1.0`  | +              | +            | ✓            | -            | -            |
+| `1.2.1`  | +              | +            | ✓            | ✓            | -            |
+| `1.3.0`  | +              | +            | ✓            | ✓            | ✓            |
+| `master` | +              | +            | +            | +            | +            |
 
 Key:
 
 * `✓` Exactly the same features in both driver and the ArangoDB version.
-* `+` Features included in driver may be not present in the ArangoDB API. Calls to the ArangoDB may results in unexpected responses (404).
+* `+` Features included in driver may be not present in the ArangoDB API. Calls to the ArangoDB may result in unexpected responses (404).
 * `-` The ArangoDB has features which are not supported by driver.


### PR DESCRIPTION
- fix typo in img url
- compact and update "supported Go versions" section
- update "supported versions" section

Closes #358

@jwierzbo  please re-check if arangod 3.8 is supported by driver v1.2.1 - I'm not sure about that.