### PR TITLE
Make v2 tests less aggressive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ ifdef RACE
 	CGO_ENABLED=1
 endif
 
+TESTV2PARALLEL ?= 8
 
 ORGPATH := github.com/arangodb
 REPONAME := $(PROJECT)
@@ -137,7 +138,7 @@ ifeq ("$(DEBUG)", "true")
 	DOCKER_V2_RUN_CMD := $(DOCKER_RUN_CMD)
 else
     DOCKER_RUN_CMD := $(GOIMAGE) go test -timeout 120m $(GOBUILDTAGSOPT) $(TESTOPTIONS) $(TESTVERBOSEOPTIONS) $(TESTS)
-    DOCKER_V2_RUN_CMD := $(GOV2IMAGE) go test -timeout 120m $(GOBUILDTAGSOPT) $(TESTOPTIONS) $(TESTVERBOSEOPTIONS) ./tests
+    DOCKER_V2_RUN_CMD := $(GOV2IMAGE) go test -timeout 120m $(GOBUILDTAGSOPT) $(TESTOPTIONS) $(TESTVERBOSEOPTIONS) -test.parallel $(TESTV2PARALLEL) ./tests
 endif
 
 .PHONY: all build clean linter run-tests vulncheck


### PR DESCRIPTION
Currently it is DDoSing the arangod in single and active failover mode such that arangod can't handle the creation of  all DBs/Collections (it tries to update user permissions but fails after 10 attempts). This happens on nodes with high number of cores, e.g. 36 because default value of parallelism is GOMAXPROCS(=Num of cores)

It does not happen with v1 tests because we don't try to execute so many tests in parallel there.