### PR TITLE
Fix ArangoDB logo image in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project contains the official Go driver for the [ArangoDB database](https:/
 [![Build Status](https://travis-ci.org/arangodb/go-driver.svg?branch=master)](https://travis-ci.org/arangodb/go-driver)
 [![GoDoc](https://godoc.org/github.com/arangodb/go-driver?status.svg)](http://godoc.org/github.com/arangodb/go-driver)
 
+
 - [Getting Started](https://www.arangodb.com/docs/stable/drivers/go-getting-started.html)
 - [Example Requests](https://www.arangodb.com/docs/stable/drivers/go-example-requests.html)
 - [Connection Management](https://www.arangodb.com/docs/stable/drivers/go-connection-management.html)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This project contains the official Go driver for the [ArangoDB database](https:/
 [![Build Status](https://travis-ci.org/arangodb/go-driver.svg?branch=master)](https://travis-ci.org/arangodb/go-driver)
 [![GoDoc](https://godoc.org/github.com/arangodb/go-driver?status.svg)](http://godoc.org/github.com/arangodb/go-driver)
 
-
 - [Getting Started](https://www.arangodb.com/docs/stable/drivers/go-getting-started.html)
 - [Example Requests](https://www.arangodb.com/docs/stable/drivers/go-example-requests.html)
 - [Connection Management](https://www.arangodb.com/docs/stable/drivers/go-connection-management.html)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![ArangoDB-Logo](https://www.arangodb.com/docs/assets/arangodb_logo_2016_inverted.png)
+![ArangoDB-Logo](https://user-images.githubusercontent.com/3998723/207981337-79d49127-48fc-4c7c-9411-8a688edca1dd.png)
+
 
 # ArangoDB GO Driver
 


### PR DESCRIPTION
it wasn't working properly on some sites because of incorrect headers/redirects at main ArangoDB site.

e.g. ![at pkg.go.dev](https://i.imgur.com/TZgdbJt.png)