### PR TITLE
Fix potential bug with DB name escaping for URL when requesting replication-related API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add replication V2 option for database creation
 - Use Go 1.20.3 for testing. Add govulncheck to pipeline
 - Fix test for extended names
+- Fix potential bug with DB name escaping for URL when requesting replication-related API
 
 ## [1.5.2](https://github.com/arangodb/go-driver/tree/v1.5.2) (2023-03-01)
 - Bump `DRIVER_VERSION`

--- a/cluster_impl.go
+++ b/cluster_impl.go
@@ -66,7 +66,7 @@ func (c *cluster) Health(ctx context.Context) (ClusterHealth, error) {
 
 // DatabaseInventory Get the inventory of the cluster containing all collections (with entire details) of a database.
 func (c *cluster) DatabaseInventory(ctx context.Context, db Database) (DatabaseInventory, error) {
-	req, err := c.conn.NewRequest("GET", path.Join("_db", db.Name(), "_api/replication/clusterInventory"))
+	req, err := c.conn.NewRequest("GET", path.Join("_db", pathEscape(db.Name()), "_api/replication/clusterInventory"))
 	if err != nil {
 		return DatabaseInventory{}, WithStack(err)
 	}

--- a/replication_impl.go
+++ b/replication_impl.go
@@ -50,7 +50,7 @@ var ErrBatchClosed = errors.New("Batch already closed")
 
 // CreateBatch creates a "batch" to prevent WAL file removal and to take a snapshot
 func (c *client) CreateBatch(ctx context.Context, db Database, serverID int64, ttl time.Duration) (Batch, error) {
-	req, err := c.conn.NewRequest("POST", path.Join("_db", db.Name(), "_api/replication/batch"))
+	req, err := c.conn.NewRequest("POST", path.Join("_db", pathEscape(db.Name()), "_api/replication/batch"))
 	if err != nil {
 		return nil, WithStack(err)
 	}
@@ -81,7 +81,7 @@ func (c *client) CreateBatch(ctx context.Context, db Database, serverID int64, t
 
 // DatabaseInventory Get the inventory of a server containing all collections (with entire details) of a database.
 func (c *client) DatabaseInventory(ctx context.Context, db Database) (DatabaseInventory, error) {
-	req, err := c.conn.NewRequest("GET", path.Join("_db", db.Name(), "_api/replication/inventory"))
+	req, err := c.conn.NewRequest("GET", path.Join("_db", pathEscape(db.Name()), "_api/replication/inventory"))
 	if err != nil {
 		return DatabaseInventory{}, WithStack(err)
 	}

--- a/revision.go
+++ b/revision.go
@@ -167,7 +167,7 @@ func (n *RevisionUInt64) MarshalVPack() (velocypack.Slice, error) {
 // GetRevisionTree retrieves the Revision tree (Merkel tree) associated with the collection.
 func (c *client) GetRevisionTree(ctx context.Context, db Database, batchId, collection string) (RevisionTree, error) {
 
-	req, err := c.conn.NewRequest("GET", path.Join("_db", db.Name(), "_api/replication/revisions/tree"))
+	req, err := c.conn.NewRequest("GET", path.Join("_db", pathEscape(db.Name()), "_api/replication/revisions/tree"))
 	if err != nil {
 		return RevisionTree{}, WithStack(err)
 	}
@@ -196,7 +196,7 @@ func (c *client) GetRevisionTree(ctx context.Context, db Database, batchId, coll
 func (c *client) GetRevisionsByRanges(ctx context.Context, db Database, batchId, collection string,
 	minMaxRevision []RevisionMinMax, resume RevisionUInt64) (RevisionRanges, error) {
 
-	req, err := c.conn.NewRequest("PUT", path.Join("_db", db.Name(), "_api/replication/revisions/ranges"))
+	req, err := c.conn.NewRequest("PUT", path.Join("_db", pathEscape(db.Name()), "_api/replication/revisions/ranges"))
 	if err != nil {
 		return RevisionRanges{}, WithStack(err)
 	}
@@ -233,7 +233,7 @@ func (c *client) GetRevisionsByRanges(ctx context.Context, db Database, batchId,
 func (c *client) GetRevisionDocuments(ctx context.Context, db Database, batchId, collection string,
 	revisions Revisions) ([]map[string]interface{}, error) {
 
-	req, err := c.conn.NewRequest("PUT", path.Join("_db", db.Name(), "_api/replication/revisions/documents"))
+	req, err := c.conn.NewRequest("PUT", path.Join("_db", pathEscape(db.Name()), "_api/replication/revisions/documents"))
 	if err != nil {
 		return nil, WithStack(err)
 	}


### PR DESCRIPTION
In all places where we use DB name in URL path, it is escaped using pathEscape function but in few places it is missing for some reason. That potentially could lead to the problem when using DB name with non-ANSI characters.