### PR TITLE
BTS-1049 Update ArangoSearch tests (nearest_neighbors, classification)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ services:
 
 language: go
 go:
-  - 1.20.3
+  - 1.20.5
 
 env:
   jobs:
@@ -42,7 +42,7 @@ env:
     - TEST_SUITE=run-v2-tests-resilientsingle
   global:
     - ARANGODB=gcr.io/gcr-for-testing/arangodb/enterprise-preview:3.11.1
-    - GOIMAGE=gcr.io/gcr-for-testing/golang:1.20.3
+    - GOIMAGE=gcr.io/gcr-for-testing/golang:1.20.5
     - ALPINE_IMAGE=gcr.io/gcr-for-testing/alpine:3.17
     - STARTER=gcr.io/gcr-for-testing/arangodb/arangodb-starter:0.15.7
     - TEST_DISALLOW_UNKNOWN_FIELDS=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ env:
     - TEST_SUITE=run-v2-tests-cluster
     - TEST_SUITE=run-v2-tests-resilientsingle
   global:
-    - ARANGODB=gcr.io/gcr-for-testing/arangodb/enterprise-preview:3.11.0-beta.1
+    - ARANGODB=gcr.io/gcr-for-testing/arangodb/enterprise-preview:3.11.1
     - GOIMAGE=gcr.io/gcr-for-testing/golang:1.20.3
     - ALPINE_IMAGE=gcr.io/gcr-for-testing/alpine:3.17
     - STARTER=gcr.io/gcr-for-testing/arangodb/arangodb-starter:0.15.7

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SCRIPTDIR := $(shell pwd)
 CURR=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 ROOTDIR:=$(CURR)
 
-GOVERSION ?= 1.20.3
+GOVERSION ?= 1.20.5
 GOIMAGE ?= golang:$(GOVERSION)
 GOV2IMAGE ?= $(GOIMAGE)
 ALPINE_IMAGE ?= alpine:3.17

--- a/test/arangosearch_analyzers_test.go
+++ b/test/arangosearch_analyzers_test.go
@@ -384,6 +384,24 @@ func TestArangoSearchAnalyzerEnsureAnalyzer(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:       "create-classificationPermalink",
+			MinVersion: newVersion("3.10.0"),
+			Definition: driver.ArangoSearchAnalyzerDefinition{
+				Name: "classification",
+				Type: driver.ArangoSearchAnalyzerTypeClassification,
+			},
+			EnterpriseOnly: true,
+		},
+		{
+			Name:       "create-NN",
+			MinVersion: newVersion("3.10.0"),
+			Definition: driver.ArangoSearchAnalyzerDefinition{
+				Name: "nearestNeighbors",
+				Type: driver.ArangoSearchAnalyzerTypeNearestNeighbors,
+			},
+			EnterpriseOnly: true,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/view_arangosearch.go
+++ b/view_arangosearch.go
@@ -89,7 +89,7 @@ const (
 	ArangoSearchAnalyzerFeatureNorm ArangoSearchAnalyzerFeature = "norm"
 	// ArangoSearchAnalyzerFeaturePosition sequentially increasing term position, required for PHRASE(). If present then the frequency feature is also required
 	ArangoSearchAnalyzerFeaturePosition ArangoSearchAnalyzerFeature = "position"
-	// ArangoSearchAnalyzerFeatureOffset can be specified if 'position' feature is set
+	// ArangoSearchAnalyzerFeatureOffset can be specified if 'position' and 'frequency' features are set (Enterprise Edition only)
 	ArangoSearchAnalyzerFeatureOffset ArangoSearchAnalyzerFeature = "offset"
 )
 

--- a/view_arangosearch.go
+++ b/view_arangosearch.go
@@ -89,7 +89,7 @@ const (
 	ArangoSearchAnalyzerFeatureNorm ArangoSearchAnalyzerFeature = "norm"
 	// ArangoSearchAnalyzerFeaturePosition sequentially increasing term position, required for PHRASE(). If present then the frequency feature is also required
 	ArangoSearchAnalyzerFeaturePosition ArangoSearchAnalyzerFeature = "position"
-	// ArangoSearchAnalyzerFeatureOffset can be specified if 'position' and 'frequency' features are set (Enterprise Edition only)
+	// ArangoSearchAnalyzerFeatureOffset can be specified only when 'position' and 'frequency' features are set (Enterprise Edition only)
 	ArangoSearchAnalyzerFeatureOffset ArangoSearchAnalyzerFeature = "offset"
 )
 


### PR DESCRIPTION
This fills the gap created by the tests removed in: https://github.com/arangodb/go-driver/commit/57324d3d3f891a021df2aee0555c24a15c4e564a