### PR TITLE
Fix auto-detection of source code paths when running tests debug

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -5,7 +5,7 @@ ARG TESTS_ROOT_PATH="."
 
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
-WORKDIR /app/
-ADD . /app/
+WORKDIR /go/src/github.com/arangodb/go-driver
+ADD . /go/src/github.com/arangodb/go-driver/
 
 RUN cd $TESTS_ROOT_PATH && go test -gcflags "all=-N -l" -c -o /test_debug.test $TESTS_DIRECTORY


### PR DESCRIPTION
When running tests with `DEBUG=true`, delve could not map the source code paths. Using default package path fixes that