### PR TITLE
Fix race when using WithRawResponse/WithResponse context with agencyConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
 - Add support for getting license
 - Add support for Raw Authentication in VST (support external jwt token as raw element)
+- Fix race when using WithRawResponse/WithResponse context with agencyConnection 
 
 ## [1.6.0](https://github.com/arangodb/go-driver/tree/v1.6.0) (2023-05-30)
 - Add ErrArangoDatabaseNotFound and IsExternalStorageError helper to v2


### PR DESCRIPTION
When using Cluster mode, the client can see unexpected behavior when passing `WithRawResponse(ctx, value)` context:

agencyConnection sends requests in parallel goroutines. That results in race condition: the rawResponse might not match to the returned response.
e.g that can happen when one agent returns a normal response (200 with non-empty body) but other agent returns status 307 (redirect to leader with empty body). In result user will get body from first response but rawResponse value will be set to empty.


The PR changes behavior such that agency connection will not run requests in parallel when user specifies WithRawResponse/WithResponse options.
