### PR TITLE
Replaced jq with a go script

### DIFF
--- a/test/json_agency_config_parse_leader_id/json_agency_config_parse_leader_id.go
+++ b/test/json_agency_config_parse_leader_id/json_agency_config_parse_leader_id.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+func ExtractValue(input io.Reader) error {
+	var data map[string]interface{}
+
+	decoder := json.NewDecoder(input)
+	if err := decoder.Decode(&data); err != nil {
+		return fmt.Errorf("failed to decode JSON: %w", err)
+	}
+
+	configuration, ok := data["configuration"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("key 'configuration' not found or not an object")
+	}
+	pool, ok := configuration["pool"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("key 'pool' not found or not an array")
+	}
+
+	leaderId, ok := data["leaderId"].(string)
+	if !ok {
+		return fmt.Errorf("key 'leaderId' not found or not a str")
+	}
+	if leaderId == "" {
+		return fmt.Errorf("key 'leaderId' not set")
+	}
+
+	endpoint, ok := pool[leaderId].(string)
+	if !ok {
+		return fmt.Errorf("key '%s' not found or not a str", leaderId)
+	}
+	fmt.Println(endpoint)
+
+	return nil
+}
+
+func main() {
+	if err := ExtractValue(os.Stdin); err != nil {
+		fmt.Fprintf(os.Stderr, "JsonAgencyConfigParseError: %v\n and as a result the agency dump could not be created.\n", err)
+
+	}
+}

--- a/test/on_failure.sh
+++ b/test/on_failure.sh
@@ -30,16 +30,19 @@ if [ -n "${DUMP_AGENCY_ON_FAILURE}" ] && [ "${TEST_MODE}" = "cluster" ]; then
     # _api/agency/config returns leader endpoint with protocol that is usually not supported by curl 
     AGENCY_CONFIG=$(bash -c "curl -k --no-progress-meter ${AUTH} ${ANY_ENDPOINT}/_api/agency/config")
     
-    LEADER_ENDPOINT_WITH_UNSUPPORTED_PROTOCOL=$(echo $AGENCY_CONFIG | jq -r '.configuration.pool[.leaderId]' | cat)
+    # same as: jq -r '.configuration.pool[.leaderId]'
+    LEADER_ENDPOINT_WITH_UNSUPPORTED_PROTOCOL=$(echo $AGENCY_CONFIG | go run ./test/json_agency_config_parse_leader_id/json_agency_config_parse_leader_id.go | cat)
     SED_UNSUPPORTED_PROTOCOL_ENDPOINT_TO_ENDPOINT="s/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//${PROTOCOL}:\/\//"
     LEADER_ENDPOINT=$(echo $LEADER_ENDPOINT_WITH_UNSUPPORTED_PROTOCOL | sed $SED_UNSUPPORTED_PROTOCOL_ENDPOINT_TO_ENDPOINT)
-    echo "Leader agent endpoint: $LEADER_ENDPOINT"
     
-    DUMP_FILE_PATH=$DUMP_AGENCY_ON_FAILURE
-    mkdir -p $(dirname ${DUMP_FILE_PATH})
-    AGENCY_DUMP=$(bash -c "curl -Lk --no-progress-meter ${AUTH} ${LEADER_ENDPOINT}/_api/agency/state")
-    echo $AGENCY_DUMP > $DUMP_FILE_PATH
-    echo "Agency dump created at $(realpath $DUMP_FILE_PATH)"
+    if expr "$LEADER_ENDPOINT" : "^$PROTOCOL" > /dev/null; then
+        echo "Leader agent endpoint: $LEADER_ENDPOINT"
+        DUMP_FILE_PATH=$DUMP_AGENCY_ON_FAILURE
+        mkdir -p $(dirname ${DUMP_FILE_PATH})
+        AGENCY_DUMP=$(bash -c "curl -Lk --no-progress-meter ${AUTH} ${LEADER_ENDPOINT}/_api/agency/state")
+        echo $AGENCY_DUMP > $DUMP_FILE_PATH
+        echo "Agency dump created at $(realpath $DUMP_FILE_PATH)"
+    fi
 fi
 
 echo "\nV${MAJOR_VERSION} Tests with ARGS: TEST_MODE=${TEST_MODE} TEST_AUTH=${TEST_AUTH} TEST_CONTENT_TYPE=${TEST_CONTENT_TYPE} TEST_SSL=${TEST_SSL} TEST_CONNECTION=${TEST_CONNECTION} TEST_CVERSION=${TEST_CVERSION}";


### PR DESCRIPTION
* The jq dependency that extracted the leader endpoint from the agency configuration has been replaced by a go script serving the same role.