### PR TITLE
Revert "GT-167 Temporary disable failing AQL tests for 3.10 (#419)"

### DIFF
--- a/test/view_test.go
+++ b/test/view_test.go
@@ -429,7 +429,7 @@ func TestUseArangoSearchView(t *testing.T) {
 	ctx := context.Background()
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, true, false)
-	skipBelowVersion(c, "3.11", t)
+	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(nil, c, "view_test", nil, t)
 	col := ensureCollection(ctx, db, "some_collection", nil, t)
 
@@ -511,7 +511,7 @@ func TestUseArangoSearchViewWithPipelineAnalyzer(t *testing.T) {
 	ctx := context.Background()
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, true, false)
-	skipBelowVersion(c, "3.11", t)
+	skipBelowVersion(c, "3.8", t)
 	db := ensureDatabase(nil, c, "view_with_pipeline_test", nil, t)
 	col := ensureCollection(ctx, db, "some_collection_with_analyzer", nil, t)
 


### PR DESCRIPTION
This reverts commit 756f3a4d4496b3d5c04b6777a9552ae5893ac1a0.