### PR TITLE
Add replication version option for database creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [V2] Fix: Plain Connection doesn't work with JWT authentication
 - Support for new error codes if write concern is not fulfilled
 - Support for geo_s2 analyzers
+- Add replication V2 option for database creation
 
 ## [1.5.2](https://github.com/arangodb/go-driver/tree/v1.5.2) (2023-03-01)
 - Bump `DRIVER_VERSION`

--- a/client_databases.go
+++ b/client_databases.go
@@ -62,6 +62,13 @@ type CreateDatabaseOptions struct {
 	Options CreateDatabaseDefaultOptions `json:"options,omitempty"`
 }
 
+type DatabaseReplicationVersion string
+
+const (
+	DatabaseReplicationVersionOne DatabaseReplicationVersion = "1"
+	DatabaseReplicationVersionTwo DatabaseReplicationVersion = "2"
+)
+
 // CreateDatabaseDefaultOptions contains options that change defaults for collections
 type CreateDatabaseDefaultOptions struct {
 	// Default replication factor for collections in database
@@ -70,6 +77,8 @@ type CreateDatabaseDefaultOptions struct {
 	WriteConcern int `json:"writeConcern,omitempty"`
 	// Default sharding for collections in database
 	Sharding DatabaseSharding `json:"sharding,omitempty"`
+	// Replication version to use for this database
+	ReplicationVersion DatabaseReplicationVersion `json:"replicationVersion,omitempty"`
 }
 
 // CreateDatabaseUserOptions contains options for creating a single user for a database.

--- a/client_databases.go
+++ b/client_databases.go
@@ -62,6 +62,9 @@ type CreateDatabaseOptions struct {
 	Options CreateDatabaseDefaultOptions `json:"options,omitempty"`
 }
 
+// DatabaseReplicationVersion defines replication protocol version to use for this database
+// Available since ArangoDB version 3.11
+// Note: this feature is still considered experimental and should not be used in production
 type DatabaseReplicationVersion string
 
 const (
@@ -78,6 +81,7 @@ type CreateDatabaseDefaultOptions struct {
 	// Default sharding for collections in database
 	Sharding DatabaseSharding `json:"sharding,omitempty"`
 	// Replication version to use for this database
+	// Available since ArangoDB version 3.11
 	ReplicationVersion DatabaseReplicationVersion `json:"replicationVersion,omitempty"`
 }
 

--- a/database.go
+++ b/database.go
@@ -94,6 +94,8 @@ type DatabaseInfo struct {
 	WriteConcern int `json:"writeConcern,omitempty"`
 	// Default sharding for collections in database
 	Sharding DatabaseSharding `json:"sharding,omitempty"`
+	// Replication version used for this database
+	ReplicationVersion DatabaseReplicationVersion `json:"replicationVersion,omitempty"`
 }
 
 // EngineType indicates type of database engine being used.

--- a/v2/arangodb/client_database.go
+++ b/v2/arangodb/client_database.go
@@ -63,6 +63,16 @@ type CreateDatabaseOptions struct {
 	Options CreateDatabaseDefaultOptions `json:"options,omitempty"`
 }
 
+// DatabaseReplicationVersion defines replication protocol version to use for this database
+// Available since ArangoDB version 3.11
+// Note: this feature is still considered experimental and should not be used in production
+type DatabaseReplicationVersion string
+
+const (
+	DatabaseReplicationVersionOne DatabaseReplicationVersion = "1"
+	DatabaseReplicationVersionTwo DatabaseReplicationVersion = "2"
+)
+
 // CreateDatabaseDefaultOptions contains options that change defaults for collections
 type CreateDatabaseDefaultOptions struct {
 	// Default replication factor for collections in database
@@ -71,6 +81,9 @@ type CreateDatabaseDefaultOptions struct {
 	WriteConcern int `json:"writeConcern,omitempty"`
 	// Default sharding for collections in database
 	Sharding DatabaseSharding `json:"sharding,omitempty"`
+	// Replication version to use for this database
+	// Available since ArangoDB version 3.11
+	ReplicationVersion DatabaseReplicationVersion `json:"replicationVersion,omitempty"`
 }
 
 // CreateDatabaseUserOptions contains options for creating a single user for a database.

--- a/v2/arangodb/database_opts.go
+++ b/v2/arangodb/database_opts.go
@@ -38,6 +38,8 @@ type DatabaseInfo struct {
 	WriteConcern int `json:"writeConcern,omitempty"`
 	// Default sharding for collections in database
 	Sharding DatabaseSharding `json:"sharding,omitempty"`
+	// Replication version used for this database
+	ReplicationVersion DatabaseReplicationVersion `json:"replicationVersion,omitempty"`
 }
 
 // EngineType indicates type of database engine being used.


### PR DESCRIPTION
For many client tools, for example `feed`, we need the go-driver to create a replication version 2 database. 