### PR TITLE
[Fix] OAS 10652 Replace documents does an update PATCH instead of a replace PUT

### DIFF
--- a/v2/arangodb/collection_documents_replace_impl.go
+++ b/v2/arangodb/collection_documents_replace_impl.go
@@ -97,7 +97,7 @@ func (c collectionDocumentReplace) ReplaceDocumentsWithOptions(ctx context.Conte
 
 	url := c.collection.url("document")
 
-	req, err := c.collection.connection().NewRequest(http.MethodPatch, url)
+	req, err := c.collection.connection().NewRequest(http.MethodPut, url)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A fix has been added https://github.com/arangodb/go-driver/issues/644 https://github.com/arangodb/go-driver/pull/645


