### PR TITLE
Search optimisation for inverted index and ArangoSearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix potential bug with DB name escaping for URL when requesting replication-related API
 - Retriable batch reads in AQL cursors
 - Add support for explain API ([v1] and [V2])
+- Search optimisation for inverted index and ArangoSearch
 
 ## [1.5.2](https://github.com/arangodb/go-driver/tree/v1.5.2) (2023-03-01)
 - Bump `DRIVER_VERSION`

--- a/collection_indexes.go
+++ b/collection_indexes.go
@@ -262,6 +262,9 @@ type InvertedIndexOptions struct {
 	// 0 value turns off this limit for any writer (buffer) and data will be flushed periodically based on the value defined for the flush thread (ArangoDB server startup option).
 	// 0 value should be used carefully due to high potential memory consumption (default: 33554432, use 0 to disable)
 	WriteBufferSizeMax *int64 `json:"writebufferSizeMax,omitempty"`
+	// OptimizeTopK is an array of strings defining optimized sort expressions.
+	// Introduced in v3.11.0, Enterprise Edition only.
+	OptimizeTopK []string `json:"optimizeTopK,omitempty"`
 }
 
 // InvertedIndexPrimarySort defines compression and list of fields to be sorted.

--- a/v2/arangodb/collection_indexe_inverted.go
+++ b/v2/arangodb/collection_indexe_inverted.go
@@ -101,6 +101,10 @@ type InvertedIndexOptions struct {
 	// 0 value turns off this limit for any writer (buffer) and data will be flushed periodically based on the value defined for the flush thread (ArangoDB server startup option).
 	// 0 value should be used carefully due to high potential memory consumption (default: 33554432, use 0 to disable)
 	WriteBufferSizeMax *int64 `json:"writebufferSizeMax,omitempty"`
+
+	// OptimizeTopK is an array of strings defining optimized sort expressions.
+	// Introduced in v3.11.0, Enterprise Edition only.
+	OptimizeTopK []string `json:"optimizeTopK,omitempty"`
 }
 
 // InvertedIndexField contains configuration for indexing of the field

--- a/view_arangosearch.go
+++ b/view_arangosearch.go
@@ -361,6 +361,10 @@ type ArangoSearchViewProperties struct {
 	// The key of the map are collection names.
 	Links ArangoSearchLinks `json:"links,omitempty"`
 
+	// OptimizeTopK is an array of strings defining optimized sort expressions.
+	// Introduced in v3.11.0, Enterprise Edition only.
+	OptimizeTopK []string `json:"optimizeTopK,omitempty"`
+
 	// PrimarySort describes how individual fields are sorted
 	PrimarySort []ArangoSearchPrimarySortEntry `json:"primarySort,omitempty"`
 


### PR DESCRIPTION
Add `optimizeTopK` for inverted index, and ArangoSearch.