### PR TITLE
[V1] Revert ReturnOld for edge/vertex operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [V2] Add support for missing query options (create documents, remove collection, remove view)
 - [V2] Adjust CursorStats and JournalSize types
 - [V1] Deprecate `AllowInconsistent` in HotBackup
+- [V1] Revert ReturnOld for edge/vertex operations
 
 ## [1.6.0](https://github.com/arangodb/go-driver/tree/v1.6.0) (2023-05-30)
 - Add ErrArangoDatabaseNotFound and IsExternalStorageError helper to v2

--- a/edge_collection_documents_impl.go
+++ b/edge_collection_documents_impl.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+// Copyright 2017-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 // limitations under the License.
 //
 // Copyright holder is ArangoDB GmbH, Cologne, Germany
-//
-// Author Ewout Prangsma
 //
 
 package driver
@@ -485,9 +483,6 @@ func (c *edgeCollection) removeDocument(ctx context.Context, key string) (Docume
 		return DocumentMeta{}, contextSettings{}, WithStack(err)
 	}
 	cs := applyContextSettings(ctx, req)
-	if cs.ReturnOld != nil {
-		return DocumentMeta{}, contextSettings{}, WithStack(InvalidArgumentError{Message: "ReturnOld is not supported when removing edges"})
-	}
 	resp, err := c.conn.Do(ctx, req)
 	if err != nil {
 		return DocumentMeta{}, cs, WithStack(err)

--- a/test/edge_remove_test.go
+++ b/test/edge_remove_test.go
@@ -24,6 +24,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	driver "github.com/arangodb/go-driver"
 )
 
@@ -79,14 +81,16 @@ func TestRemoveEdgeReturnOld(t *testing.T) {
 		Distance: 32,
 	}
 	meta, err := ec.CreateDocument(ctx, doc)
-	if err != nil {
-		t.Fatalf("Failed to create new document: %s", describe(err))
-	}
+	require.NoError(t, err)
+
 	var old RouteEdge
 	ctx = driver.WithReturnOld(ctx, &old)
-	if _, err := ec.RemoveDocument(ctx, meta.Key); !driver.IsInvalidArgument(err) {
-		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
+
+	_, err = ec.RemoveDocument(ctx, meta.Key)
+	require.NoError(t, err)
+
+	// Check an old document
+	require.Equal(t, doc, old)
 }
 
 // TestRemoveEdgeSilent creates a document, removes it with Silent() and then checks the meta is indeed empty.

--- a/test/edges_remove_test.go
+++ b/test/edges_remove_test.go
@@ -24,6 +24,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	driver "github.com/arangodb/go-driver"
 )
 
@@ -115,14 +117,12 @@ func TestRemoveEdgesReturnOld(t *testing.T) {
 	oldDocs := make([]RouteEdge, len(docs))
 	ctx = driver.WithReturnOld(ctx, oldDocs)
 	_, errs, err = ec.RemoveDocuments(ctx, metas.Keys())
-	if err != nil {
-		t.Fatalf("Failed to remove documents: %s", describe(err))
-	}
-	// Check errors
-	for i, err := range errs {
-		if !driver.IsInvalidArgument(err) {
-			t.Fatalf("Expected InvalidArgumentError at %d, got  %s", i, describe(err))
-		}
+	require.Nil(t, err)
+	require.NoError(t, errs.FirstNonNil())
+
+	// Check old documents
+	for i, doc := range docs {
+		require.Equal(t, doc, oldDocs[i])
 	}
 }
 

--- a/test/vertex_remove_test.go
+++ b/test/vertex_remove_test.go
@@ -24,6 +24,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	driver "github.com/arangodb/go-driver"
 )
 
@@ -73,14 +75,15 @@ func TestRemoveVertexReturnOld(t *testing.T) {
 		Title: "Testing 101",
 	}
 	meta, err := vc.CreateDocument(ctx, doc)
-	if err != nil {
-		t.Fatalf("Failed to create new document: %s", describe(err))
-	}
+	require.NoError(t, err)
+
 	var old Book
 	ctx = driver.WithReturnOld(ctx, &old)
-	if _, err := vc.RemoveDocument(ctx, meta.Key); !driver.IsInvalidArgument(err) {
-		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
+	_, err = vc.RemoveDocument(ctx, meta.Key)
+	require.NoError(t, err)
+
+	// Check an old document
+	require.Equal(t, doc, old)
 }
 
 // TestRemoveVertexSilent creates a document, removes it with Silent() and then checks the meta is indeed empty.

--- a/test/vertices_remove_test.go
+++ b/test/vertices_remove_test.go
@@ -24,6 +24,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	driver "github.com/arangodb/go-driver"
 )
 
@@ -85,22 +87,18 @@ func TestRemoveVerticesReturnOld(t *testing.T) {
 		},
 	}
 	metas, errs, err := vc.CreateDocuments(ctx, docs)
-	if err != nil {
-		t.Fatalf("Failed to create new document: %s", describe(err))
-	} else if err := errs.FirstNonNil(); err != nil {
-		t.Fatalf("Expected no errors, got first: %s", describe(err))
-	}
+	require.NoError(t, err)
+	require.NoError(t, errs.FirstNonNil())
+
 	oldDocs := make([]Book, len(docs))
 	ctx = driver.WithReturnOld(ctx, oldDocs)
 	_, errs, err = vc.RemoveDocuments(ctx, metas.Keys())
-	if err != nil {
-		t.Fatalf("Failed to remove documents: %s", describe(err))
-	}
-	// Check errors
-	for i, err := range errs {
-		if !driver.IsInvalidArgument(err) {
-			t.Fatalf("Expected InvalidArgumentError at %d, got  %s", i, describe(err))
-		}
+	require.NoError(t, err)
+	require.NoError(t, errs.FirstNonNil())
+
+	// Check old documents
+	for i, doc := range docs {
+		require.Equal(t, doc, oldDocs[i])
 	}
 }
 

--- a/vertex_collection_documents_impl.go
+++ b/vertex_collection_documents_impl.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2017 ArangoDB GmbH, Cologne, Germany
+// Copyright 2017-2023 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 // limitations under the License.
 //
 // Copyright holder is ArangoDB GmbH, Cologne, Germany
-//
-// Author Ewout Prangsma
 //
 
 package driver
@@ -484,9 +482,6 @@ func (c *vertexCollection) removeDocument(ctx context.Context, key string) (Docu
 		return DocumentMeta{}, contextSettings{}, WithStack(err)
 	}
 	cs := applyContextSettings(ctx, req)
-	if cs.ReturnOld != nil {
-		return DocumentMeta{}, contextSettings{}, WithStack(InvalidArgumentError{Message: "ReturnOld is not support when removing vertices"})
-	}
 	resp, err := c.conn.Do(ctx, req)
 	if err != nil {
 		return DocumentMeta{}, cs, WithStack(err)


### PR DESCRIPTION
It's reverting https://github.com/arangodb/go-driver/pull/92/files since Return old in edge/vertex operations is working fine since 3.8