### PR TITLE
Add support for `computedValues` into collection inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
 - Add `hex` property to analyzer's properties
 - Add support for `computedValues`
+- Add support for `computedValues` into collection inventory
 
 ## [1.3.3](https://github.com/arangodb/go-driver/tree/v1.3.3) (2022-07-27)
 - Fix `lastValue` field type

--- a/cluster.go
+++ b/cluster.go
@@ -289,6 +289,8 @@ type InventoryCollectionParameters struct {
 	WaitForSync                bool `json:"waitForSync,omitempty"`
 	// Available from 3.6 ArangoD version.
 	WriteConcern int `json:"writeConcern,omitempty"`
+	// Available from 3.10 ArangoD version.
+	ComputedValues []ComputedValue `json:"computedValues,omitempty"`
 }
 
 // IsSatellite returns true if the collection is a satellite collection

--- a/cluster_impl.go
+++ b/cluster_impl.go
@@ -319,6 +319,8 @@ type inventoryCollectionParametersInternal struct {
 	WaitForSync                bool `json:"waitForSync,omitempty"`
 	// Available from 3.6 ArangoD version.
 	WriteConcern int `json:"writeConcern,omitempty"`
+	// Available from 3.10 ArangoD version.
+	ComputedValues []ComputedValue `json:"computedValues,omitempty"`
 }
 
 func (p *InventoryCollectionParameters) asInternal() inventoryCollectionParametersInternal {
@@ -370,6 +372,7 @@ func (p *InventoryCollectionParameters) asInternal() inventoryCollectionParamete
 		UsesRevisionsAsDocumentIds: p.UsesRevisionsAsDocumentIds,
 		WaitForSync:                p.WaitForSync,
 		WriteConcern:               p.WriteConcern,
+		ComputedValues:             p.ComputedValues,
 	}
 }
 
@@ -424,6 +427,7 @@ func (p *inventoryCollectionParametersInternal) asExternal() InventoryCollection
 		UsesRevisionsAsDocumentIds: p.UsesRevisionsAsDocumentIds,
 		WaitForSync:                p.WaitForSync,
 		WriteConcern:               p.WriteConcern,
+		ComputedValues:             p.ComputedValues,
 	}
 }
 


### PR DESCRIPTION
example output from `/clusterInventory` API endpoint:
```
"computedValues": [
          {
            "name": "date-timestamp-value",
            "expression": "RETURN DATE_NOW()",
            "computeOn": [
              "insert"
            ],
            "overwrite": false,
            "failOnWarning": true,
            "keepNull": true
          }
        ],
```