### PR TITLE
Fix cursor executionTime statistics getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
 - Add support for `exclusive` field for transaction options
+- Fix cursor executionTime statistics getter
 
 ## [1.3.0](https://github.com/arangodb/go-driver/tree/v1.3.0) (2022-03-17)
 - Disallow unknown fields feature

--- a/cursor_impl.go
+++ b/cursor_impl.go
@@ -319,5 +319,5 @@ func (cs cursorStats) FullCount() int64 {
 
 // query execution time (wall-clock time). value will be set from the outside
 func (cs cursorStats) ExecutionTime() time.Duration {
-	return time.Duration(cs.ExecutionTimeInt) * time.Second
+	return time.Duration(cs.ExecutionTimeInt * float64(time.Second))
 }

--- a/test/cursor_test.go
+++ b/test/cursor_test.go
@@ -28,8 +28,9 @@ import (
 	"testing"
 	"time"
 
-	driver "github.com/arangodb/go-driver"
 	"github.com/stretchr/testify/require"
+
+	driver "github.com/arangodb/go-driver"
 )
 
 func TestCreateCursorWithMaxRuntime(t *testing.T) {
@@ -288,6 +289,10 @@ func TestCreateCursor(t *testing.T) {
 						}
 					}
 				}
+
+				executionTime := cursor.Statistics().ExecutionTime()
+				require.Greaterf(t, executionTime.Nanoseconds(), int64(0), "execution time must be greater than 0")
+
 				// Close anyway (this tests calling Close more than once)
 				if err := cursor.Close(); err != nil {
 					t.Errorf("Expected success in Close of cursor from query %d (%s), got '%s'", i, test.Query, describe(err))


### PR DESCRIPTION
Fixes rounding error.
The value returned by arangod is in seconds: https://github.com/arangodb/arangodb/blob/devel/js/apps/system/_admin/aardvark/APP/frontend/js/views/queryView.js#L2078

Closes #373 