### PR TITLE
OAS-10536 Go-Driver shouldn't trigger unmarshaling error when the document contains fields 'code', 'error' etc.

### DIFF
--- a/v2/arangodb/collection_documents_read_impl.go
+++ b/v2/arangodb/collection_documents_read_impl.go
@@ -79,9 +79,8 @@ func (c collectionDocumentRead) ReadDocumentWithOptions(ctx context.Context, key
 		DocumentMeta          `json:",inline"`
 	}
 
-	data := newUnmarshalInto(result)
-
-	resp, err := connection.CallGet(ctx, c.collection.connection(), url, newMultiUnmarshaller(&response, data), c.collection.withModifiers(opts.modifyRequest)...)
+	orderedMultiUnmarshaller := newOrderedMultiUnmarshaller(newUnmarshalInto(&response), newUnmarshalInto(result))
+	resp, err := connection.CallGet(ctx, c.collection.connection(), url, orderedMultiUnmarshaller, c.collection.withModifiers(opts.modifyRequest)...)
 	if err != nil {
 		return DocumentMeta{}, err
 	}

--- a/v2/tests/collections_document_read_test.go
+++ b/v2/tests/collections_document_read_test.go
@@ -1,0 +1,112 @@
+//
+// DISCLAIMER
+//
+// Copyright 2023-2024 ArangoDB GmbH, Cologne, Germany
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arangodb/go-driver/v2/arangodb"
+	"github.com/arangodb/go-driver/v2/arangodb/shared"
+)
+
+func Test_CollectionDocumentsReadWithStringErrorCode(t *testing.T) {
+	Wrap(t, func(t *testing.T, client arangodb.Client) {
+		WithDatabase(t, client, nil, func(db arangodb.Database) {
+			WithCollection(t, db, nil, func(col arangodb.Collection) {
+				withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
+
+					type DocWithNoCode struct {
+						Rev  string `json:"_rev,omitempty"`
+						Key  string `json:"_key,omitempty"`
+						Name string `json:"name"`
+					}
+					doc_with_no_code := DocWithNoCode{
+						Name: "DocWithNoCode",
+					}
+					meta_with_no_code, err := col.CreateDocument(ctx, doc_with_no_code)
+					require.NoError(t, err)
+
+					type DocWithCode struct {
+						Rev  string `json:"_rev,omitempty"`
+						Key  string `json:"_key,omitempty"`
+						Name string `json:"name"`
+						Code string `json:"code"`
+					}
+					doc_with_code := DocWithCode{
+						Name: "DocWithCode",
+						Code: "777",
+					}
+					meta_with_code, err := col.CreateDocument(ctx, doc_with_code)
+					require.NoError(t, err)
+
+					type DocWithResponselike struct {
+						Rev          string `json:"_rev,omitempty"`
+						Key          string `json:"_key,omitempty"`
+						Name         string `json:"name"`
+						Error        bool   `json:"error,omitempty"`
+						Code         int    `json:"code,omitempty"`
+						ErrorMessage string `json:"errorMessage,omitempty"`
+						ErrorNum     int    `json:"errorNum,omitempty"`
+					}
+					doc_with_responselike := DocWithResponselike{
+						Name: "DocWithResponselike",
+						Code: 777,
+					}
+					meta_with_responselike, err := col.CreateDocument(ctx, doc_with_responselike)
+					require.NoError(t, err)
+
+					t.Run("sanity check, proper doc should have no error", func(t *testing.T) {
+						var docRead DocWithNoCode
+						_, err := col.ReadDocumentWithOptions(ctx, meta_with_no_code.Key, &docRead, nil)
+						require.NoError(t, err)
+					})
+					t.Run("sanity check, proper doc that doesn't exist should have error", func(t *testing.T) {
+						var docRead DocWithNoCode
+						_, err := col.ReadDocumentWithOptions(ctx, "404", &docRead, nil)
+						require.Error(t, err)
+						require.Equal(t, err.(shared.ArangoError).Code, 404)
+					})
+					t.Run("doc with code should have no error", func(t *testing.T) {
+						var docRead DocWithCode
+						_, err := col.ReadDocumentWithOptions(ctx, meta_with_code.Key, &docRead, nil)
+						require.NoError(t, err)
+						require.Equal(t, docRead.Code, "777")
+					})
+					t.Run("doc with code that doesn't exist should have error", func(t *testing.T) {
+						var docRead DocWithCode
+						_, err := col.ReadDocumentWithOptions(ctx, "404", &docRead, nil)
+						require.Error(t, err)
+						require.Equal(t, err.(shared.ArangoError).Code, 404)
+					})
+					t.Run("doc with responselike format should be doc", func(t *testing.T) {
+						var docRead DocWithResponselike
+						_, err := col.ReadDocumentWithOptions(ctx, meta_with_responselike.Key, &docRead, nil)
+						require.NoError(t, err)
+						require.Equal(t, docRead.Code, 777)
+					})
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
- Added orderedMultiUnmarshaller that unmarshalles into both interfaces independently raising an error only if all unmarshalings produce the error. Errors can be retrieved by GetError with index in order of the interfaces passed to orderedMultiUnmarshaller
- ReadDocumentWithOptions now uses orderedMultiUnmarshaller for both response struct and the result interface. It should unmarshal the document properly even if both structs share the field names and/or field types. 
- There is no test to verify the behaviour of the change if the JSON, provided by the server the documents are read from, is malformed.