### PR TITLE
Deprecate ClientConfig.SynchronizeEndpointsInterval due to bug in implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [V2] Agency: Supply ClientID with agency transactions
 - Bugfix: Force analyzer removal
 - Move examples to separate package
+- Deprecate ClientConfig.SynchronizeEndpointsInterval due to bug in implementation
 
 ## [1.6.0](https://github.com/arangodb/go-driver/tree/v1.6.0) (2023-05-30)
 - Add ErrArangoDatabaseNotFound and IsExternalStorageError helper to v2

--- a/client.go
+++ b/client.go
@@ -112,6 +112,8 @@ type ClientConfig struct {
 	Connection Connection
 	// Authentication implements authentication on the server.
 	Authentication Authentication
+
+	// Deprecated: using non-zero duration causes routine leak. Please create your own implementation using Client.SynchronizeEndpoints2
 	// SynchronizeEndpointsInterval is the interval between automatic synchronization of endpoints.
 	// If this value is 0, no automatic synchronization is performed.
 	// If this value is > 0, automatic synchronization is started on a go routine.

--- a/client_impl.go
+++ b/client_impl.go
@@ -106,6 +106,7 @@ func (c *client) SynchronizeEndpoints2(ctx context.Context, dbname string) error
 	return nil
 }
 
+// Deprecated: should not be called in new code.
 // autoSynchronizeEndpoints performs automatic endpoint synchronization.
 func (c *client) autoSynchronizeEndpoints(interval time.Duration) {
 	for {

--- a/client_test.go
+++ b/client_test.go
@@ -45,7 +45,8 @@ func TestNewClient(t *testing.T) {
 	var clients = make(map[int]driver.Client)
 
 	before := runtime.NumGoroutine()
-	for i := 0; i < 30; i++ {
+	const iterations = 30
+	for i := 0; i < iterations; i++ {
 		c, err := driver.NewClient(cfg)
 		require.NoError(t, err, "iter %d", i)
 
@@ -53,5 +54,8 @@ func TestNewClient(t *testing.T) {
 	}
 
 	after := runtime.NumGoroutine()
-	require.Less(t, after-before, 32)
+
+	// SynchronizeEndpointsInterval feature has a bug where new go-routine would be created per each call to NewClient
+	// This feature should not be used. The test is present here only to document this behaviour.
+	require.Equal(t, after-before, iterations)
 }


### PR DESCRIPTION

There is no clean way to fix that implementation without introducing NewClient2 function which might be very confusing.