### PR TITLE
[Feature] OAS-10519 Expose OldRev Document Metadata In go-driver v2

### DIFF
--- a/v2/arangodb/collection_documents_replace.go
+++ b/v2/arangodb/collection_documents_replace.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2023 ArangoDB GmbH, Cologne, Germany
+// Copyright 2023-2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,11 +34,13 @@ type CollectionDocumentReplace interface {
 	// ReplaceDocument replaces a single document with given key in the collection.
 	// If no document exists with given key, a NotFoundError is returned.
 	// If `_id` field is present in the document body, it is always ignored.
+	// SmartGraphs and Enterprise Graphs cannot use existing collections and cannot use the document interface
 	ReplaceDocument(ctx context.Context, key string, document interface{}) (CollectionDocumentReplaceResponse, error)
 
 	// ReplaceDocumentWithOptions replaces a single document with given key in the collection.
 	// If no document exists with given key, a NotFoundError is returned.
 	// If `_id` field is present in the document body, it is always ignored.
+	// SmartGraphs and Enterprise Graphs cannot use existing collections and cannot use the document interface
 	ReplaceDocumentWithOptions(ctx context.Context, key string, document interface{}, options *CollectionDocumentReplaceOptions) (CollectionDocumentReplaceResponse, error)
 
 	// ReplaceDocuments replaces multiple document with given keys in the collection.
@@ -46,6 +48,7 @@ type CollectionDocumentReplace interface {
 	// If no document exists with a given key, a NotFoundError is returned at its errors index.
 	// Each element in the replaces slice must contain a `_key` field.
 	// If `_id` field is present in the document body, it is always ignored.
+	// SmartGraphs and Enterprise Graphs cannot use existing collections and cannot use the document interface
 	ReplaceDocuments(ctx context.Context, documents interface{}) (CollectionDocumentReplaceResponseReader, error)
 
 	// ReplaceDocumentsWithOptions replaces multiple document with given keys in the collection.
@@ -53,6 +56,7 @@ type CollectionDocumentReplace interface {
 	// If no document exists with a given key, a NotFoundError is returned at its errors index.
 	// Each element in the replaces slice must contain a `_key` field.
 	// If `_id` field is present in the document body, it is always ignored.
+	// SmartGraphs and Enterprise Graphs cannot use existing collections and cannot use the document interface
 	ReplaceDocumentsWithOptions(ctx context.Context, documents interface{}, opts *CollectionDocumentReplaceOptions) (CollectionDocumentReplaceResponseReader, error)
 }
 
@@ -61,7 +65,7 @@ type CollectionDocumentReplaceResponseReader interface {
 }
 
 type CollectionDocumentReplaceResponse struct {
-	DocumentMeta
+	DocumentMetaWithOldRev
 	shared.ResponseStruct `json:",inline"`
 	Old, New              interface{}
 }

--- a/v2/arangodb/collection_documents_replace_impl.go
+++ b/v2/arangodb/collection_documents_replace_impl.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2023 ArangoDB GmbH, Cologne, Germany
+// Copyright 2023-2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,13 +59,13 @@ func (c collectionDocumentReplace) ReplaceDocumentWithOptions(ctx context.Contex
 	}
 
 	response := struct {
-		*DocumentMeta          `json:",inline"`
-		*shared.ResponseStruct `json:",inline"`
-		Old                    *UnmarshalInto `json:"old,omitempty"`
-		New                    *UnmarshalInto `json:"new,omitempty"`
+		*DocumentMetaWithOldRev `json:",inline"`
+		*shared.ResponseStruct  `json:",inline"`
+		Old                     *UnmarshalInto `json:"old,omitempty"`
+		New                     *UnmarshalInto `json:"new,omitempty"`
 	}{
-		DocumentMeta:   &meta.DocumentMeta,
-		ResponseStruct: &meta.ResponseStruct,
+		DocumentMetaWithOldRev: &meta.DocumentMetaWithOldRev,
+		ResponseStruct:         &meta.ResponseStruct,
 
 		Old: newUnmarshalInto(meta.Old),
 		New: newUnmarshalInto(meta.New),
@@ -142,7 +142,7 @@ type collectionDocumentReplaceResponseReader struct {
 	array    *connection.Array
 	options  *CollectionDocumentReplaceOptions
 	response struct {
-		*DocumentMeta
+		*DocumentMetaWithOldRev
 		*shared.ResponseStruct `json:",inline"`
 		Old                    *UnmarshalInto `json:"old,omitempty"`
 		New                    *UnmarshalInto `json:"new,omitempty"`
@@ -161,7 +161,7 @@ func (c *collectionDocumentReplaceResponseReader) Read() (CollectionDocumentRepl
 		meta.New = c.options.NewObject
 	}
 
-	c.response.DocumentMeta = &meta.DocumentMeta
+	c.response.DocumentMetaWithOldRev = &meta.DocumentMetaWithOldRev
 	c.response.ResponseStruct = &meta.ResponseStruct
 
 	if err := c.array.Unmarshal(&c.response); err != nil {

--- a/v2/arangodb/collection_documents_update.go
+++ b/v2/arangodb/collection_documents_update.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2020-2024 ArangoDB GmbH, Cologne, Germany
+// Copyright 2020-2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ type CollectionDocumentUpdateResponseReader interface {
 }
 
 type CollectionDocumentUpdateResponse struct {
-	DocumentMeta
+	DocumentMetaWithOldRev
 	shared.ResponseStruct `json:",inline"`
 	Old, New              interface{}
 }

--- a/v2/arangodb/collection_documents_update_impl.go
+++ b/v2/arangodb/collection_documents_update_impl.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2020-2023 ArangoDB GmbH, Cologne, Germany
+// Copyright 2020-2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,13 +59,13 @@ func (c collectionDocumentUpdate) UpdateDocumentWithOptions(ctx context.Context,
 	}
 
 	response := struct {
-		*DocumentMeta          `json:",inline"`
-		*shared.ResponseStruct `json:",inline"`
-		Old                    *UnmarshalInto `json:"old,omitempty"`
-		New                    *UnmarshalInto `json:"new,omitempty"`
+		*DocumentMetaWithOldRev `json:",inline"`
+		*shared.ResponseStruct  `json:",inline"`
+		Old                     *UnmarshalInto `json:"old,omitempty"`
+		New                     *UnmarshalInto `json:"new,omitempty"`
 	}{
-		DocumentMeta:   &meta.DocumentMeta,
-		ResponseStruct: &meta.ResponseStruct,
+		DocumentMetaWithOldRev: &meta.DocumentMetaWithOldRev,
+		ResponseStruct:         &meta.ResponseStruct,
 
 		Old: newUnmarshalInto(meta.Old),
 		New: newUnmarshalInto(meta.New),
@@ -142,7 +142,7 @@ type collectionDocumentUpdateResponseReader struct {
 	array    *connection.Array
 	options  *CollectionDocumentUpdateOptions
 	response struct {
-		*DocumentMeta
+		*DocumentMetaWithOldRev
 		*shared.ResponseStruct `json:",inline"`
 		Old                    *UnmarshalInto `json:"old,omitempty"`
 		New                    *UnmarshalInto `json:"new,omitempty"`
@@ -161,7 +161,7 @@ func (c *collectionDocumentUpdateResponseReader) Read() (CollectionDocumentUpdat
 		meta.New = c.options.NewObject
 	}
 
-	c.response.DocumentMeta = &meta.DocumentMeta
+	c.response.DocumentMetaWithOldRev = &meta.DocumentMetaWithOldRev
 	c.response.ResponseStruct = &meta.ResponseStruct
 
 	if err := c.array.Unmarshal(&c.response); err != nil {

--- a/v2/arangodb/meta.go
+++ b/v2/arangodb/meta.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2020-2021 ArangoDB GmbH, Cologne, Germany
+// Copyright 2020-2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,6 +42,11 @@ type DocumentMeta struct {
 	Key string     `json:"_key,omitempty"`
 	ID  DocumentID `json:"_id,omitempty"`
 	Rev string     `json:"_rev,omitempty"`
+}
+
+type DocumentMetaWithOldRev struct {
+	DocumentMeta
+	OldRev string `json:"_oldRev,omitempty"`
 }
 
 // validateKey returns an error if the given key is empty otherwise invalid.

--- a/v2/tests/database_collection_doc_replace_test.go
+++ b/v2/tests/database_collection_doc_replace_test.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2023-2024 ArangoDB GmbH, Cologne, Germany
+// Copyright 2023-2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -119,6 +119,33 @@ func Test_DatabaseCollectionDocReplaceIgnoreRevs(t *testing.T) {
 						require.NoError(t, err)
 						require.NotEmpty(t, metaReplaced.Rev)
 						require.NotEqual(t, metaReplaced.Rev, meta.Rev)
+					})
+				})
+			})
+		})
+	})
+}
+
+func Test_DatabaseCollectionDocReplaceReturnOldRev(t *testing.T) {
+	Wrap(t, func(t *testing.T, client arangodb.Client) {
+		WithDatabase(t, client, nil, func(db arangodb.Database) {
+			WithCollection(t, db, nil, func(col arangodb.Collection) {
+				withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
+					doc := DocWithRev{
+						Name: "test-ORG",
+					}
+
+					metaOrg, err := col.CreateDocument(ctx, doc)
+					require.NoError(t, err)
+
+					docReplace := DocWithRev{
+						Name: "test-REPLACED",
+					}
+
+					t.Run("OldRev should match", func(t *testing.T) {
+						metaRep, err := col.ReplaceDocumentWithOptions(ctx, metaOrg.Key, docReplace, nil)
+						require.NoError(t, err)
+						require.Equal(t, metaOrg.Rev, metaRep.OldRev)
 					})
 				})
 			})

--- a/v2/tests/database_collection_doc_update_test.go
+++ b/v2/tests/database_collection_doc_update_test.go
@@ -1,7 +1,7 @@
 //
 // DISCLAIMER
 //
-// Copyright 2023-2024 ArangoDB GmbH, Cologne, Germany
+// Copyright 2023-2025 ArangoDB GmbH, Cologne, Germany
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -119,6 +119,33 @@ func Test_DatabaseCollectionDocUpdateIgnoreRevs(t *testing.T) {
 						require.NoError(t, err)
 						require.NotEmpty(t, metaUpdated.Rev)
 						require.NotEqual(t, metaUpdated.Rev, meta.Rev)
+					})
+				})
+			})
+		})
+	})
+}
+
+func Test_DatabaseCollectionDocUpdateReturnOldRev(t *testing.T) {
+	Wrap(t, func(t *testing.T, client arangodb.Client) {
+		WithDatabase(t, client, nil, func(db arangodb.Database) {
+			WithCollection(t, db, nil, func(col arangodb.Collection) {
+				withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
+					doc := DocWithRev{
+						Name: "test-ORG",
+					}
+
+					metaOrg, err := col.CreateDocument(ctx, doc)
+					require.NoError(t, err)
+
+					docUpdate := DocWithRev{
+						Name: "test-UPDATED",
+					}
+
+					t.Run("OldRev should match", func(t *testing.T) {
+						metaRep, err := col.UpdateDocumentWithOptions(ctx, metaOrg.Key, docUpdate, nil)
+						require.NoError(t, err)
+						require.Equal(t, metaOrg.Rev, metaRep.OldRev)
 					})
 				})
 			})


### PR DESCRIPTION
Extended DocumentMeta with DocumentMetaWithOldRev to support the OldRev field response from Replace and Update operations.