### PR TITLE
GT-336 TTL index creation fails when expireAt is 0 - fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Use Go 1.19.4
 - Add `IsExternalStorageError` to check for [external storage errors](https://www.arangodb.com/docs/stable/appendix-error-codes.html#external-arangodb-storage-errors)
 - `nested` field in arangosearch type View
+- Fix: TTL index creation fails when expireAt is 0
 
 ## [1.4.1](https://github.com/arangodb/go-driver/tree/v1.4.1) (2022-12-14)
 - Add support for `checksum` in Collections

--- a/collection_indexes_impl.go
+++ b/collection_indexes_impl.go
@@ -40,7 +40,7 @@ type indexData struct {
 	Estimates           *bool    `json:"estimates,omitempty"`
 	MaxNumCoverCells    int      `json:"maxNumCoverCells,omitempty"`
 	MinLength           int      `json:"minLength,omitempty"`
-	ExpireAfter         int      `json:"expireAfter,omitempty"`
+	ExpireAfter         int      `json:"expireAfter"`
 	Name                string   `json:"name,omitempty"`
 	FieldValueTypes     string   `json:"fieldValueTypes,omitempty"`
 	IsNewlyCreated      *bool    `json:"isNewlyCreated,omitempty"`

--- a/test/index_ensure_test.go
+++ b/test/index_ensure_test.go
@@ -447,6 +447,21 @@ func TestEnsureTTLIndex(t *testing.T) {
 	} else if found {
 		t.Errorf("Index '%s' does exist, expected it not to exist", idx.Name())
 	}
+
+	// Create index with expireAfter = 0
+	idx, created, err = col.EnsureTTLIndex(nil, "createdAt", 0, nil)
+	if err != nil {
+		t.Fatalf("Failed to create new index: %s", describe(err))
+	}
+	if !created {
+		t.Error("Expected created to be true, got false")
+	}
+	if idxType := idx.Type(); idxType != driver.TTLIndex {
+		t.Errorf("Expected TTLIndex, found `%s`", idxType)
+	}
+	if idx.ExpireAfter() != 0 {
+		t.Errorf("Expected ExpireAfter to be 0, found `%d`", idx.ExpireAfter())
+	}
 }
 
 // TestEnsureZKDIndex creates a collection with a ZKD index.


### PR DESCRIPTION
Fix for https://github.com/arangodb/go-driver/issues/291