### PR TITLE
OAS-10368 Grab Agenecy dump on test failures in go-driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,11 @@ else ifeq ("$(TEST_AUTH)", "jwt")
 	ARANGOARGS := --server.jwt-secret=/jwtsecret
 endif
 
-TEST_NET := --net=container:$(TESTCONTAINER)-ns
+TEST_NET := --net=host
+
+ifndef DUMP_ON_FAILURE
+	DUMP_ON_FAILURE := 0
+endif
 
 # By default we run tests against single endpoint to avoid problems with data propagation in Cluster mode
 # e.g. when we create a document in one endpoint, it may not be visible in another endpoint for a while
@@ -118,7 +122,6 @@ ifeq ("$(TEST_BENCHMARK)", "true")
 endif
 
 ifdef TEST_ENDPOINTS_OVERRIDE
-	TEST_NET := --net=host
 	TEST_ENDPOINTS := $(TEST_ENDPOINTS_OVERRIDE)
 endif
 
@@ -391,68 +394,63 @@ run-tests-cluster-vst-1.1-ssl:
 	@echo "Cluster server, Velocystream 1.1, SSL, with authentication"
 	@${MAKE} TEST_MODE="cluster" TEST_AUTH="rootpw" TEST_SSL="auto" TEST_CONNECTION="vst" TEST_CVERSION="1.1" __run_tests
 
+
+COMMON_DOCKER_CMD_PARAMS = \
+	--name=$(TESTCONTAINER) \
+	$(TEST_NET) \
+	-e TEST_ENDPOINTS=$(TEST_ENDPOINTS) \
+	-e TEST_NOT_WAIT_UNTIL_READY=$(TEST_NOT_WAIT_UNTIL_READY) \
+	-e TEST_AUTHENTICATION=$(TEST_AUTHENTICATION) \
+	-e TEST_JWTSECRET=$(TEST_JWTSECRET) \
+	-e TEST_MODE=$(TEST_MODE) \
+	-e TEST_BACKUP_REMOTE_REPO=$(TEST_BACKUP_REMOTE_REPO) \
+	-e TEST_BACKUP_REMOTE_CONFIG='$(TEST_BACKUP_REMOTE_CONFIG)' \
+	-e TEST_DEBUG='$(TEST_DEBUG)' \
+	-e TEST_ENABLE_SHUTDOWN=$(TEST_ENABLE_SHUTDOWN) \
+	-e ENABLE_DATABASE_EXTRA_FEATURES=$(ENABLE_DATABASE_EXTRA_FEATURES) \
+	-e GODEBUG=tls13=1 \
+	-e CGO_ENABLED=$(CGO_ENABLED)
+
+
 # Internal test tasks
 __run_tests: __test_debug__ __test_prepare __test_go_test __test_cleanup
 
+
+ALL_DOCKER_CMD_PARAMS=\
+	$(COMMON_DOCKER_CMD_PARAMS) \
+	-e TEST_CONNECTION=$(TEST_CONNECTION) \
+	-e TEST_CVERSION=$(TEST_CVERSION) \
+	-e TEST_CONTENT_TYPE=$(TEST_CONTENT_TYPE) \
+	-e TEST_PPROF=$(TEST_PPROF) \
+	-e TEST_REQUEST_LOG=$(TEST_REQUEST_LOG) \
+	-e TEST_DISALLOW_UNKNOWN_FIELDS=$(TEST_DISALLOW_UNKNOWN_FIELDS) \
+	-v "${ROOTDIR}":/usr/code ${TEST_RESOURCES_VOLUME} \
+	-w /usr/code/
+
 __test_go_test:
-	$(DOCKER_CMD) \
-		--name=$(TESTCONTAINER) \
-		$(TEST_NET) \
-		-v "${ROOTDIR}":/usr/code ${TEST_RESOURCES_VOLUME} \
-		-e TEST_ENDPOINTS=$(TEST_ENDPOINTS) \
-		-e TEST_NOT_WAIT_UNTIL_READY=$(TEST_NOT_WAIT_UNTIL_READY) \
-		-e TEST_AUTHENTICATION=$(TEST_AUTHENTICATION) \
-		-e TEST_JWTSECRET=$(TEST_JWTSECRET) \
-		-e TEST_CONNECTION=$(TEST_CONNECTION) \
-		-e TEST_CVERSION=$(TEST_CVERSION) \
-		-e TEST_CONTENT_TYPE=$(TEST_CONTENT_TYPE) \
-		-e TEST_PPROF=$(TEST_PPROF) \
-		-e TEST_MODE=$(TEST_MODE) \
-		-e TEST_BACKUP_REMOTE_REPO=$(TEST_BACKUP_REMOTE_REPO) \
-		-e TEST_BACKUP_REMOTE_CONFIG='$(TEST_BACKUP_REMOTE_CONFIG)' \
-		-e TEST_DEBUG='$(TEST_DEBUG)' \
-		-e TEST_ENABLE_SHUTDOWN=$(TEST_ENABLE_SHUTDOWN) \
-		-e TEST_REQUEST_LOG=$(TEST_REQUEST_LOG) \
-		-e TEST_DISALLOW_UNKNOWN_FIELDS=$(TEST_DISALLOW_UNKNOWN_FIELDS) \
-		-e ENABLE_DATABASE_EXTRA_FEATURES=$(ENABLE_DATABASE_EXTRA_FEATURES) \
-		-e GODEBUG=tls13=1 \
-		-e CGO_ENABLED=$(CGO_ENABLED) \
-		-w /usr/code/ \
-		$(DOCKER_RUN_CMD) && echo "success!" || ( \
-			echo "failure! \n\nARANGODB-STARTER logs:"; \
-			docker logs ${TESTCONTAINER}-s; \
-			echo "\nARANGODB logs:"; \
-			docker ps -f name=${TESTCONTAINER}-s- -q | xargs -L 1 docker logs; \
-			echo "\nV1 Tests with ARGS: TEST_MODE=${TEST_MODE} TEST_AUTH=${TEST_AUTH} TEST_CONTENT_TYPE=${TEST_CONTENT_TYPE} TEST_SSL=${TEST_SSL} TEST_CONNECTION=${TEST_CONNECTION} TEST_CVERSION=${TEST_CVERSION}\n\n"; \
-			exit 1)
+	$(DOCKER_CMD) $(ALL_DOCKER_CMD_PARAMS) $(DOCKER_RUN_CMD) \
+	&& echo "success!" \
+	|| ( \
+		$(foreach var,$(sort $(.VARIABLES)),$(eval export $(var)=$($(var)))) \
+		MAJOR_VERSION=1 . ./test/on_failure.sh \
+	)
+
+			
 # Internal test tasks
 __run_v2_tests: __test_v2_debug__ __test_prepare __test_v2_go_test __test_cleanup
 
+ALL_DOCKER_CMD_V2_PARAMS=\
+	$(COMMON_DOCKER_CMD_PARAMS) \
+	-v "${ROOTDIR}":/usr/code:ro ${TEST_RESOURCES_VOLUME} \
+	-w /usr/code/v2/
+
 __test_v2_go_test:
-	$(DOCKER_CMD) \
-		--name=$(TESTCONTAINER) \
-		$(TEST_NET) \
-		-v "${ROOTDIR}":/usr/code:ro ${TEST_RESOURCES_VOLUME} \
-		-e TEST_ENDPOINTS=$(TEST_ENDPOINTS) \
-		-e TEST_NOT_WAIT_UNTIL_READY=$(TEST_NOT_WAIT_UNTIL_READY) \
-		-e TEST_AUTHENTICATION=$(TEST_AUTHENTICATION) \
-		-e TEST_JWTSECRET=$(TEST_JWTSECRET) \
-		-e TEST_MODE=$(TEST_MODE) \
-		-e TEST_BACKUP_REMOTE_REPO=$(TEST_BACKUP_REMOTE_REPO) \
-		-e TEST_BACKUP_REMOTE_CONFIG='$(TEST_BACKUP_REMOTE_CONFIG)' \
-		-e TEST_DEBUG='$(TEST_DEBUG)' \
-		-e TEST_ENABLE_SHUTDOWN=$(TEST_ENABLE_SHUTDOWN) \
-		-e ENABLE_DATABASE_EXTRA_FEATURES=$(ENABLE_DATABASE_EXTRA_FEATURES) \
-		-e GODEBUG=tls13=1 \
-		-e CGO_ENABLED=$(CGO_ENABLED) \
-		-w /usr/code/v2/ \
-		$(DOCKER_V2_RUN_CMD) && echo "success!" || ( \
-		    echo "failure! \n\nARANGODB-STARTER logs:"; \
-		    docker logs ${TESTCONTAINER}-s; \
-			echo "\nARANGODB logs:"; \
-			docker ps -f name=${TESTCONTAINER}-s- -q | xargs -L 1 docker logs; \
-			echo "\nV2 Tests with ARGS: TEST_MODE=${TEST_MODE} TEST_AUTH=${TEST_AUTH} TEST_CONTENT_TYPE=${TEST_CONTENT_TYPE} TEST_SSL=${TEST_SSL} TEST_CONNECTION=${TEST_CONNECTION} TEST_CVERSION=${TEST_CVERSION}\n\n"; \
-			exit 1)
+	$(DOCKER_CMD) $(ALL_DOCKER_CMD_V2_PARAMS) $(DOCKER_V2_RUN_CMD) \
+	&& echo "success!" \
+	|| ( \
+		$(foreach var,$(sort $(.VARIABLES)),$(eval export $(var)=$($(var)))) \
+		MAJOR_VERSION=2 . ./test/on_failure.sh \
+	)
 
 __test_debug__:
 ifeq ("$(DEBUG)", "true")
@@ -479,7 +477,7 @@ endif
 	@-docker rm -f -v $(TESTCONTAINER) &> /dev/null
 	@TESTCONTAINER=$(TESTCONTAINER) ARANGODB=$(ARANGODB) ALPINE_IMAGE=$(ALPINE_IMAGE) ENABLE_BACKUP=$(ENABLE_BACKUP) \
 	  ARANGO_LICENSE_KEY=$(ARANGO_LICENSE_KEY) STARTER=$(STARTER) STARTERMODE=$(TEST_MODE) TMPDIR="${TMPDIR}" \
-	  ENABLE_DATABASE_EXTRA_FEATURES=$(ENABLE_DATABASE_EXTRA_FEATURES) DEBUG_PORT=$(DEBUG_PORT) $(CLUSTERENV) "${ROOTDIR}/test/cluster.sh" start
+	  ENABLE_DATABASE_EXTRA_FEATURES=$(ENABLE_DATABASE_EXTRA_FEATURES) DEBUG_PORT=$(DEBUG_PORT) $(CLUSTERENV) DOCKER_NETWORK=${TEST_NET} "${ROOTDIR}/test/cluster.sh" start
 endif
 
 __test_cleanup:
@@ -488,7 +486,7 @@ ifdef TESTCONTAINER
 	@if [ -n "$$TESTCONTAINERS" ]; then docker rm -f -v $$(docker ps -a -q --filter="name=$(TESTCONTAINER)"); fi
 endif
 ifndef TEST_ENDPOINTS_OVERRIDE
-	@TESTCONTAINER=$(TESTCONTAINER) ARANGODB=$(ARANGODB) ALPINE_IMAGE=$(ALPINE_IMAGE) STARTER=$(STARTER) STARTERMODE=$(TEST_MODE) "${ROOTDIR}/test/cluster.sh" cleanup
+	@TESTCONTAINER=$(TESTCONTAINER) ARANGODB=$(ARANGODB) ALPINE_IMAGE=$(ALPINE_IMAGE) STARTER=$(STARTER) STARTERMODE=$(TEST_MODE) DOCKER_NETWORK=${TEST_NET} "${ROOTDIR}/test/cluster.sh" cleanup
 else
 	@-docker rm -f -v $(TESTCONTAINER) &> /dev/null
 endif

--- a/test/jwt.sh
+++ b/test/jwt.sh
@@ -1,0 +1,22 @@
+#!/bin/bash 
+
+IAT=$(date -u +%s)
+EXP=$(($IAT+36000))
+
+HEADER='{"alg":"HS256","typ":"JWT"}'
+PAYLOAD1='{"exp": '
+PAYLOAD2=', "iat":'
+PAYLOAD3=', "iss":"arangodb","server_id":"arangodb"}'
+PAYLOAD="$PAYLOAD1$EXP$PAYLOAD2$IAT$PAYLOAD3"
+
+PAYLOAD='{"iss":"arangodb","server_id":"arangodb"}'
+
+jwt_header=$(echo $(echo -n '{"alg":"HS256","typ":"JWT"}' | base64) | sed 's/ /_/g' | sed 's/+/-/g' | sed -E s/=+$//)
+payload=$(echo $(echo -n "${PAYLOAD}" | base64) | sed 's/ /_/g' | sed 's/+/-/g' |  sed -E s/=+$//)
+
+hexsecret=$(echo -n "$JWTSECRET" | xxd -p | paste -sd "")
+hmac_signature=$(echo $(echo -n "${jwt_header}.${payload}" |  openssl dgst -sha256 -mac HMAC -macopt hexkey:$hexsecret -binary | base64 ) | sed 's/\//_/g' | sed 's/+/-/g' | sed -E s/=+$//)
+
+# Create the full token
+jwt="${jwt_header}.${payload}.${hmac_signature}"
+echo $jwt

--- a/test/on_failure.sh
+++ b/test/on_failure.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+echo "failure!\n"
+
+echo "\nARANGODB-STARTER logs: "
+docker logs ${TESTCONTAINER}-s
+
+echo -n "\nARANGODB-S-* logs:"
+docker ps -f name=${TESTCONTAINER}-s- --format "{{.ID}} {{.Names}}" | xargs -L1 bash -c 'echo -e "\n\tLogs from $1:"; docker logs $0'
+
+if [ $DUMP_ON_FAILURE -eq 1 ] && [ "${TEST_MODE}" != "single" ]; then
+    echo "\nAgency dump..."
+    AGENCY_CONTATIONER_NAME='agent'
+    ANY_CONNECTION_HTTPS=$(docker ps -f name=${TESTCONTAINER}-s-${AGENCY_CONTATIONER_NAME}  --format '{{.Names}}'  | head -n 1 | sed -E 's/.*-([a-zA-Z0-9.-]+)-([0-9]+)$/https:\/\/\1:\2/')
+    LEADER_CONNECTION_SSL=$(curl -Lk --no-progress-meter $ANY_CONNECTION_HTTPS/_api/agency/config | jq -r '.configuration.pool[.leaderId]')
+    LEADER_CONNECTION_HTTPS=$(echo $LEADER_CONNECTION_SSL | sed 's/^ssl:\/\//https:\/\//')
+    DUMP_FOLDER_PATH=./arango_data_v$(cat ./v2/version/VERSION)
+    mkdir -p $DUMP_FOLDER_PATH
+    DUMP_FILE_PATH=$DUMP_FOLDER_PATH/FAIL_agency_dump-HTTP_VPACK.json
+    echo $(curl -Lk --no-progress-meter $LEADER_CONNECTION_HTTPS/_api/agency/state) > $DUMP_FILE_PATH
+    echo "Agency dump created at $(realpath $DUMP_FILE_PATH)"
+fi
+
+echo "\nV${MAJOR_VERSION} Tests with ARGS: TEST_MODE=${TEST_MODE} TEST_AUTH=${TEST_AUTH} TEST_CONTENT_TYPE=${TEST_CONTENT_TYPE} TEST_SSL=${TEST_SSL} TEST_CONNECTION=${TEST_CONNECTION} TEST_CVERSION=${TEST_CVERSION}";
+
+echo "\n"
+exit 1


### PR DESCRIPTION
Changes:
* Added agency dump when `DUMP_AGENCY_ON_FAILURE=<file_path>` to be saved in the fiile path
eg. `DUMP_AGENCY_ON_FAILURE=agency_dump.json make run-tests-cluster-vpack-no-auth` 

*  Made arangodb_starter start test containers in host network; `--net=host` instead of running an alpine container to serve that funciton

* Separated all functions that need to be executed when go-driver-test docker container returns any messages (fails) to a separete file `on_failure.sh`

Requirements
* needs `jq` installed on host in order to parse the JSON responses that are received from the database API when creating agency dumps.