### PR TITLE
Add cache for ArangoSearchView Link and StoredValue types and `primarySortCache` for ArangoSearchView type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
 - Add support for `checksum` in Collections
-- Add `cache` for ArangoSearchView Link and StoredValue types and `primarySortCache` for ArangoSearchView type
+- Add `cache` for ArangoSearchView Link and StoredValue types and `primarySortCache`, `primaryKeyCache` for ArangoSearchView type
 
 ## [1.4.0](https://github.com/arangodb/go-driver/tree/v1.4.0) (2022-10-04)
 - Add `hex` property to analyzer's properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
 - Add support for `checksum` in Collections
+- Add `cache` for ArangoSearchView Link and StoredValue types and `primarySortCache` for ArangoSearchView type
 
 ## [1.4.0](https://github.com/arangodb/go-driver/tree/v1.4.0) (2022-10-04)
 - Add `hex` property to analyzer's properties

--- a/test/arangosearch_analyzers_test.go
+++ b/test/arangosearch_analyzers_test.go
@@ -364,7 +364,7 @@ func TestArangoSearchAnalyzerEnsureAnalyzer(t *testing.T) {
 				if testCase.MaxVersion == nil {
 					skipBelowVersion(c, *testCase.MinVersion, t)
 				} else {
-					skipBetweenVersion(c, *testCase.MinVersion, *testCase.MaxVersion, t)
+					skipVersionNotInRange(c, *testCase.MinVersion, *testCase.MaxVersion, t)
 				}
 			}
 			if testCase.EnterpriseOnly {

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -106,6 +106,18 @@ func skipVersionNotInRange(c driver.Client, minVersion, maxVersion driver.Versio
 	return x
 }
 
+// skipBetweenVersions skips test if DB version is in interval (close-ended)
+func skipBetweenVersions(c driver.Client, minVersion, maxVersion driver.Version, t *testing.T) driver.VersionInfo {
+	x, err := c.Version(nil)
+	if err != nil {
+		t.Fatalf("Failed to get version info: %s", describe(err))
+	}
+	if x.Version.CompareTo(minVersion) >= 0 && x.Version.CompareTo(maxVersion) <= 0 {
+		t.Skipf("Skipping between version '%s' and '%s': got version '%s'", minVersion, maxVersion, x.Version)
+	}
+	return x
+}
+
 // skipBelowVersion skips the test if the current server version is less than
 // the given version.
 func skipBelowVersion(c driver.Client, version driver.Version, t *testing.T) driver.VersionInfo {

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -90,9 +90,9 @@ func skipNoEnterprise(t *testing.T) {
 	}
 }
 
-// skipBetweenVersion skips the test if the current server version is less than
+// skipVersionNotInRange skips the test if the current server version is less than
 // the min version or higher/equal max version
-func skipBetweenVersion(c driver.Client, minVersion, maxVersion driver.Version, t *testing.T) driver.VersionInfo {
+func skipVersionNotInRange(c driver.Client, minVersion, maxVersion driver.Version, t *testing.T) driver.VersionInfo {
 	x, err := c.Version(nil)
 	if err != nil {
 		t.Fatalf("Failed to get version info: %s", describe(err))

--- a/test/view_test.go
+++ b/test/view_test.go
@@ -895,8 +895,9 @@ func TestArangoSearchViewProperties353(t *testing.T) {
 func TestArangoSearchViewLinkAndStoredValueCache(t *testing.T) {
 	ctx := context.Background()
 	c := createClientFromEnv(t, true)
-	// feature was introduced in 3.9.5 and is not ported to 3.10+ yet:
-	skipVersionNotInRange(c, "3.9.5", "3.10.0", t)
+	// feature was introduced in 3.9.5 and in 3.10.2:
+	skipBelowVersion(c, "3.9.5", t)
+	skipBetweenVersions(c, "3.10.0", "3.10.1", t)
 	skipNoEnterprise(t)
 	db := ensureDatabase(ctx, c, "view_test_links_stored_value_cache", nil, t)
 	linkedColName := "linkedColumn"
@@ -947,8 +948,9 @@ func TestArangoSearchViewInMemoryCache(t *testing.T) {
 	db := ensureDatabase(ctx, c, "view_test_in_memory_cache", nil, t)
 
 	t.Run("primarySortCache", func(t *testing.T) {
-		// feature was introduced in 3.9.5 and is not ported to 3.10+ yet:
-		skipVersionNotInRange(c, "3.9.5", "3.10.0", t)
+		// feature was introduced in 3.9.5 and in 3.10.2:
+		skipBelowVersion(c, "3.9.5", t)
+		skipBetweenVersions(c, "3.10.0", "3.10.1", t)
 
 		name := "test_create_asview"
 		opts := &driver.ArangoSearchViewProperties{
@@ -964,22 +966,12 @@ func TestArangoSearchViewInMemoryCache(t *testing.T) {
 			skipBelowVersion(c, "3.9.6", t)
 			require.Equal(t, newBool(true), p.PrimarySortCache)
 		})
-
-		// update props: set to cached
-		p.PrimarySortCache = newBool(false)
-		err = v.SetProperties(ctx, p)
-		require.NoError(t, err)
-
-		// check updates applied
-		p, err = v.Properties(ctx)
-		require.NoError(t, err)
-		require.Nil(t, p.PrimarySortCache)
-		require.Nil(t, p.PrimaryKeyCache)
 	})
 
 	t.Run("primaryKeyCache", func(t *testing.T) {
-		// feature was introduced in 3.9.6 and is not ported to 3.10+ yet:
-		skipVersionNotInRange(c, "3.9.6", "3.10.0", t)
+		// feature was introduced in 3.9.6 and 3.10.2:
+		skipBelowVersion(c, "3.9.6", t)
+		skipBetweenVersions(c, "3.10.0", "3.10.1", t)
 
 		name := "test_view_"
 		opts := &driver.ArangoSearchViewProperties{
@@ -991,15 +983,5 @@ func TestArangoSearchViewInMemoryCache(t *testing.T) {
 		p, err := v.Properties(ctx)
 		require.NoError(t, err)
 		require.Equal(t, newBool(true), p.PrimaryKeyCache)
-
-		// update props: set to cached
-		p.PrimaryKeyCache = newBool(false)
-		err = v.SetProperties(ctx, p)
-		require.NoError(t, err)
-
-		// check updates applied
-		p, err = v.Properties(ctx)
-		require.NoError(t, err)
-		require.Nil(t, p.PrimaryKeyCache)
 	})
 }

--- a/view_arangosearch.go
+++ b/view_arangosearch.go
@@ -349,6 +349,10 @@ type ArangoSearchViewProperties struct {
 	// Introduced in v3.9.5, Enterprise Edition only
 	PrimarySortCache *bool `json:"primarySortCache,omitempty"`
 
+	// PrimaryKeyCache If you enable this option, then the primary key columns are always cached in memory.
+	// Introduced in v3.9.6, Enterprise Edition only
+	PrimaryKeyCache *bool `json:"primaryKeyCache,omitempty"`
+
 	// StoredValues An array of objects to describe which document attributes to store in the View index (introduced in v3.7.1).
 	// It can then cover search queries, which means the data can be taken from the index directly and accessing the storage engine can be avoided.
 	// This option is immutable.

--- a/view_arangosearch.go
+++ b/view_arangosearch.go
@@ -345,6 +345,10 @@ type ArangoSearchViewProperties struct {
 	// ArangoDB v3.5 and v3.6 always compress the index using LZ4. This option is immutable.
 	PrimarySortCompression PrimarySortCompression `json:"primarySortCompression,omitempty"`
 
+	// PrimarySortCache If you enable this option, then the primary sort columns are always cached in memory.
+	// Introduced in v3.9.5, Enterprise Edition only
+	PrimarySortCache *bool `json:"primarySortCache,omitempty"`
+
 	// StoredValues An array of objects to describe which document attributes to store in the View index (introduced in v3.7.1).
 	// It can then cover search queries, which means the data can be taken from the index directly and accessing the storage engine can be avoided.
 	// This option is immutable.
@@ -366,6 +370,9 @@ const (
 type StoredValue struct {
 	Fields      []string               `json:"fields,omitempty"`
 	Compression PrimarySortCompression `json:"compression,omitempty"`
+	// Cache attribute allows you to always cache stored values in memory
+	// Introduced in v3.9.5, Enterprise Edition only
+	Cache *bool `json:"cache,omitempty"`
 }
 
 // ArangoSearchSortDirection describes the sorting direction
@@ -479,6 +486,9 @@ type ArangoSearchElementProperties struct {
 	// so that it remains basically available. inBackground is an option that can be set when adding links.
 	// It does not get persisted as it is not a View property, but only a one-off option
 	InBackground *bool `json:"inBackground,omitempty"`
+	// Cache If you enable this option, then field normalization values are always cached in memory.
+	// Introduced in v3.9.5, Enterprise Edition only
+	Cache *bool `json:"cache,omitempty"`
 }
 
 // ArangoSearchStoreValues is the type of the StoreValues option of an ArangoSearch element.

--- a/view_arangosearch.go
+++ b/view_arangosearch.go
@@ -346,11 +346,13 @@ type ArangoSearchViewProperties struct {
 	PrimarySortCompression PrimarySortCompression `json:"primarySortCompression,omitempty"`
 
 	// PrimarySortCache If you enable this option, then the primary sort columns are always cached in memory.
+	// Can't be changed after creating View.
 	// Introduced in v3.9.5, Enterprise Edition only
 	PrimarySortCache *bool `json:"primarySortCache,omitempty"`
 
 	// PrimaryKeyCache If you enable this option, then the primary key columns are always cached in memory.
 	// Introduced in v3.9.6, Enterprise Edition only
+	// Can't be changed after creating View.
 	PrimaryKeyCache *bool `json:"primaryKeyCache,omitempty"`
 
 	// StoredValues An array of objects to describe which document attributes to store in the View index (introduced in v3.7.1).


### PR DESCRIPTION
https://www.arangodb.com/docs/3.9/arangosearch-views.html#link-properties
https://www.arangodb.com/docs/3.9/arangosearch-views.html#view-properties

PrimaryKeyCache:
https://github.com/arangodb/docs/pull/1191

For now GET /properties does not work properly in 3.9-nightly image - one sub test will fail until fix.