### PR TITLE
Fix selectivityEstimate Index field type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
+- Fix selectivityEstimate Index field type
 
 ## [1.3.1](https://github.com/arangodb/go-driver/tree/v1.3.1) (2022-03-23)
 - Add support for `exclusive` field for transaction options

--- a/collection_indexes_impl.go
+++ b/collection_indexes_impl.go
@@ -43,7 +43,7 @@ type indexData struct {
 	Name                string   `json:"name,omitempty"`
 	FieldValueTypes     string   `json:"fieldValueTypes,omitempty"`
 	IsNewlyCreated      *bool    `json:"isNewlyCreated,omitempty"`
-	SelectivityEstimate int      `json:"selectivityEstimate,omitempty"`
+	SelectivityEstimate float64  `json:"selectivityEstimate,omitempty"`
 	BestIndexedLevel    int      `json:"bestIndexedLevel,omitempty"`
 	WorstIndexedLevel   int      `json:"worstIndexedLevel,omitempty"`
 


### PR DESCRIPTION
Fix for https://github.com/arangodb/go-driver/issues/393