### PR TITLE
Support optimizer rules in AQL queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Retriable batch reads in AQL cursors
 - Add support for explain API ([v1] and [V2])
 - Search optimisation for inverted index and ArangoSearch
+- Support for optimizer rules in AQL query
 
 ## [1.5.2](https://github.com/arangodb/go-driver/tree/v1.5.2) (2023-03-01)
 - Bump `DRIVER_VERSION`

--- a/test/doc.go
+++ b/test/doc.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// Copyright 2018-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,10 +17,33 @@
 //
 // Copyright holder is ArangoDB GmbH, Cologne, Germany
 //
-// Author Ewout Prangsma
-//
 
-/*
-Package test implements add tests for the go-driver.
-*/
 package test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/arangodb/go-driver"
+)
+
+// CreateDocuments creates given number of documents for the provided collection.
+func CreateDocuments(ctx context.Context, col driver.Collection, docCount int, generator func(i int) any) error {
+	if generator == nil {
+		return errors.New("document generator can not be nil")
+	}
+	if col == nil {
+		return errors.New("collection can not be nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	docs := make([]any, 0, docCount)
+	for i := 0; i < docCount; i++ {
+		docs = append(docs, generator(i))
+	}
+
+	_, _, err := col.CreateDocuments(ctx, docs)
+	return err
+}

--- a/v2/arangodb/cursor.go
+++ b/v2/arangodb/cursor.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+// Copyright 2020-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 // limitations under the License.
 //
 // Copyright holder is ArangoDB GmbH, Cologne, Germany
-//
-// Author Adam Janikowski
 //
 
 package arangodb
@@ -52,6 +50,9 @@ type Cursor interface {
 	// Statistics returns the query execution statistics for this cursor.
 	// This might not be valid if the cursor has been created with `Stream`
 	Statistics() CursorStats
+
+	// Plan returns the query execution plan for this cursor.
+	Plan() CursorPlan
 }
 
 // CursorStats TODO: all these int64 should be changed into uint64
@@ -97,5 +98,48 @@ type cursorData struct {
 	HasMore bool       `json:"hasMore,omitempty"` // A boolean indicator whether there are more results available for the cursor on the server
 	Extra   struct {
 		Stats CursorStats `json:"stats,omitempty"`
+		// Plan describes plan for a cursor.
+		Plan CursorPlan `json:"plan,omitempty"`
 	} `json:"extra"`
+}
+
+// CursorPlan describes execution plan for a query.
+type CursorPlan struct {
+	// Nodes describes a nested list of the execution plan nodes.
+	Nodes []CursorPlanNodes `json:"nodes,omitempty"`
+	// Rules describes a list with the names of the applied optimizer rules.
+	Rules []string `json:"rules,omitempty"`
+	// Collections describes list of the collections involved in the query.
+	Collections []CursorPlanCollection `json:"collections,omitempty"`
+	// Variables describes list of variables involved in the query.
+	Variables []CursorPlanVariable `json:"variables,omitempty"`
+	// EstimatedCost is an estimated cost of the query.
+	EstimatedCost float64 `json:"estimatedCost,omitempty"`
+	// EstimatedNrItems is an estimated number of results.
+	EstimatedNrItems int `json:"estimatedNrItems,omitempty"`
+	// IsModificationQuery describes whether the query contains write operations.
+	IsModificationQuery bool `json:"isModificationQuery,omitempty"`
+}
+
+// CursorPlanNodes describes map of nodes which take part in the execution.
+type CursorPlanNodes map[string]interface{}
+
+// CursorPlanCollection describes a collection involved in the query.
+type CursorPlanCollection struct {
+	// Name is a name of collection.
+	Name string `json:"name"`
+	// Type describes how the collection is used: read, write or exclusive.
+	Type string `json:"type"`
+}
+
+// CursorPlanVariable describes variable's settings.
+type CursorPlanVariable struct {
+	// ID is a variable's id.
+	ID int `json:"id"`
+	// Name is a variable's name.
+	Name string `json:"name"`
+	// IsDataFromCollection is set to true when data comes from a collection.
+	IsDataFromCollection bool `json:"isDataFromCollection"`
+	// IsFullDocumentFromCollection is set to true when all data comes from a collection.
+	IsFullDocumentFromCollection bool `json:"isFullDocumentFromCollection"`
 }

--- a/v2/arangodb/cursor_impl.go
+++ b/v2/arangodb/cursor_impl.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+// Copyright 2020-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 // limitations under the License.
 //
 // Copyright holder is ArangoDB GmbH, Cologne, Germany
-//
-// Author Adam Janikowski
 //
 
 package arangodb
@@ -157,4 +155,9 @@ func (c *cursor) Count() int64 {
 
 func (c *cursor) Statistics() CursorStats {
 	return c.data.Extra.Stats
+}
+
+// Plan returns the query execution plan for this cursor.
+func (c *cursor) Plan() CursorPlan {
+	return c.data.Extra.Plan
 }

--- a/v2/arangodb/database_query.go
+++ b/v2/arangodb/database_query.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+// Copyright 2020-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 // limitations under the License.
 //
 // Copyright holder is ArangoDB GmbH, Cologne, Germany
-//
-// Author Adam Janikowski
 //
 
 package arangodb
@@ -41,12 +39,14 @@ type DatabaseQuery interface {
 type QuerySubOptions struct {
 	// ShardId query option
 	ShardIds []string `json:"shardIds,omitempty"`
-	// If set to true, then the additional query profiling information will be returned in the sub-attribute profile of the
-	// extra return attribute if the query result is not served from the query cache.
-	Profile bool `json:"profile,omitempty"`
-	// A list of to-be-included or to-be-excluded optimizer rules can be put into this attribute, telling the optimizer to include or exclude specific rules.
-	// To disable a rule, prefix its name with a -, to enable a rule, prefix it with a +. There is also a pseudo-rule all, which will match all optimizer rules.
-	OptimizerRules string `json:"optimizer.rules,omitempty"`
+	// Profile If set to 1, then the additional query profiling information is returned in the profile sub-attribute
+	// of the extra return attribute, unless the query result is served from the query cache.
+	// If set to 2, the query includes execution stats per query plan node in stats.nodes
+	// sub-attribute of the extra return attribute.
+	// Additionally, the query plan is returned in the extra.plan sub-attribute.
+	Profile uint `json:"profile,omitempty"`
+	// Optimizer contains options related to the query optimizer.
+	Optimizer QuerySubOptionsOptimizer `json:"optimizer,omitempty"`
 	// This Enterprise Edition parameter allows to configure how long a DBServer will have time to bring the satellite collections
 	// involved in the query into sync. The default value is 60.0 (seconds). When the max time has been reached the query will be stopped.
 	SatelliteSyncWait float64 `json:"satelliteSyncWait,omitempty"`
@@ -97,6 +97,15 @@ type QueryOptions struct {
 	// key/value pairs representing the bind parameters.
 	BindVars map[string]interface{} `json:"bindVars,omitempty"`
 	Options  QuerySubOptions        `json:"options,omitempty"`
+}
+
+// QuerySubOptionsOptimizer describes optimization's settings for AQL queries.
+type QuerySubOptionsOptimizer struct {
+	// A list of to-be-included or to-be-excluded optimizer rules can be put into this attribute,
+	// telling the optimizer to include or exclude specific rules.
+	// To disable a rule, prefix its name with a -, to enable a rule, prefix it with a +.
+	// There is also a pseudo-rule all, which will match all optimizer rules.
+	Rules []string `json:"rules,omitempty"`
 }
 
 type QueryRequest struct {

--- a/v2/arangodb/utils.go
+++ b/v2/arangodb/utils.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2020 ArangoDB GmbH, Cologne, Germany
+// Copyright 2020-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,13 +17,12 @@
 //
 // Copyright holder is ArangoDB GmbH, Cologne, Germany
 //
-// Author Adam Janikowski
-//
 
 package arangodb
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"reflect"
@@ -146,4 +145,25 @@ func (j *jsonReader) HasMore() bool {
 		return false
 	}
 	return j.inStream.More()
+}
+
+// CreateDocuments creates given number of documents for the provided collection.
+func CreateDocuments(ctx context.Context, col Collection, docCount int, generator func(i int) any) error {
+	if generator == nil {
+		return errors.New("document generator can not be nil")
+	}
+	if col == nil {
+		return errors.New("collection can not be nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	docs := make([]any, 0, docCount)
+	for i := 0; i < docCount; i++ {
+		docs = append(docs, generator(i))
+	}
+
+	_, err := col.CreateDocuments(ctx, docs)
+	return err
 }


### PR DESCRIPTION
- Fix optimizers rules options
- Users can set optimizers rules
- Add support for plan cursor in v2