### PR TITLE
GT-376 Restore tests for silent doc removal

### DIFF
--- a/v2/tests/database_collection_doc_create_test.go
+++ b/v2/tests/database_collection_doc_create_test.go
@@ -281,8 +281,7 @@ func Test_DatabaseCollectionDocCreateSilent(t *testing.T) {
 		WithDatabase(t, client, nil, func(db arangodb.Database) {
 			WithCollection(t, db, nil, func(col arangodb.Collection) {
 				withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
-					// TODO cluster mode is broken https://arangodb.atlassian.net/browse/BTS-1302
-					requireSingleMode(t)
+					skipBelowVersion(client, ctx, "3.12", t)
 
 					doc := DocWithRev{
 						Name: "test-silent",

--- a/v2/tests/database_collection_doc_delete_test.go
+++ b/v2/tests/database_collection_doc_delete_test.go
@@ -293,8 +293,7 @@ func Test_DatabaseCollectionDocDeleteSilent(t *testing.T) {
 		WithDatabase(t, client, nil, func(db arangodb.Database) {
 			WithCollection(t, db, nil, func(col arangodb.Collection) {
 				withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
-					// TODO cluster mode is broken https://arangodb.atlassian.net/browse/BTS-1302
-					requireSingleMode(t)
+					skipBelowVersion(client, ctx, "3.12", t)
 
 					doc := DocWithRev{
 						Name: "test-silent",

--- a/v2/tests/database_collection_doc_replace_test.go
+++ b/v2/tests/database_collection_doc_replace_test.go
@@ -129,8 +129,7 @@ func Test_DatabaseCollectionDocReplaceSilent(t *testing.T) {
 		WithDatabase(t, client, nil, func(db arangodb.Database) {
 			WithCollection(t, db, nil, func(col arangodb.Collection) {
 				withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
-					// TODO cluster mode is broken https://arangodb.atlassian.net/browse/BTS-1302
-					requireSingleMode(t)
+					skipBelowVersion(client, ctx, "3.12", t)
 
 					doc := DocWithRev{
 						Name: "test-silent",

--- a/v2/tests/database_collection_doc_update_test.go
+++ b/v2/tests/database_collection_doc_update_test.go
@@ -273,8 +273,7 @@ func Test_DatabaseCollectionDocUpdateSilent(t *testing.T) {
 		WithDatabase(t, client, nil, func(db arangodb.Database) {
 			WithCollection(t, db, nil, func(col arangodb.Collection) {
 				withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
-					// TODO cluster mode is broken https://arangodb.atlassian.net/browse/BTS-1302
-					requireSingleMode(t)
+					skipBelowVersion(client, ctx, "3.12", t)
 
 					doc := DocWithRev{
 						Name: "test-silent",


### PR DESCRIPTION
Silent removal has been fixed for cluster mode in 3.12