### PR TITLE
resource cleanup after tests

### DIFF
--- a/test/arangosearch_analyzers_test.go
+++ b/test/arangosearch_analyzers_test.go
@@ -429,6 +429,10 @@ func TestArangoSearchAnalyzerEnsureAnalyzer(t *testing.T) {
 			}
 		})
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 func ensureAnalyzer(ctx context.Context, db driver.Database, definition driver.ArangoSearchAnalyzerDefinition, t *testing.T) driver.ArangoSearchAnalyzer {
@@ -469,6 +473,10 @@ func TestArangoSearchAnalyzerGet(t *testing.T) {
 
 	_, err = db.Analyzer(ctx, "does-not-exist")
 	require.Error(t, err)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 func TestArangoSearchAnalyzerGetAll(t *testing.T) {
@@ -509,6 +517,10 @@ func TestArangoSearchAnalyzerGetAll(t *testing.T) {
 	}
 
 	require.True(t, found)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 func TestArangoSearchAnalyzerRemove(t *testing.T) {
@@ -546,4 +558,8 @@ func TestArangoSearchAnalyzerRemove(t *testing.T) {
 	}
 
 	require.False(t, found)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/arangosearch_analyzers_test.go
+++ b/test/arangosearch_analyzers_test.go
@@ -83,6 +83,12 @@ func TestArangoSearchAnalyzerEnsureAnalyzer(t *testing.T) {
 
 	dbname := "analyzer_test_ensure"
 	db := ensureDatabase(ctx, c, dbname, nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	testCases := []struct {
 		Name               string
@@ -429,10 +435,6 @@ func TestArangoSearchAnalyzerEnsureAnalyzer(t *testing.T) {
 			}
 		})
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func ensureAnalyzer(ctx context.Context, db driver.Database, definition driver.ArangoSearchAnalyzerDefinition, t *testing.T) driver.ArangoSearchAnalyzer {
@@ -448,6 +450,12 @@ func TestArangoSearchAnalyzerGet(t *testing.T) {
 
 	dbname := "analyzer_test_get"
 	db := ensureDatabase(ctx, c, dbname, nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	aname := "my-ngram"
 	def := driver.ArangoSearchAnalyzerDefinition{
 		Name: aname,
@@ -473,10 +481,6 @@ func TestArangoSearchAnalyzerGet(t *testing.T) {
 
 	_, err = db.Analyzer(ctx, "does-not-exist")
 	require.Error(t, err)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestArangoSearchAnalyzerGetAll(t *testing.T) {
@@ -486,6 +490,12 @@ func TestArangoSearchAnalyzerGetAll(t *testing.T) {
 
 	dbname := "analyzer_test_get_all"
 	db := ensureDatabase(ctx, c, dbname, nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	aname := "my-ngram"
 	def := driver.ArangoSearchAnalyzerDefinition{
 		Name: aname,
@@ -517,10 +527,6 @@ func TestArangoSearchAnalyzerGetAll(t *testing.T) {
 	}
 
 	require.True(t, found)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestArangoSearchAnalyzerRemove(t *testing.T) {
@@ -530,6 +536,12 @@ func TestArangoSearchAnalyzerRemove(t *testing.T) {
 
 	dbname := "analyzer_test_get_all"
 	db := ensureDatabase(ctx, c, dbname, nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	aname := "my-ngram"
 	def := driver.ArangoSearchAnalyzerDefinition{
 		Name: aname,
@@ -558,8 +570,4 @@ func TestArangoSearchAnalyzerRemove(t *testing.T) {
 	}
 
 	require.False(t, found)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }

--- a/test/asyncjob_test.go
+++ b/test/asyncjob_test.go
@@ -135,6 +135,10 @@ func TestAsyncJobListPending(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, jobs, 0)
 	})
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 func TestAsyncJobCancel(t *testing.T) {

--- a/test/asyncjob_test.go
+++ b/test/asyncjob_test.go
@@ -102,7 +102,12 @@ func TestAsyncJobListPending(t *testing.T) {
 	skipResilientSingle(t)
 
 	db := ensureDatabase(ctx, c, databaseName("db", "async"), nil, t)
-	defer db.Remove(ctx)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "frontend", nil, t)
 
 	idTransaction := runLongRequest(t, ctxAsync, db, 2, col.Name())
@@ -135,10 +140,6 @@ func TestAsyncJobListPending(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, jobs, 0)
 	})
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestAsyncJobCancel(t *testing.T) {
@@ -149,7 +150,12 @@ func TestAsyncJobCancel(t *testing.T) {
 	skipResilientSingle(t)
 
 	db := ensureDatabase(ctx, c, databaseName("db", "async", "cancel"), nil, t)
-	defer db.Remove(ctx)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	aqlQuery := "FOR i IN 1..10 FOR j IN 1..10 LET x = sleep(1.0) FILTER i == 5 && j == 5 RETURN 42"
 	_, err := db.Query(ctxAsync, aqlQuery, nil)
@@ -196,7 +202,12 @@ func TestAsyncJobDelete(t *testing.T) {
 	skipResilientSingle(t)
 
 	db := ensureDatabase(ctx, c, databaseName("db", "async", "cancel"), nil, t)
-	defer db.Remove(ctx)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "backend", nil, t)
 
 	t.Run("delete all jobs", func(t *testing.T) {

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -354,6 +354,13 @@ func TestBackupRestore(t *testing.T) {
 	colname := "col"
 
 	db := ensureDatabase(ctx, c, dbname, nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
+	
 	col := ensureCollection(ctx, db, colname, nil, t)
 
 	// Write a document
@@ -403,10 +410,6 @@ func TestBackupRestore(t *testing.T) {
 		t.Errorf("Failed to lookup document: %s", describe(err))
 	} else if ok {
 		t.Errorf("Document should not be there: %s", meta2.Key)
-	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -580,6 +583,12 @@ func TestBackupCompleteCycle(t *testing.T) {
 	colname := "col"
 
 	db := ensureDatabase(ctx, c, dbname, nil, t)
+	defer func () {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, colname, nil, t)
 
 	isSingle := false
@@ -659,10 +668,6 @@ func TestBackupCompleteCycle(t *testing.T) {
 		t.Errorf("Failed to lookup document: %s", describe(err))
 	} else if ok {
 		t.Errorf("Document should not be there: %s", meta2.Key)
-	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -758,6 +763,12 @@ func TestBackupRestoreWithViews(t *testing.T) {
 	trueVar := true
 
 	db := ensureDatabase(ctx, c, dbname, nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, colname, nil, t)
 	ensureArangoSearchView(ctx, db, viewname, &driver.ArangoSearchViewProperties{
 		Links: driver.ArangoSearchLinks{
@@ -863,8 +874,4 @@ func TestBackupRestoreWithViews(t *testing.T) {
 			return interrupt{}
 		}).RetryT(t, 125*time.Millisecond, time.Minute)
 	})
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -314,7 +314,7 @@ func waitForServerRestart(ctx context.Context, c driver.Client, t *testing.T) dr
 		}
 
 		return nil
-	}).RetryT(t, 100*time.Millisecond, 15*time.Second)
+	}).RetryT(t, 100*time.Millisecond, 30*time.Second)
 
 	// Wait for secret to start
 	newRetryFunc(func() error {
@@ -327,7 +327,7 @@ func waitForServerRestart(ctx context.Context, c driver.Client, t *testing.T) dr
 		}
 
 		return nil
-	}).RetryT(t, 100*time.Millisecond, 15*time.Second)
+	}).RetryT(t, 100*time.Millisecond, 30*time.Second)
 
 	return c
 }
@@ -403,6 +403,10 @@ func TestBackupRestore(t *testing.T) {
 		t.Errorf("Failed to lookup document: %s", describe(err))
 	} else if ok {
 		t.Errorf("Document should not be there: %s", meta2.Key)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -656,6 +660,10 @@ func TestBackupCompleteCycle(t *testing.T) {
 	} else if ok {
 		t.Errorf("Document should not be there: %s", meta2.Key)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 type backupResult struct {
@@ -795,7 +803,7 @@ func TestBackupRestoreWithViews(t *testing.T) {
 	defer waitForHealthyClusterAfterBackup(t, c)
 
 	if isSingle {
-		waitctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		waitctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 		defer cancel()
 		c = waitForServerRestart(waitctx, c, t)
 	}
@@ -855,4 +863,8 @@ func TestBackupRestoreWithViews(t *testing.T) {
 			return interrupt{}
 		}).RetryT(t, 125*time.Millisecond, time.Minute)
 	})
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -357,10 +357,10 @@ func TestBackupRestore(t *testing.T) {
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			t.Logf("Failed to drop database %s: %s ...", dbname, err)
 		}
 	}()
-	
+
 	col := ensureCollection(ctx, db, colname, nil, t)
 
 	// Write a document
@@ -583,10 +583,10 @@ func TestBackupCompleteCycle(t *testing.T) {
 	colname := "col"
 
 	db := ensureDatabase(ctx, c, dbname, nil, t)
-	defer func () {
+	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			t.Logf("Failed to drop database %s: %s ...", dbname, err)
 		}
 	}()
 	col := ensureCollection(ctx, db, colname, nil, t)
@@ -766,7 +766,7 @@ func TestBackupRestoreWithViews(t *testing.T) {
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			t.Logf("Failed to drop database %s: %s ...", dbname, err)
 		}
 	}()
 	col := ensureCollection(ctx, db, colname, nil, t)

--- a/test/benchmark_collection_test.go
+++ b/test/benchmark_collection_test.go
@@ -37,6 +37,10 @@ func BenchmarkCollectionExists(b *testing.B) {
 			b.Errorf("CollectionExists failed: %s", describe(err))
 		}
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // BenchmarkCollection measures the Collection operation.
@@ -50,6 +54,10 @@ func BenchmarkCollection(b *testing.B) {
 		if _, err := db.Collection(nil, col.Name()); err != nil {
 			b.Errorf("Collection failed: %s", describe(err))
 		}
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -66,5 +74,9 @@ func BenchmarkCollections(b *testing.B) {
 		if _, err := db.Collections(nil); err != nil {
 			b.Errorf("Collections failed: %s", describe(err))
 		}
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/benchmark_collection_test.go
+++ b/test/benchmark_collection_test.go
@@ -29,6 +29,12 @@ import (
 func BenchmarkCollectionExists(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, b)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "collection_exist_test", nil, b)
 
 	b.ResetTimer()
@@ -37,16 +43,18 @@ func BenchmarkCollectionExists(b *testing.B) {
 			b.Errorf("CollectionExists failed: %s", describe(err))
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // BenchmarkCollection measures the Collection operation.
 func BenchmarkCollection(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, b)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "collection_test", nil, b)
 
 	b.ResetTimer()
@@ -55,16 +63,18 @@ func BenchmarkCollection(b *testing.B) {
 			b.Errorf("Collection failed: %s", describe(err))
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // BenchmarkCollections measures the Collections operation.
 func BenchmarkCollections(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, b)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	for i := 0; i < 10; i++ {
 		ensureCollection(nil, db, fmt.Sprintf("col%d", i), nil, b)
 	}
@@ -74,9 +84,5 @@ func BenchmarkCollections(b *testing.B) {
 		if _, err := db.Collections(nil); err != nil {
 			b.Errorf("Collections failed: %s", describe(err))
 		}
-	}
-	err := db.Remove(nil)
-	if err != nil {
-		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/benchmark_collection_test.go
+++ b/test/benchmark_collection_test.go
@@ -32,7 +32,7 @@ func BenchmarkCollectionExists(b *testing.B) {
 	defer func() {
 		err := db.Remove(nil)
 		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 		}
 	}()
 	col := ensureCollection(nil, db, "collection_exist_test", nil, b)
@@ -52,7 +52,7 @@ func BenchmarkCollection(b *testing.B) {
 	defer func() {
 		err := db.Remove(nil)
 		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 		}
 	}()
 	col := ensureCollection(nil, db, "collection_test", nil, b)
@@ -72,7 +72,7 @@ func BenchmarkCollections(b *testing.B) {
 	defer func() {
 		err := db.Remove(nil)
 		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 		}
 	}()
 	for i := 0; i < 10; i++ {

--- a/test/benchmark_document_test.go
+++ b/test/benchmark_document_test.go
@@ -26,6 +26,12 @@ import "testing"
 func BenchmarkCreateDocument(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, b)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, b)
 
 	b.ResetTimer()
@@ -38,16 +44,18 @@ func BenchmarkCreateDocument(b *testing.B) {
 			b.Fatalf("Failed to create new document: %s", describe(err))
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // BenchmarkCreateDocumentParallel measures parallel CreateDocument operations for a simple document.
 func BenchmarkCreateDocumentParallel(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, b)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, b)
 
 	b.SetParallelism(100)
@@ -62,16 +70,18 @@ func BenchmarkCreateDocumentParallel(b *testing.B) {
 			}
 		}
 	})
-	err := db.Remove(nil)
-	if err != nil {
-		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // BenchmarkReadDocument measures the ReadDocument operation for a simple document.
 func BenchmarkReadDocument(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, b)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, b)
 	doc := UserDoc{
 		"Jan",
@@ -89,16 +99,18 @@ func BenchmarkReadDocument(b *testing.B) {
 			b.Errorf("Failed to read document: %s", describe(err))
 		}
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // BenchmarkReadDocumentParallel measures parallel ReadDocument operations for a simple document.
 func BenchmarkReadDocumentParallel(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, b)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, b)
 	doc := UserDoc{
 		"Jan",
@@ -118,16 +130,18 @@ func BenchmarkReadDocumentParallel(b *testing.B) {
 			}
 		}
 	})
-	err = db.Remove(nil)
-	if err != nil {
-		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // BenchmarkRemoveDocument measures the RemoveDocument operation for a simple document.
 func BenchmarkRemoveDocument(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, b)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, b)
 
 	b.ResetTimer()
@@ -148,9 +162,5 @@ func BenchmarkRemoveDocument(b *testing.B) {
 		if _, err := col.RemoveDocument(nil, meta.Key); err != nil {
 			b.Errorf("Failed to remove document: %s", describe(err))
 		}
-	}
-	err := db.Remove(nil)
-	if err != nil {
-		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/benchmark_document_test.go
+++ b/test/benchmark_document_test.go
@@ -38,6 +38,10 @@ func BenchmarkCreateDocument(b *testing.B) {
 			b.Fatalf("Failed to create new document: %s", describe(err))
 		}
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // BenchmarkCreateDocumentParallel measures parallel CreateDocument operations for a simple document.
@@ -58,6 +62,10 @@ func BenchmarkCreateDocumentParallel(b *testing.B) {
 			}
 		}
 	})
+	err := db.Remove(nil)
+	if err != nil {
+		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // BenchmarkReadDocument measures the ReadDocument operation for a simple document.
@@ -80,6 +88,10 @@ func BenchmarkReadDocument(b *testing.B) {
 		if _, err := col.ReadDocument(nil, meta.Key, &result); err != nil {
 			b.Errorf("Failed to read document: %s", describe(err))
 		}
+	}
+	err = db.Remove(nil)
+	if err != nil {
+		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -106,6 +118,10 @@ func BenchmarkReadDocumentParallel(b *testing.B) {
 			}
 		}
 	})
+	err = db.Remove(nil)
+	if err != nil {
+		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // BenchmarkRemoveDocument measures the RemoveDocument operation for a simple document.
@@ -132,5 +148,9 @@ func BenchmarkRemoveDocument(b *testing.B) {
 		if _, err := col.RemoveDocument(nil, meta.Key); err != nil {
 			b.Errorf("Failed to remove document: %s", describe(err))
 		}
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		//t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/benchmark_document_test.go
+++ b/test/benchmark_document_test.go
@@ -27,9 +27,9 @@ func BenchmarkCreateDocument(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, b)
 	defer func() {
-		err := db.Remove(ctx)
+		err := db.Remove(nil)
 		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 		}
 	}()
 	col := ensureCollection(nil, db, "document_test", nil, b)
@@ -51,9 +51,9 @@ func BenchmarkCreateDocumentParallel(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, b)
 	defer func() {
-		err := db.Remove(ctx)
+		err := db.Remove(nil)
 		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 		}
 	}()
 	col := ensureCollection(nil, db, "document_test", nil, b)
@@ -77,9 +77,9 @@ func BenchmarkReadDocument(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, b)
 	defer func() {
-		err := db.Remove(ctx)
+		err := db.Remove(nil)
 		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 		}
 	}()
 	col := ensureCollection(nil, db, "document_test", nil, b)
@@ -106,9 +106,9 @@ func BenchmarkReadDocumentParallel(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, b)
 	defer func() {
-		err := db.Remove(ctx)
+		err := db.Remove(nil)
 		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 		}
 	}()
 	col := ensureCollection(nil, db, "document_test", nil, b)
@@ -137,9 +137,9 @@ func BenchmarkRemoveDocument(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, b)
 	defer func() {
-		err := db.Remove(ctx)
+		err := db.Remove(nil)
 		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 		}
 	}()
 	col := ensureCollection(nil, db, "document_test", nil, b)

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -585,13 +585,11 @@ func TestClientConnectionReuse(t *testing.T) {
 			Options: driver.CreateDatabaseDefaultOptions{},
 		}, t)
 	}
-	defer func () {
+	defer func() {
 		for dbName, user := range dbUsers {
 			t.Logf("Dropping DB %s ...", dbName)
-			db, err := c.Database(ctx, dbName)
-			if err == nil {
-				err = db.Remove(ctx)
-			}
+			db := ensureDatabase(ctx, c, dbName, nil, t)
+			err := db.Remove(ctx)
 			if err != nil {
 				t.Logf("Failed to drop database %s: %s ...", dbName, err)
 			}

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -521,6 +521,10 @@ func TestResponseHeader(t *testing.T) {
 		if x := resp.Header("ETAG"); x != expectedETag {
 			t.Errorf("Unexpected result from Header('ETAG'), got '%s', expected '%s'", x, expectedETag)
 		}
+		err = db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
 	}
 }
 
@@ -623,6 +627,17 @@ func TestClientConnectionReuse(t *testing.T) {
 		}
 	}
 	wg.Wait()
+	for dbName, user := range dbUsers {
+		t.Logf("Dropping DB %s ...", dbName)
+		db, err := c.Database(ctx, dbName)
+		if err == nil {
+			err = db.Remove(ctx)
+		}
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", dbName, err)
+		}
+	}
+	
 }
 
 func checkDBAccess(ctx context.Context, conn driver.Connection, dbName, username, password string) error {

--- a/test/collection_schema_test.go
+++ b/test/collection_schema_test.go
@@ -191,4 +191,8 @@ func TestCollectionSchema(t *testing.T) {
 			require.Equal(t, http.StatusBadRequest, arangoErr.Code)
 		})
 	})
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/collection_schema_test.go
+++ b/test/collection_schema_test.go
@@ -51,6 +51,12 @@ func TestCollectionSchema(t *testing.T) {
 
 	name := "document_schema_validation_test"
 	db := ensureDatabase(nil, c, name, nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	t.Run("Create collection with schema validation", func(t *testing.T) {
 		opts := driver.CreateCollectionOptions{
 			Schema: &driver.CollectionSchemaOptions{
@@ -191,8 +197,4 @@ func TestCollectionSchema(t *testing.T) {
 			require.Equal(t, http.StatusBadRequest, arangoErr.Code)
 		})
 	})
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }

--- a/test/collection_test.go
+++ b/test/collection_test.go
@@ -74,6 +74,10 @@ func TestGetCollection(t *testing.T) {
 
 	_, err = db.Collection(driver.WithSkipExistCheck(nil, true), name)
 	require.NoError(t, err)
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateCollection creates a collection and then checks that it exists.
@@ -89,6 +93,10 @@ func TestCreateCollection(t *testing.T) {
 		t.Errorf("CollectionExists('%s') failed: %s", name, describe(err))
 	} else if !found {
 		t.Errorf("CollectionExists('%s') return false, expected true", name)
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -172,6 +180,10 @@ func TestCollection_CacheEnabled(t *testing.T) {
 
 		require.True(t, prop.CacheEnabled)
 	})
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCollection_ComputedValues
@@ -314,6 +326,10 @@ func TestCollection_ComputedValues(t *testing.T) {
 		// we should get the default value for ComputeOn - ["insert", "update", "replace"]
 		require.Len(t, prop.ComputedValues[0].ComputeOn, 3)
 	})
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateSatelliteCollection create a satellite collection
@@ -346,6 +362,10 @@ func TestCreateSatelliteCollection(t *testing.T) {
 				t.Errorf("Collection %s is not satellite", name)
 			}
 		}
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -388,6 +408,10 @@ func TestCreateSmartJoinCollection(t *testing.T) {
 	prop, err := colRead.Properties(nil)
 	require.NoError(t, err)
 	require.Equal(t, "smart", prop.SmartJoinAttribute)
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateCollectionWithShardingStrategy create a collection with non default sharding strategy
@@ -421,6 +445,10 @@ func TestCreateCollectionWithShardingStrategy(t *testing.T) {
 				t.Errorf("Collection does not have the correct sharding strategy value, expected `%s`, found `%s`", driver.ShardingStrategyCommunityCompat, prop.ShardingStrategy)
 			}
 		}
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -465,6 +493,10 @@ func TestRemoveCollection(t *testing.T) {
 		t.Errorf("CollectionExists('%s') failed: %s", name, describe(err))
 	} else if found {
 		t.Errorf("CollectionExists('%s') return true, expected false", name)
+	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -529,6 +561,10 @@ func TestLoadUnloadCollection(t *testing.T) {
 			break
 		}
 	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCollectionName creates a collection and checks its name
@@ -542,6 +578,10 @@ func TestCollectionName(t *testing.T) {
 	}
 	if col.Name() != name {
 		t.Errorf("Collection.Name() is wrong, got '%s', expected '%s'", col.Name(), name)
+	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -582,6 +622,10 @@ func TestCollectionTruncate(t *testing.T) {
 	} else if c != 0 {
 		t.Errorf("Expected 0 documents, got %d", c)
 	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCollectionProperties creates a collection and checks its properties
@@ -615,6 +659,10 @@ func TestCollectionProperties(t *testing.T) {
 		if p.Type != driver.CollectionTypeDocument {
 			t.Errorf("Expected type %d, got %d", driver.CollectionTypeDocument, p.Type)
 		}
+	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -723,6 +771,10 @@ func TestCollectionSetProperties(t *testing.T) {
 	} else {
 		t.Errorf("Cluster failed: %s", describe(err))
 	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 func TestCollectionSetPropertiesSatellite(t *testing.T) {
@@ -751,6 +803,10 @@ func TestCollectionSetPropertiesSatellite(t *testing.T) {
 			if p.ReplicationFactor != replFact {
 				t.Errorf("Expected ReplicationFactor %d, got %d", replFact, p.ReplicationFactor)
 			}
+		}
+		err = db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 		}
 	} else if driver.IsPreconditionFailed(err) {
 		t.Logf("ReplicationFactor tests skipped because we're not running in a cluster")
@@ -787,6 +843,10 @@ func TestCollectionRevision(t *testing.T) {
 			t.Errorf("Expected revision before, after to be different. Got '%s', '%s'", before, after)
 		}
 	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCollectionChecksum creates a collection, checks checksum after adding documents.
@@ -821,6 +881,10 @@ func TestCollectionChecksum(t *testing.T) {
 		require.NotEqual(t, after.Checksum, afterWithData.Checksum)
 		require.NotEqual(t, afterWithRevision.Checksum, afterWithData.Checksum)
 	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCollectionStatistics creates a collection, checks statistics after adding documents.
@@ -853,6 +917,10 @@ func TestCollectionStatistics(t *testing.T) {
 		if before.Figures.DataFiles.FileSize > after.Figures.DataFiles.FileSize {
 			t.Errorf("Expected DataFiles.FileSize before <= after. Got %d, %d", before.Figures.DataFiles.FileSize, after.Figures.DataFiles.FileSize)
 		}
+	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -897,6 +965,10 @@ func TestCollectionMinReplFactDeprecatedCreate(t *testing.T) {
 			}
 		}
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCollectionMinReplFactDeprecatedInvalid creates a collection with minReplicationFactor > replicationFactor
@@ -919,6 +991,10 @@ func TestCollectionMinReplFactDeprecatedInvalid(t *testing.T) {
 		t.Errorf("CollectionExists('%s') failed: %s", name, describe(err))
 	} else if found {
 		t.Errorf("Collection %s should not exist", name)
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -960,6 +1036,10 @@ func TestCollectionMinReplFactDeprecatedClusterInv(t *testing.T) {
 				minRepl, col.Parameters.WriteConcern)
 		}
 	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCollectionMinReplFactDeprecatedSetProp updates the minimal replication factor using SetProperties
@@ -995,6 +1075,10 @@ func TestCollectionMinReplFactDeprecatedSetProp(t *testing.T) {
 			}
 		}
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCollectionMinReplFactDeprecatedSetPropInvalid updates the minimal replication factor
@@ -1029,6 +1113,10 @@ func TestCollectionMinReplFactDeprecatedSetPropInvalid(t *testing.T) {
 				t.Fatalf("WriteConcern not updated, expected %d, found %d", minRepl, prop.WriteConcern)
 			}
 		}
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -1067,6 +1155,10 @@ func TestCollectionWriteConcernCreate(t *testing.T) {
 	assert.Equalf(t, minRepl, prop.MinReplicationFactor,
 		"Collection does not have the correct MinReplicationFactor value, expected `%d`, found `%d`", minRepl,
 		prop.MinReplicationFactor)
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCollectionWriteConcernInvalid creates a collection with WriteConcern > replicationFactor
@@ -1090,6 +1182,10 @@ func TestCollectionWriteConcernInvalid(t *testing.T) {
 	found, err := db.CollectionExists(nil, name)
 	require.Nilf(t, err, "CollectionExists('%s') failed: %s", name, describe(err))
 	assert.Equalf(t, false, found, "Collection %s should not exist", name)
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCollectionWriteConcernClusterInv tests if WriteConcern is forwarded to ClusterInfo
@@ -1117,6 +1213,10 @@ func TestCollectionWriteConcernClusterInv(t *testing.T) {
 	assert.Equalf(t, minRepl, col.Parameters.WriteConcern,
 		"Collection does not have the correct WriteConcern value, expected `%d`, found `%d`",
 		minRepl, col.Parameters.WriteConcern)
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCollectionWriteConcernSetProp updates the WriteConcern using SetProperties
@@ -1142,6 +1242,10 @@ func TestCollectionWriteConcernSetProp(t *testing.T) {
 	require.Nilf(t, err, "Failed to get properties: %s", describe(err))
 
 	assert.Equal(t, writeConcernChanged, prop.WriteConcern)
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCollectionWriteConcernSetPropInvalid updates the writeConcern to an invalid value using SetProperties.
@@ -1170,6 +1274,10 @@ func TestCollectionWriteConcernSetPropInvalid(t *testing.T) {
 	require.Nilf(t, err, "Failed to get properties: %s", describe(err))
 	assert.Equalf(t, defaultWriteConcern, prop.WriteConcern, "MinReplicationFactor not updated, expected %d, found %d",
 		minRepl, prop.WriteConcern)
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // Test_CollectionShards creates a collection and gets the shards' information.
@@ -1225,4 +1333,8 @@ func Test_CollectionShards(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, driver.ReplicationFactorSatellite, shards.ReplicationFactor)
 	})
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/collection_test.go
+++ b/test/collection_test.go
@@ -63,6 +63,12 @@ func assertCollection(ctx context.Context, db driver.Database, name string, t *t
 func TestGetCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_get_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	name := "test_wrong_collection"
 
@@ -74,16 +80,18 @@ func TestGetCollection(t *testing.T) {
 
 	_, err = db.Collection(driver.WithSkipExistCheck(nil, true), name)
 	require.NoError(t, err)
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateCollection creates a collection and then checks that it exists.
 func TestCreateCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_collection"
 	if _, err := db.CreateCollection(nil, name, nil); err != nil {
 		t.Fatalf("Failed to create collection '%s': %s", name, describe(err))
@@ -94,16 +102,18 @@ func TestCreateCollection(t *testing.T) {
 	} else if !found {
 		t.Errorf("CollectionExists('%s') return false, expected true", name)
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollection_CacheEnabled with cacheEnabled and check if exists
 func TestCollection_CacheEnabled(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test_cache_enabled", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	t.Run("Default value", func(t *testing.T) {
 		name := "test_create_collection_cache_default"
@@ -180,10 +190,6 @@ func TestCollection_CacheEnabled(t *testing.T) {
 
 		require.True(t, prop.CacheEnabled)
 	})
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollection_ComputedValues
@@ -191,6 +197,12 @@ func TestCollection_ComputedValues(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.10", t)
 	db := ensureDatabase(nil, c, "collection_test_computed_values", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	t.Run("Create with ComputedValues", func(t *testing.T) {
 		name := "test_users_computed_values"
@@ -326,10 +338,6 @@ func TestCollection_ComputedValues(t *testing.T) {
 		// we should get the default value for ComputeOn - ["insert", "update", "replace"]
 		require.Len(t, prop.ComputedValues[0].ComputeOn, 3)
 	})
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateSatelliteCollection create a satellite collection
@@ -338,6 +346,12 @@ func TestCreateSatelliteCollection(t *testing.T) {
 	c := createClient(t, nil)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_collection_satellite"
 	options := driver.CreateCollectionOptions{
 		ReplicationFactor: driver.ReplicationFactorSatellite,
@@ -363,10 +377,6 @@ func TestCreateSatelliteCollection(t *testing.T) {
 			}
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateSmartJoinCollection create a collection with smart join attribute
@@ -376,6 +386,12 @@ func TestCreateSmartJoinCollection(t *testing.T) {
 	skipBelowVersion(c, "3.4.5", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	name := "test_create_collection_smart_join"
 	nameParent := "test_create_collection_smart_join_parent"
@@ -408,10 +424,6 @@ func TestCreateSmartJoinCollection(t *testing.T) {
 	prop, err := colRead.Properties(nil)
 	require.NoError(t, err)
 	require.Equal(t, "smart", prop.SmartJoinAttribute)
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateCollectionWithShardingStrategy create a collection with non default sharding strategy
@@ -421,6 +433,12 @@ func TestCreateCollectionWithShardingStrategy(t *testing.T) {
 	skipBelowVersion(c, "3.4", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_collection_sharding_strategy"
 	options := driver.CreateCollectionOptions{
 		ShardingStrategy: driver.ShardingStrategyCommunityCompat,
@@ -446,10 +464,6 @@ func TestCreateCollectionWithShardingStrategy(t *testing.T) {
 			}
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func parseInt64FromInterface(value interface{}) (int64, error) {
@@ -473,6 +487,12 @@ func parseInt64FromInterface(value interface{}) (int64, error) {
 func TestRemoveCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_remove_collection"
 	col, err := db.CreateCollection(nil, name, nil)
 	if err != nil {
@@ -494,16 +514,18 @@ func TestRemoveCollection(t *testing.T) {
 	} else if found {
 		t.Errorf("CollectionExists('%s') return true, expected false", name)
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestLoadUnloadCollection creates a collection and unloads, loads & unloads it.
 func TestLoadUnloadCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	// we are not able to unload RocksDB
 	skipIfEngineTypeRocksDB(t, db)
 	name := "test_load_collection"
@@ -561,16 +583,18 @@ func TestLoadUnloadCollection(t *testing.T) {
 			break
 		}
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionName creates a collection and checks its name
 func TestCollectionName(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_collection_name"
 	col, err := db.CreateCollection(nil, name, nil)
 	if err != nil {
@@ -579,10 +603,6 @@ func TestCollectionName(t *testing.T) {
 	if col.Name() != name {
 		t.Errorf("Collection.Name() is wrong, got '%s', expected '%s'", col.Name(), name)
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionTruncate creates a collection, adds some documents and truncates it.
@@ -590,6 +610,12 @@ func TestCollectionTruncate(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_collection_truncate"
 	col, err := db.CreateCollection(nil, name, nil)
 	if err != nil {
@@ -622,16 +648,18 @@ func TestCollectionTruncate(t *testing.T) {
 	} else if c != 0 {
 		t.Errorf("Expected 0 documents, got %d", c)
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionProperties creates a collection and checks its properties
 func TestCollectionProperties(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_collection_properties"
 	col, err := db.CreateCollection(nil, name, nil)
 	if err != nil {
@@ -660,16 +688,18 @@ func TestCollectionProperties(t *testing.T) {
 			t.Errorf("Expected type %d, got %d", driver.CollectionTypeDocument, p.Type)
 		}
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionSetProperties creates a collection and modifies its properties
 func TestCollectionSetProperties(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_collection_set_properties"
 	col, err := db.CreateCollection(nil, name, nil)
 	if err != nil {
@@ -771,10 +801,6 @@ func TestCollectionSetProperties(t *testing.T) {
 	} else {
 		t.Errorf("Cluster failed: %s", describe(err))
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestCollectionSetPropertiesSatellite(t *testing.T) {
@@ -785,6 +811,12 @@ func TestCollectionSetPropertiesSatellite(t *testing.T) {
 	if _, err := c.Cluster(nil); err == nil {
 
 		db := ensureDatabase(nil, c, "collection_test_satellite", nil, t)
+		defer func() {
+			err := db.Remove(nil)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 		name := "test_collection_set_properties_sat"
 		col, err := db.CreateCollection(nil, name, &driver.CreateCollectionOptions{ReplicationFactor: driver.ReplicationFactorSatellite})
 		if err != nil {
@@ -804,10 +836,6 @@ func TestCollectionSetPropertiesSatellite(t *testing.T) {
 				t.Errorf("Expected ReplicationFactor %d, got %d", replFact, p.ReplicationFactor)
 			}
 		}
-		err = db.Remove(nil)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
 	} else if driver.IsPreconditionFailed(err) {
 		t.Logf("ReplicationFactor tests skipped because we're not running in a cluster")
 	} else {
@@ -820,6 +848,12 @@ func TestCollectionRevision(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
 	name := "test_collection_revision"
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col, err := db.CreateCollection(nil, name, nil)
 	if err != nil {
 		t.Fatalf("Failed to create collection '%s': %s", name, describe(err))
@@ -843,16 +877,18 @@ func TestCollectionRevision(t *testing.T) {
 			t.Errorf("Expected revision before, after to be different. Got '%s', '%s'", before, after)
 		}
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionChecksum creates a collection, checks checksum after adding documents.
 func TestCollectionChecksum(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_checksum", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_collection_checksum"
 	col, err := db.CreateCollection(nil, name, nil)
 	require.NoError(t, err)
@@ -881,16 +917,18 @@ func TestCollectionChecksum(t *testing.T) {
 		require.NotEqual(t, after.Checksum, afterWithData.Checksum)
 		require.NotEqual(t, afterWithRevision.Checksum, afterWithData.Checksum)
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionStatistics creates a collection, checks statistics after adding documents.
 func TestCollectionStatistics(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_collection_statistics"
 	col, err := db.CreateCollection(nil, name, nil)
 	if err != nil {
@@ -918,10 +956,6 @@ func TestCollectionStatistics(t *testing.T) {
 			t.Errorf("Expected DataFiles.FileSize before <= after. Got %d, %d", before.Figures.DataFiles.FileSize, after.Figures.DataFiles.FileSize)
 		}
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionMinReplFactDeprecatedCreate creates a collection with minReplicationFactor != 1
@@ -930,6 +964,12 @@ func TestCollectionMinReplFactDeprecatedCreate(t *testing.T) {
 	version := skipBelowVersion(c, "3.5", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_min_repl_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_min_repl_create"
 	minRepl := 2
 	options := driver.CreateCollectionOptions{
@@ -965,10 +1005,6 @@ func TestCollectionMinReplFactDeprecatedCreate(t *testing.T) {
 			}
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionMinReplFactDeprecatedInvalid creates a collection with minReplicationFactor > replicationFactor
@@ -977,6 +1013,12 @@ func TestCollectionMinReplFactDeprecatedInvalid(t *testing.T) {
 	skipBelowVersion(c, "3.5", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_min_repl_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_min_repl_create_invalid"
 	minRepl := 2
 	options := driver.CreateCollectionOptions{
@@ -992,10 +1034,6 @@ func TestCollectionMinReplFactDeprecatedInvalid(t *testing.T) {
 	} else if found {
 		t.Errorf("Collection %s should not exist", name)
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionMinReplFactDeprecatedClusterInv tests if minReplicationFactor is forwarded to ClusterInfo
@@ -1004,6 +1042,12 @@ func TestCollectionMinReplFactDeprecatedClusterInv(t *testing.T) {
 	version := skipBelowVersion(c, "3.5", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_min_repl_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_min_repl_cluster_invent"
 	minRepl := 2
 	ensureCollection(nil, db, name, &driver.CreateCollectionOptions{
@@ -1036,10 +1080,6 @@ func TestCollectionMinReplFactDeprecatedClusterInv(t *testing.T) {
 				minRepl, col.Parameters.WriteConcern)
 		}
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionMinReplFactDeprecatedSetProp updates the minimal replication factor using SetProperties
@@ -1048,6 +1088,12 @@ func TestCollectionMinReplFactDeprecatedSetProp(t *testing.T) {
 	version := skipBelowVersion(c, "3.5", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_min_repl_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_min_repl_set_prop"
 	minRepl := 2
 	minReplChanged := 1
@@ -1075,10 +1121,6 @@ func TestCollectionMinReplFactDeprecatedSetProp(t *testing.T) {
 			}
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionMinReplFactDeprecatedSetPropInvalid updates the minimal replication factor
@@ -1088,6 +1130,12 @@ func TestCollectionMinReplFactDeprecatedSetPropInvalid(t *testing.T) {
 	version := skipBelowVersion(c, "3.5", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_min_repl_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_min_repl_set_prop_inv"
 	minRepl := 2
 	col := ensureCollection(nil, db, name, &driver.CreateCollectionOptions{
@@ -1114,10 +1162,6 @@ func TestCollectionMinReplFactDeprecatedSetPropInvalid(t *testing.T) {
 			}
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionWriteConcernCreate creates a collection with WriteConcern != 1.
@@ -1126,6 +1170,12 @@ func TestCollectionWriteConcernCreate(t *testing.T) {
 	skipBelowVersion(c, "3.6", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_write_concern_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_write_concern_create"
 	minRepl := 2
 	options := driver.CreateCollectionOptions{
@@ -1155,10 +1205,6 @@ func TestCollectionWriteConcernCreate(t *testing.T) {
 	assert.Equalf(t, minRepl, prop.MinReplicationFactor,
 		"Collection does not have the correct MinReplicationFactor value, expected `%d`, found `%d`", minRepl,
 		prop.MinReplicationFactor)
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionWriteConcernInvalid creates a collection with WriteConcern > replicationFactor
@@ -1168,6 +1214,12 @@ func TestCollectionWriteConcernInvalid(t *testing.T) {
 	skipNoCluster(c, t)
 
 	db := ensureDatabase(nil, c, "collection_write_concern_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_write_concern_invalid"
 	minRepl := 2
 	options := driver.CreateCollectionOptions{
@@ -1182,10 +1234,6 @@ func TestCollectionWriteConcernInvalid(t *testing.T) {
 	found, err := db.CollectionExists(nil, name)
 	require.Nilf(t, err, "CollectionExists('%s') failed: %s", name, describe(err))
 	assert.Equalf(t, false, found, "Collection %s should not exist", name)
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionWriteConcernClusterInv tests if WriteConcern is forwarded to ClusterInfo
@@ -1194,6 +1242,12 @@ func TestCollectionWriteConcernClusterInv(t *testing.T) {
 	skipBelowVersion(c, "3.6", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_write_concern_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_write_concern_cluster_invent"
 	minRepl := 2
 	ensureCollection(nil, db, name, &driver.CreateCollectionOptions{
@@ -1213,10 +1267,6 @@ func TestCollectionWriteConcernClusterInv(t *testing.T) {
 	assert.Equalf(t, minRepl, col.Parameters.WriteConcern,
 		"Collection does not have the correct WriteConcern value, expected `%d`, found `%d`",
 		minRepl, col.Parameters.WriteConcern)
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionWriteConcernSetProp updates the WriteConcern using SetProperties
@@ -1225,6 +1275,12 @@ func TestCollectionWriteConcernSetProp(t *testing.T) {
 	skipBelowVersion(c, "3.6", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_write_concern_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_write_concern_set_prop"
 	minRepl := 2
 	writeConcernChanged := 1
@@ -1242,10 +1298,6 @@ func TestCollectionWriteConcernSetProp(t *testing.T) {
 	require.Nilf(t, err, "Failed to get properties: %s", describe(err))
 
 	assert.Equal(t, writeConcernChanged, prop.WriteConcern)
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCollectionWriteConcernSetPropInvalid updates the writeConcern to an invalid value using SetProperties.
@@ -1254,6 +1306,12 @@ func TestCollectionWriteConcernSetPropInvalid(t *testing.T) {
 	skipBelowVersion(c, "3.6", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_write_concern_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_write_concern_set_prop_inv"
 	minRepl := 2
 	defaultWriteConcern := 1
@@ -1274,10 +1332,6 @@ func TestCollectionWriteConcernSetPropInvalid(t *testing.T) {
 	require.Nilf(t, err, "Failed to get properties: %s", describe(err))
 	assert.Equalf(t, defaultWriteConcern, prop.WriteConcern, "MinReplicationFactor not updated, expected %d, found %d",
 		minRepl, prop.WriteConcern)
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // Test_CollectionShards creates a collection and gets the shards' information.
@@ -1289,6 +1343,12 @@ func Test_CollectionShards(t *testing.T) {
 	databaseName := getCallerFunctionName()
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, databaseName, nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_collection_set_properties"
 	col, err := db.CreateCollection(nil, name, &driver.CreateCollectionOptions{
 		ReplicationFactor: 2,
@@ -1333,8 +1393,4 @@ func Test_CollectionShards(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, driver.ReplicationFactorSatellite, shards.ReplicationFactor)
 	})
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }

--- a/test/concurrency_test.go
+++ b/test/concurrency_test.go
@@ -56,6 +56,12 @@ func TestConcurrentCreateSmallDocuments(t *testing.T) {
 		t.Skip("Skipping VST load test on 3.2")
 	} else {
 		db := ensureDatabase(nil, c, "document_test", nil, t)
+		defer func() {
+			err := db.Remove(nil)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 		col := ensureCollection(nil, db, "TestConcurrentCreateSmallDocuments", nil, t)
 
 		docChan := make(chan driver.DocumentMeta, 128*1024)
@@ -120,10 +126,6 @@ func TestConcurrentCreateSmallDocuments(t *testing.T) {
 		wgCreators.Wait()
 		close(docChan)
 		wgReaders.Wait()
-		err = db.Remove(nil)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
 	}
 }
 
@@ -151,6 +153,12 @@ func TestConcurrentCreateBigDocuments(t *testing.T) {
 		t.Skip("Skipping VST load test on 3.2")
 	} else {
 		db := ensureDatabase(nil, c, "document_test", nil, t)
+		defer func() {
+			err := db.Remove(nil)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 		col := ensureCollection(nil, db, "TestConcurrentCreateBigDocuments", nil, t)
 
 		docChan := make(chan driver.DocumentMeta, 16*1024)
@@ -217,9 +225,5 @@ func TestConcurrentCreateBigDocuments(t *testing.T) {
 		wgCreators.Wait()
 		close(docChan)
 		wgReaders.Wait()
-		err = db.Remove(nil)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
 	}
 }

--- a/test/concurrency_test.go
+++ b/test/concurrency_test.go
@@ -120,6 +120,10 @@ func TestConcurrentCreateSmallDocuments(t *testing.T) {
 		wgCreators.Wait()
 		close(docChan)
 		wgReaders.Wait()
+		err = db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
 	}
 }
 
@@ -213,5 +217,9 @@ func TestConcurrentCreateBigDocuments(t *testing.T) {
 		wgCreators.Wait()
 		close(docChan)
 		wgReaders.Wait()
+		err = db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
 	}
 }

--- a/test/cursor_test.go
+++ b/test/cursor_test.go
@@ -40,6 +40,12 @@ func TestCreateCursorWithMaxRuntime(t *testing.T) {
 	skipBelowVersion(c, "3.6", t)
 	ctx := context.Background()
 	db := ensureDatabase(ctx, c, "cursor_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	ensureCollection(context.Background(), db, collectionName, nil, t)
 
 	tests := []struct {
@@ -82,17 +88,20 @@ func TestCreateCursorWithMaxRuntime(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestWithQueryOptimizerRules(t *testing.T) {
 	collectionName := "col_query_optimizer_rules"
 	fieldName := "value"
 	c := createClient(t, nil)
-	db := ensureDatabase(context.Background(), c, "query_optimizer_rules", nil, t)
+	ctx := context.Background()
+	db := ensureDatabase(ctx, c, "query_optimizer_rules", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(context.Background(), db, collectionName, nil, t)
 
 	tests := map[string]struct {
@@ -173,10 +182,6 @@ func TestWithQueryOptimizerRules(t *testing.T) {
 			}
 		})
 	}
-	err = db.Remove(ctxBackground)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateCursor creates several cursors.
@@ -185,6 +190,12 @@ func TestCreateCursor(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "cursor_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	// Create data set
 	collectionData := map[string][]interface{}{
@@ -401,10 +412,6 @@ func TestCreateCursor(t *testing.T) {
 			}
 		}
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateCursorReturnNull creates a cursor with a `RETURN NULL` query.
@@ -412,6 +419,12 @@ func TestCreateCursorReturnNull(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "cursor_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	var result interface{}
 	query := "return null"
@@ -425,10 +438,6 @@ func TestCreateCursorReturnNull(t *testing.T) {
 	}
 	if result != nil {
 		t.Errorf("Expected result to be nil, got %#v", result)
-	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -450,6 +459,12 @@ func TestCreateStreamCursor(t *testing.T) {
 	}
 
 	db := ensureDatabase(ctx, c, "cursor_stream_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "cursor_stream_test", nil, t)
 
 	// Query engine info (on rocksdb, JournalSize is always 0)
@@ -557,9 +572,5 @@ func TestCreateStreamCursor(t *testing.T) {
 
 	if readCount != expectedResults {
 		t.Errorf("Expected to read %d documents, instead got %d", expectedResults, readCount)
-	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/cursor_test.go
+++ b/test/cursor_test.go
@@ -38,7 +38,8 @@ func TestCreateCursorWithMaxRuntime(t *testing.T) {
 	collectionName := "cursor_max_retry_test"
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.6", t)
-	db := ensureDatabase(context.Background(), c, "cursor_test", nil, t)
+	ctx := context.Background()
+	db := ensureDatabase(ctx, c, "cursor_test", nil, t)
 	ensureCollection(context.Background(), db, collectionName, nil, t)
 
 	tests := []struct {
@@ -80,6 +81,10 @@ func TestCreateCursorWithMaxRuntime(t *testing.T) {
 
 			require.NoError(t, err)
 		})
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -167,6 +172,10 @@ func TestWithQueryOptimizerRules(t *testing.T) {
 				require.NotContains(t, r.Rules, rule)
 			}
 		})
+	}
+	err = db.Remove(ctxBackground)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -392,6 +401,10 @@ func TestCreateCursor(t *testing.T) {
 			}
 		}
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateCursorReturnNull creates a cursor with a `RETURN NULL` query.
@@ -412,6 +425,10 @@ func TestCreateCursorReturnNull(t *testing.T) {
 	}
 	if result != nil {
 		t.Errorf("Expected result to be nil, got %#v", result)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -540,5 +557,9 @@ func TestCreateStreamCursor(t *testing.T) {
 
 	if readCount != expectedResults {
 		t.Errorf("Expected to read %d documents, instead got %d", expectedResults, readCount)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/database_collection_defaults_test.go
+++ b/test/database_collection_defaults_test.go
@@ -70,6 +70,12 @@ func TestDatabaseSharding(t *testing.T) {
 
 			db, err := c.CreateDatabase(nil, name, &opt)
 			require.NoError(t, err)
+			defer func() {
+				err := db.Remove(nil)
+				if err != nil {
+					t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+				}
+			}()
 
 			info, err := db.Info(nil)
 			require.NoError(t, err)
@@ -169,6 +175,12 @@ func TestDatabaseDefaults(t *testing.T) {
 
 			db, err := c.CreateDatabase(nil, name, &opt)
 			require.NoError(t, err)
+			defer func() {
+				err := db.Remove(nil)
+				if err != nil {
+					t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+				}
+			}()
 
 			col, err := db.CreateCollection(nil, "test", &scenario.col)
 			require.NoError(t, err)

--- a/test/database_test.go
+++ b/test/database_test.go
@@ -256,7 +256,7 @@ func TestCreateDatabaseReplication2(t *testing.T) {
 	}
 
 	// Read database properties
-	db, err := c.Database(nil, name)
+	db, err = c.Database(nil, name)
 	if err != nil {
 		t.Fatal("Failed to get database ")
 	}

--- a/test/database_test.go
+++ b/test/database_test.go
@@ -230,45 +230,45 @@ func TestDatabaseNameUnicode(t *testing.T) {
 }
 
 // TestCreateDatabaseReplication2 creates a database with replication version two.
-func TestCreateDatabaseReplication2(t *testing.T) {
-	c := createClient(t, nil)
-	databaseReplication2Required(t, c)
-
-	name := "create_test_replication2"
-	opts := driver.CreateDatabaseOptions{Options: driver.CreateDatabaseDefaultOptions{
-		ReplicationVersion: driver.DatabaseReplicationVersionTwo,
-	}}
-	db, err := c.CreateDatabase(nil, name, &opts)
-	if err != nil {
-		t.Fatalf("Failed to create database '%s': %s", name, describe(err))
-	}
-	defer func() {
-		err := db.Remove(nil)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
-	}()
-	// Database must exist now
-	if found, err := c.DatabaseExists(nil, name); err != nil {
-		t.Errorf("DatabaseExists('%s') failed: %s", name, describe(err))
-	} else if !found {
-		t.Errorf("DatabaseExists('%s') return false, expected true", name)
-	}
-
-	// Read database properties
-	db, err = c.Database(nil, name)
-	if err != nil {
-		t.Fatal("Failed to get database ")
-	}
-	info, err := db.Info(nil)
-	if err != nil {
-		t.Fatal("Failed to get database name")
-	}
-
-	if info.ReplicationVersion != driver.DatabaseReplicationVersionTwo {
-		t.Errorf("Wrong replication version, expected %s, found %s", driver.DatabaseReplicationVersionTwo, info.ReplicationVersion)
-	}
-}
+//func TestCreateDatabaseReplication2(t *testing.T) {
+//	c := createClient(t, nil)
+//	databaseReplication2Required(t, c)
+//
+//	name := "create_test_replication2"
+//	opts := driver.CreateDatabaseOptions{Options: driver.CreateDatabaseDefaultOptions{
+//		ReplicationVersion: driver.DatabaseReplicationVersionTwo,
+//	}}
+//	db, err := c.CreateDatabase(nil, name, &opts)
+//	if err != nil {
+//		t.Fatalf("Failed to create database '%s': %s", name, describe(err))
+//	}
+//	defer func() {
+//		err := db.Remove(nil)
+//		if err != nil {
+//			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+//		}
+//	}()
+//	// Database must exist now
+//	if found, err := c.DatabaseExists(nil, name); err != nil {
+//		t.Errorf("DatabaseExists('%s') failed: %s", name, describe(err))
+//	} else if !found {
+//		t.Errorf("DatabaseExists('%s') return false, expected true", name)
+//	}
+//
+//	// Read database properties
+//	db, err = c.Database(nil, name)
+//	if err != nil {
+//		t.Fatal("Failed to get database ")
+//	}
+//	info, err := db.Info(nil)
+//	if err != nil {
+//		t.Fatal("Failed to get database name")
+//	}
+//
+//	if info.ReplicationVersion != driver.DatabaseReplicationVersionTwo {
+//		t.Errorf("Wrong replication version, expected %s, found %s", driver.DatabaseReplicationVersionTwo, info.ReplicationVersion)
+//	}
+//}
 
 // databaseReplication2Required skips test if the version is < 3.12.0.
 // It also skips the test if the ArangoDB has not been launched with the option--database.default-replication-version=2.

--- a/test/database_test.go
+++ b/test/database_test.go
@@ -281,12 +281,12 @@ func databaseReplication2Required(t *testing.T, c driver.Client) {
 		ReplicationVersion: driver.DatabaseReplicationVersionTwo,
 	}}
 
-	db, err := c.CreateDatabase(nil, name, &opts)
+	db, err := c.CreateDatabase(ctx, dbName, &opts)
 	if err != nil {
 		require.NoErrorf(t, db.Remove(ctx), "failed to remove testing replication2 database")
 	}
 	defer func() {
-		err := db.Remove(nil)
+		err := db.Remove(ctx)
 		if err != nil {
 			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 		}

--- a/test/database_test.go
+++ b/test/database_test.go
@@ -172,6 +172,12 @@ func TestDatabaseInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create database '%s': %s", name, describe(err))
 	}
+	defer func() {
+		err := d.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", d.Name(), err)
+		}
+	}()
 	info, err = d.Info(ctx)
 	if err != nil {
 		t.Fatalf("Failed to get %s database info: %s", name, describe(err))

--- a/test/database_test.go
+++ b/test/database_test.go
@@ -102,6 +102,12 @@ func TestCreateDatabase(t *testing.T) {
 	} else if !found {
 		t.Errorf("DatabaseExists('%s') return false, expected true", name)
 	}
+	db, err := c.Database(driver.WithSkipExistCheck(nil, true), name)
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
+
 }
 
 // TestRemoveDatabase creates a database and then removes it.

--- a/test/database_test.go
+++ b/test/database_test.go
@@ -272,30 +272,30 @@ func TestCreateDatabaseReplication2(t *testing.T) {
 
 // databaseReplication2Required skips test if the version is < 3.12.0.
 // It also skips the test if the ArangoDB has not been launched with the option--database.default-replication-version=2.
-func databaseReplication2Required(t *testing.T, c driver.Client) {
-	ctx := context.Background()
-	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.12.0")).Cluster()
-
-	dbName := "create_test_replication2"
-	opts := driver.CreateDatabaseOptions{Options: driver.CreateDatabaseDefaultOptions{
-		ReplicationVersion: driver.DatabaseReplicationVersionTwo,
-	}}
-
-	db, err := c.CreateDatabase(ctx, dbName, &opts)
-	if err != nil {
-		require.NoErrorf(t, db.Remove(ctx), "failed to remove testing replication2 database")
-	}
-	defer func() {
-		err := db.Remove(ctx)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
-	}()
-
-	if strings.Contains(err.Error(), "Replication version 2 is disabled in this binary") {
-		t.Skipf("ArangoDB is not launched with the option --database.default-replication-version=2")
-	}
-
-	// Some other error that has not been expected.
-	require.NoError(t, err)
-}
+//func databaseReplication2Required(t *testing.T, c driver.Client) {
+//	ctx := context.Background()
+//	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.12.0")).Cluster()
+//
+//	dbName := "create_test_replication2"
+//	opts := driver.CreateDatabaseOptions{Options: driver.CreateDatabaseDefaultOptions{
+//		ReplicationVersion: driver.DatabaseReplicationVersionTwo,
+//	}}
+//
+//	db, err := c.CreateDatabase(ctx, dbName, &opts)
+//	if err != nil {
+//		require.NoErrorf(t, db.Remove(ctx), "failed to remove testing replication2 database")
+//	}
+//	defer func() {
+//		err := db.Remove(ctx)
+//		if err != nil {
+//			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+//		}
+//	}()
+//
+//	if strings.Contains(err.Error(), "Replication version 2 is disabled in this binary") {
+//		t.Skipf("ArangoDB is not launched with the option --database.default-replication-version=2")
+//	}
+//
+//	// Some other error that has not been expected.
+//	require.NoError(t, err)
+//}

--- a/test/database_test.go
+++ b/test/database_test.go
@@ -147,12 +147,6 @@ func TestDatabaseInfo(t *testing.T) {
 
 	// Test system DB
 	db := ensureDatabase(ctx, c, "_system", nil, t)
-	defer func() {
-		// Cleanup: Remove database
-		if err := db.Remove(context.Background()); err != nil {
-			t.Fatalf("Failed to remove database: %s", describe(err))
-		}
-	}()
 	info, err := db.Info(ctx)
 	if err != nil {
 		t.Fatalf("Failed to get _system database info: %s", describe(err))

--- a/test/database_transaction_test.go
+++ b/test/database_transaction_test.go
@@ -68,6 +68,10 @@ func TestDatabaseTransaction(t *testing.T) {
 			}
 		})
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 func insertDocument(ctx context.Context, col driver.Collection, t *testing.T) driver.DocumentMeta {
@@ -127,6 +131,10 @@ func TestTransactionCommit(t *testing.T) {
 
 	// document should exist
 	documentExists(ctx, col, meta1.Key, true, t)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 func TestTransactionAbort(t *testing.T) {
@@ -158,4 +166,8 @@ func TestTransactionAbort(t *testing.T) {
 
 	// document should exist
 	documentExists(ctx, col, meta1.Key, false, t)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/database_transaction_test.go
+++ b/test/database_transaction_test.go
@@ -35,6 +35,12 @@ func TestDatabaseTransaction(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.2", t)
 	db := ensureDatabase(nil, c, "transaction_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	const colName = "books"
 	ensureCollection(context.Background(), db, colName, nil, t)
@@ -68,10 +74,6 @@ func TestDatabaseTransaction(t *testing.T) {
 			}
 		})
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func insertDocument(ctx context.Context, col driver.Collection, t *testing.T) driver.DocumentMeta {
@@ -104,6 +106,12 @@ func TestTransactionCommit(t *testing.T) {
 	colname := "trx_test_col"
 	ctx := context.Background()
 	db := ensureDatabase(ctx, c, "trx_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, colname, nil, t)
 
 	trxid, err := db.BeginTransaction(ctx, driver.TransactionCollections{Exclusive: []string{colname}}, nil)
@@ -131,10 +139,6 @@ func TestTransactionCommit(t *testing.T) {
 
 	// document should exist
 	documentExists(ctx, col, meta1.Key, true, t)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestTransactionAbort(t *testing.T) {
@@ -143,6 +147,12 @@ func TestTransactionAbort(t *testing.T) {
 	colname := "trx_test_col_abort"
 	ctx := context.Background()
 	db := ensureDatabase(ctx, c, "trx_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, colname, nil, t)
 
 	trxid, err := db.BeginTransaction(ctx, driver.TransactionCollections{Exclusive: []string{colname}}, nil)
@@ -166,8 +176,4 @@ func TestTransactionAbort(t *testing.T) {
 
 	// document should exist
 	documentExists(ctx, col, meta1.Key, false, t)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }

--- a/test/document_create_test.go
+++ b/test/document_create_test.go
@@ -67,6 +67,10 @@ func TestCreateDocument(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateDocumentWithKey creates a document with given key and then checks that it exists.
@@ -100,6 +104,10 @@ func TestCreateDocumentWithKey(t *testing.T) {
 	// Retry creating the document with same key. This must fail.
 	if _, err := col.CreateDocument(nil, doc); !driver.IsConflict(err) {
 		t.Fatalf("Expected ConflictError, got %s", describe(err))
+	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -142,6 +150,10 @@ func TestCreateDocumentReturnNew(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateDocumentSilent creates a document with WithSilent.
@@ -159,6 +171,10 @@ func TestCreateDocumentSilent(t *testing.T) {
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateDocumentNil creates a document with a nil document.
@@ -168,6 +184,10 @@ func TestCreateDocumentNil(t *testing.T) {
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	if _, err := col.CreateDocument(nil, nil); !driver.IsInvalidArgument(err) {
 		t.Fatalf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -201,5 +221,9 @@ func TestCreateDocumentInWaitForSyncCollection(t *testing.T) {
 	}
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
+	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/document_create_test.go
+++ b/test/document_create_test.go
@@ -44,6 +44,12 @@ func TestCreateDocument(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Jan",
@@ -67,10 +73,6 @@ func TestCreateDocument(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateDocumentWithKey creates a document with given key and then checks that it exists.
@@ -78,6 +80,12 @@ func TestCreateDocumentWithKey(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_withKey_test", nil, t)
 	doc := UserDocWithKey{
 		"jan",
@@ -105,10 +113,6 @@ func TestCreateDocumentWithKey(t *testing.T) {
 	if _, err := col.CreateDocument(nil, doc); !driver.IsConflict(err) {
 		t.Fatalf("Expected ConflictError, got %s", describe(err))
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateDocumentReturnNew creates a document and checks the document returned in in ReturnNew.
@@ -117,6 +121,12 @@ func TestCreateDocumentReturnNew(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"JanNew",
@@ -150,10 +160,6 @@ func TestCreateDocumentReturnNew(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateDocumentSilent creates a document with WithSilent.
@@ -161,6 +167,12 @@ func TestCreateDocumentSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Sjjjj",
@@ -171,23 +183,21 @@ func TestCreateDocumentSilent(t *testing.T) {
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateDocumentNil creates a document with a nil document.
 func TestCreateDocumentNil(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	if _, err := col.CreateDocument(nil, nil); !driver.IsInvalidArgument(err) {
 		t.Fatalf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -197,6 +207,12 @@ func TestCreateDocumentInWaitForSyncCollection(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "TestCreateDocumentInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)
@@ -221,9 +237,5 @@ func TestCreateDocumentInWaitForSyncCollection(t *testing.T) {
 	}
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
-	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/document_read_test.go
+++ b/test/document_read_test.go
@@ -69,4 +69,8 @@ func TestReadDocumentWithIfMatch(t *testing.T) {
 	if resp.StatusCode() != 412 {
 		t.Errorf("Expected status code 412, found %d", resp.StatusCode())
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/document_remove_test.go
+++ b/test/document_remove_test.go
@@ -56,6 +56,10 @@ func TestRemoveDocument(t *testing.T) {
 	} else if found {
 		t.Errorf("DocumentExists returned true for '%s', expected false", meta.Key)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveDocumentReturnOld creates a document, removes it checks the ReturnOld value.
@@ -87,6 +91,10 @@ func TestRemoveDocumentReturnOld(t *testing.T) {
 	if _, err := col.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveDocumentSilent creates a document, removes it with Silent() and then checks the meta is indeed empty.
@@ -113,6 +121,10 @@ func TestRemoveDocumentSilent(t *testing.T) {
 	var readDoc Account
 	if _, err := col.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -157,6 +169,10 @@ func TestRemoveDocumentRevision(t *testing.T) {
 	if _, err := col.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveDocumentKeyEmpty removes a document it with an empty key.
@@ -166,6 +182,10 @@ func TestRemoveDocumentKeyEmpty(t *testing.T) {
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	if _, err := col.RemoveDocument(nil, ""); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -200,5 +220,9 @@ func TestRemoveDocumentInWaitForSyncCollection(t *testing.T) {
 		t.Fatalf("DocumentExists failed for '%s': %s", meta.Key, describe(err))
 	} else if found {
 		t.Errorf("DocumentExists returned true for '%s', expected false", meta.Key)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/document_remove_test.go
+++ b/test/document_remove_test.go
@@ -33,6 +33,12 @@ func TestRemoveDocument(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Piere",
@@ -56,10 +62,6 @@ func TestRemoveDocument(t *testing.T) {
 	} else if found {
 		t.Errorf("DocumentExists returned true for '%s', expected false", meta.Key)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveDocumentReturnOld creates a document, removes it checks the ReturnOld value.
@@ -68,6 +70,12 @@ func TestRemoveDocumentReturnOld(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Tim",
@@ -91,10 +99,6 @@ func TestRemoveDocumentReturnOld(t *testing.T) {
 	if _, err := col.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveDocumentSilent creates a document, removes it with Silent() and then checks the meta is indeed empty.
@@ -102,6 +106,12 @@ func TestRemoveDocumentSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Angela",
@@ -122,10 +132,6 @@ func TestRemoveDocumentSilent(t *testing.T) {
 	if _, err := col.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveDocumentRevision creates a document, removes it with an incorrect revision.
@@ -133,6 +139,12 @@ func TestRemoveDocumentRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"DryLake",
@@ -169,23 +181,21 @@ func TestRemoveDocumentRevision(t *testing.T) {
 	if _, err := col.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveDocumentKeyEmpty removes a document it with an empty key.
 func TestRemoveDocumentKeyEmpty(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	if _, err := col.RemoveDocument(nil, ""); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -196,6 +206,12 @@ func TestRemoveDocumentInWaitForSyncCollection(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "TestRemoveDocumentInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)
@@ -220,9 +236,5 @@ func TestRemoveDocumentInWaitForSyncCollection(t *testing.T) {
 		t.Fatalf("DocumentExists failed for '%s': %s", meta.Key, describe(err))
 	} else if found {
 		t.Errorf("DocumentExists returned true for '%s', expected false", meta.Key)
-	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/document_replace_test.go
+++ b/test/document_replace_test.go
@@ -34,6 +34,12 @@ func TestReplaceDocument(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Piere",
@@ -59,10 +65,6 @@ func TestReplaceDocument(t *testing.T) {
 	if !reflect.DeepEqual(replacement, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", replacement, readDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceDocumentReturnOld creates a document, replaces it checks the ReturnOld value.
@@ -71,6 +73,12 @@ func TestReplaceDocumentReturnOld(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Tim",
@@ -93,10 +101,6 @@ func TestReplaceDocumentReturnOld(t *testing.T) {
 	if !reflect.DeepEqual(doc, old) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, old)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceDocumentReturnNew creates a document, replaces it checks the ReturnNew value.
@@ -105,6 +109,12 @@ func TestReplaceDocumentReturnNew(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Tim",
@@ -128,10 +138,6 @@ func TestReplaceDocumentReturnNew(t *testing.T) {
 	if !reflect.DeepEqual(expected, newDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", expected, newDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceDocumentSilent creates a document, replaces it with Silent() and then checks the meta is indeed empty.
@@ -139,6 +145,12 @@ func TestReplaceDocumentSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Angela",
@@ -158,10 +170,6 @@ func TestReplaceDocumentSilent(t *testing.T) {
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceDocumentRevision creates a document, replaces it with a specific (correct) revision.
@@ -170,6 +178,12 @@ func TestReplaceDocumentRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Revision",
@@ -206,16 +220,18 @@ func TestReplaceDocumentRevision(t *testing.T) {
 	if _, err := col.ReplaceDocument(replacedRevCtx, meta.Key, replacement); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceDocumentKeyEmpty replaces a document it with an empty key.
 func TestReplaceDocumentKeyEmpty(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	// Update document
 	replacement := map[string]interface{}{
@@ -224,23 +240,21 @@ func TestReplaceDocumentKeyEmpty(t *testing.T) {
 	if _, err := col.ReplaceDocument(nil, "", replacement); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceDocumentUpdateNil replaces a document it with a nil update.
 func TestReplaceDocumentUpdateNil(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	if _, err := col.ReplaceDocument(nil, "validKey", nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -251,6 +265,12 @@ func TestReplaceDocumentInWaitForSyncCollection(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "TestReplaceDocumentInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)
@@ -277,9 +297,5 @@ func TestReplaceDocumentInWaitForSyncCollection(t *testing.T) {
 	}
 	if !reflect.DeepEqual(replacement, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", replacement, readDoc)
-	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/document_replace_test.go
+++ b/test/document_replace_test.go
@@ -59,6 +59,10 @@ func TestReplaceDocument(t *testing.T) {
 	if !reflect.DeepEqual(replacement, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", replacement, readDoc)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceDocumentReturnOld creates a document, replaces it checks the ReturnOld value.
@@ -88,6 +92,10 @@ func TestReplaceDocumentReturnOld(t *testing.T) {
 	// Check old document
 	if !reflect.DeepEqual(doc, old) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, old)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -120,6 +128,10 @@ func TestReplaceDocumentReturnNew(t *testing.T) {
 	if !reflect.DeepEqual(expected, newDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", expected, newDoc)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceDocumentSilent creates a document, replaces it with Silent() and then checks the meta is indeed empty.
@@ -145,6 +157,10 @@ func TestReplaceDocumentSilent(t *testing.T) {
 		t.Fatalf("Failed to replace document '%s': %s", meta.Key, describe(err))
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -190,6 +206,10 @@ func TestReplaceDocumentRevision(t *testing.T) {
 	if _, err := col.ReplaceDocument(replacedRevCtx, meta.Key, replacement); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceDocumentKeyEmpty replaces a document it with an empty key.
@@ -204,6 +224,10 @@ func TestReplaceDocumentKeyEmpty(t *testing.T) {
 	if _, err := col.ReplaceDocument(nil, "", replacement); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceDocumentUpdateNil replaces a document it with a nil update.
@@ -213,6 +237,10 @@ func TestReplaceDocumentUpdateNil(t *testing.T) {
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	if _, err := col.ReplaceDocument(nil, "validKey", nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -249,5 +277,9 @@ func TestReplaceDocumentInWaitForSyncCollection(t *testing.T) {
 	}
 	if !reflect.DeepEqual(replacement, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", replacement, readDoc)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/document_update_test.go
+++ b/test/document_update_test.go
@@ -59,6 +59,10 @@ func TestUpdateDocument1(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateDocumentReturnOld creates a document, updates it checks the ReturnOld value.
@@ -88,6 +92,10 @@ func TestUpdateDocumentReturnOld(t *testing.T) {
 	// Check old document
 	if !reflect.DeepEqual(doc, old) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, old)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -120,6 +128,10 @@ func TestUpdateDocumentReturnNew(t *testing.T) {
 	expected.Name = "Updated"
 	if !reflect.DeepEqual(expected, newDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", expected, newDoc)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -166,6 +178,10 @@ func TestUpdateDocumentWithMergeObjectsTrue(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateDocumentKeepNullTrue creates a document, updates it with WithMerge(false) and then checks the update has succeeded.
@@ -211,6 +227,10 @@ func TestUpdateDocumentWithMergeObjectsFalse(t *testing.T) {
 	}
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -259,6 +279,10 @@ func TestUpdateDocumentKeepNullTrue(t *testing.T) {
 	} else if raw != nil {
 		t.Errorf("Expected user to be found and nil, got %s", string(*raw))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateDocumentKeepNullFalse creates a document, updates it with KeepNull(false) and then checks the update has succeeded.
@@ -295,6 +319,10 @@ func TestUpdateDocumentKeepNullFalse(t *testing.T) {
 	if readDoc.User == nil {
 		t.Errorf("Expected user to be untouched, got %v", readDoc.User)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateDocumentSilent creates a document, updates it with Silent() and then checks the meta is indeed empty.
@@ -320,6 +348,10 @@ func TestUpdateDocumentSilent(t *testing.T) {
 		t.Fatalf("Failed to update document '%s': %s", meta.Key, describe(err))
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -365,6 +397,10 @@ func TestUpdateDocumentRevision(t *testing.T) {
 	if _, err := col.UpdateDocument(updatedRevCtx, meta.Key, update); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateDocumentKeyEmpty updates a document it with an empty key.
@@ -379,6 +415,10 @@ func TestUpdateDocumentKeyEmpty(t *testing.T) {
 	if _, err := col.UpdateDocument(nil, "", update); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateDocumentUpdateNil updates a document it with a nil update.
@@ -388,6 +428,10 @@ func TestUpdateDocumentUpdateNil(t *testing.T) {
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	if _, err := col.UpdateDocument(nil, "validKey", nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -424,5 +468,9 @@ func TestUpdateDocumentInWaitForSyncCollection(t *testing.T) {
 	doc.Name = "Updated"
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/document_update_test.go
+++ b/test/document_update_test.go
@@ -34,6 +34,12 @@ func TestUpdateDocument1(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Piere",
@@ -59,10 +65,6 @@ func TestUpdateDocument1(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentReturnOld creates a document, updates it checks the ReturnOld value.
@@ -71,6 +73,12 @@ func TestUpdateDocumentReturnOld(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Tim",
@@ -93,10 +101,6 @@ func TestUpdateDocumentReturnOld(t *testing.T) {
 	if !reflect.DeepEqual(doc, old) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, old)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentReturnNew creates a document, updates it checks the ReturnNew value.
@@ -105,6 +109,12 @@ func TestUpdateDocumentReturnNew(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Tim",
@@ -129,10 +139,6 @@ func TestUpdateDocumentReturnNew(t *testing.T) {
 	if !reflect.DeepEqual(expected, newDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", expected, newDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentKeepNullTrue creates a document, updates it with MergeObjects(true) and then checks the update has succeeded.
@@ -141,6 +147,12 @@ func TestUpdateDocumentWithMergeObjectsTrue(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	type account struct {
 		ID   string                 `json:"id"`
@@ -178,10 +190,6 @@ func TestUpdateDocumentWithMergeObjectsTrue(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentKeepNullTrue creates a document, updates it with WithMerge(false) and then checks the update has succeeded.
@@ -190,6 +198,12 @@ func TestUpdateDocumentWithMergeObjectsFalse(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	type account struct {
 		ID   string                 `json:"id"`
@@ -228,10 +242,6 @@ func TestUpdateDocumentWithMergeObjectsFalse(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentKeepNullTrue creates a document, updates it with KeepNull(true) and then checks the update has succeeded.
@@ -241,6 +251,12 @@ func TestUpdateDocumentKeepNullTrue(t *testing.T) {
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	conn := c.Connection()
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := Account{
 		ID: "1234",
@@ -279,10 +295,6 @@ func TestUpdateDocumentKeepNullTrue(t *testing.T) {
 	} else if raw != nil {
 		t.Errorf("Expected user to be found and nil, got %s", string(*raw))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentKeepNullFalse creates a document, updates it with KeepNull(false) and then checks the update has succeeded.
@@ -291,6 +303,12 @@ func TestUpdateDocumentKeepNullFalse(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := Account{
 		ID: "1234",
@@ -319,10 +337,6 @@ func TestUpdateDocumentKeepNullFalse(t *testing.T) {
 	if readDoc.User == nil {
 		t.Errorf("Expected user to be untouched, got %v", readDoc.User)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentSilent creates a document, updates it with Silent() and then checks the meta is indeed empty.
@@ -330,6 +344,12 @@ func TestUpdateDocumentSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Angela",
@@ -349,10 +369,6 @@ func TestUpdateDocumentSilent(t *testing.T) {
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentRevision creates a document, updates it with a specific (correct) revision.
@@ -361,6 +377,12 @@ func TestUpdateDocumentRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Revision",
@@ -397,16 +419,18 @@ func TestUpdateDocumentRevision(t *testing.T) {
 	if _, err := col.UpdateDocument(updatedRevCtx, meta.Key, update); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentKeyEmpty updates a document it with an empty key.
 func TestUpdateDocumentKeyEmpty(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	// Update document
 	update := map[string]interface{}{
@@ -415,23 +439,21 @@ func TestUpdateDocumentKeyEmpty(t *testing.T) {
 	if _, err := col.UpdateDocument(nil, "", update); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentUpdateNil updates a document it with a nil update.
 func TestUpdateDocumentUpdateNil(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	if _, err := col.UpdateDocument(nil, "validKey", nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -442,6 +464,12 @@ func TestUpdateDocumentInWaitForSyncCollection(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "TestUpdateDocumentInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)
@@ -468,9 +496,5 @@ func TestUpdateDocumentInWaitForSyncCollection(t *testing.T) {
 	doc.Name = "Updated"
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
-	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/documents_create_overwrite_test.go
+++ b/test/documents_create_overwrite_test.go
@@ -48,6 +48,12 @@ func TestCreateOverwriteDocument(t *testing.T) {
 	defer cancel()
 
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_overwrite_test", nil, t)
 
 	t.Run("Single Doc - replace", func(t *testing.T) {
@@ -89,10 +95,6 @@ func TestCreateOverwriteDocument(t *testing.T) {
 		}
 	})
 
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateOverwriteModeDocument creates a document and then checks that it exists. Check with overwriteMode flag.
@@ -106,6 +108,12 @@ func TestCreateOverwriteModeDocument(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.7.0"))
 
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 
 	t.Run("Single Doc - ignore", func(t *testing.T) {
@@ -480,8 +488,4 @@ func TestCreateOverwriteModeDocument(t *testing.T) {
 		require.EqualError(t, errSlice[0], "unique constraint violated - in index primary of type primary over '_key'; conflicting key: "+id[0])
 		require.EqualError(t, errSlice[1], "unique constraint violated - in index primary of type primary over '_key'; conflicting key: "+id[1])
 	})
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }

--- a/test/documents_create_overwrite_test.go
+++ b/test/documents_create_overwrite_test.go
@@ -89,6 +89,10 @@ func TestCreateOverwriteDocument(t *testing.T) {
 		}
 	})
 
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateOverwriteModeDocument creates a document and then checks that it exists. Check with overwriteMode flag.
@@ -476,4 +480,8 @@ func TestCreateOverwriteModeDocument(t *testing.T) {
 		require.EqualError(t, errSlice[0], "unique constraint violated - in index primary of type primary over '_key'; conflicting key: "+id[0])
 		require.EqualError(t, errSlice[1], "unique constraint violated - in index primary of type primary over '_key'; conflicting key: "+id[1])
 	})
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/documents_create_test.go
+++ b/test/documents_create_test.go
@@ -84,6 +84,10 @@ func TestCreateDocuments(t *testing.T) {
 			}
 		}
 	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateDocumentsReturnNew creates a document and checks the document returned in in ReturnNew.
@@ -128,6 +132,10 @@ func TestCreateDocumentsReturnNew(t *testing.T) {
 			}
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateDocumentsSilent creates a document with WithSilent.
@@ -156,6 +164,10 @@ func TestCreateDocumentsSilent(t *testing.T) {
 			t.Errorf("Expected 0 errors, got %d", len(errs))
 		}
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateDocumentsNil creates multiple documents with a nil documents input.
@@ -165,6 +177,10 @@ func TestCreateDocumentsNil(t *testing.T) {
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	if _, _, err := col.CreateDocuments(nil, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -180,6 +196,10 @@ func TestCreateDocumentsNonSlice(t *testing.T) {
 	var m map[string]interface{}
 	if _, _, err := col.CreateDocuments(nil, &m); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -225,5 +245,9 @@ func TestCreateDocumentsInWaitForSyncCollection(t *testing.T) {
 				t.Errorf("Got wrong document. Expected %+v, got %+v", docs[i], readDoc)
 			}
 		}
+	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/documents_create_test.go
+++ b/test/documents_create_test.go
@@ -33,6 +33,12 @@ func TestCreateDocuments(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -84,10 +90,6 @@ func TestCreateDocuments(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateDocumentsReturnNew creates a document and checks the document returned in in ReturnNew.
@@ -96,6 +98,12 @@ func TestCreateDocumentsReturnNew(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -132,10 +140,6 @@ func TestCreateDocumentsReturnNew(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateDocumentsSilent creates a document with WithSilent.
@@ -143,6 +147,12 @@ func TestCreateDocumentsSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -164,23 +174,21 @@ func TestCreateDocumentsSilent(t *testing.T) {
 			t.Errorf("Expected 0 errors, got %d", len(errs))
 		}
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateDocumentsNil creates multiple documents with a nil documents input.
 func TestCreateDocumentsNil(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	if _, _, err := col.CreateDocuments(nil, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -188,6 +196,12 @@ func TestCreateDocumentsNil(t *testing.T) {
 func TestCreateDocumentsNonSlice(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	var obj UserDoc
 	if _, _, err := col.CreateDocuments(nil, &obj); !driver.IsInvalidArgument(err) {
@@ -197,10 +211,6 @@ func TestCreateDocumentsNonSlice(t *testing.T) {
 	if _, _, err := col.CreateDocuments(nil, &m); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateDocumentsInWaitForSyncCollection creates a few documents in a collection with waitForSync enabled and then checks that it exists.
@@ -208,6 +218,12 @@ func TestCreateDocumentsInWaitForSyncCollection(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "TestCreateDocumentsInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)
@@ -245,9 +261,5 @@ func TestCreateDocumentsInWaitForSyncCollection(t *testing.T) {
 				t.Errorf("Got wrong document. Expected %+v, got %+v", docs[i], readDoc)
 			}
 		}
-	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/documents_import_test.go
+++ b/test/documents_import_test.go
@@ -30,6 +30,12 @@ import (
 func TestImportDocumentsWithKeys(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_withKeys_test", nil, t)
 	docs := []UserDocWithKey{
 		{
@@ -65,16 +71,18 @@ func TestImportDocumentsWithKeys(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 0, stats.Empty, formatRawResponse(raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportDocumentsWithoutKeys imports documents and then checks that it exists.
 func TestImportDocumentsWithoutKeys(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_withoutKeys_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -107,10 +115,6 @@ func TestImportDocumentsWithoutKeys(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 0, stats.Empty, formatRawResponse(raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportDocumentsEmptyEntries imports documents and then checks that it exists.
@@ -121,6 +125,12 @@ func TestImportDocumentsEmptyEntries(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_emptyEntries_test", nil, t)
 	docs := []*UserDocWithKey{
 		{
@@ -157,10 +167,6 @@ func TestImportDocumentsEmptyEntries(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 1, stats.Empty, formatRawResponse(raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportDocumentsInvalidEntries imports documents and then checks that it exists.
@@ -170,6 +176,12 @@ func TestImportDocumentsInvalidEntries(t *testing.T) {
 	}
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_invalidEntries_test", nil, t)
 	docs := []interface{}{
 		&UserDocWithKey{
@@ -208,16 +220,18 @@ func TestImportDocumentsInvalidEntries(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 1, stats.Empty, formatRawResponse(raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportDocumentsDuplicateEntries imports documents and then checks that it exists.
 func TestImportDocumentsDuplicateEntries(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_duplicateEntries_test", nil, t)
 	docs := []interface{}{
 		&UserDocWithKey{
@@ -254,16 +268,18 @@ func TestImportDocumentsDuplicateEntries(t *testing.T) {
 			t.Errorf("Expected %d ignored documents, got %d (json %s)", 0, stats.Ignored, formatRawResponse(raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportDocumentsDuplicateEntriesComplete imports documents and then checks that it exists.
 func TestImportDocumentsDuplicateEntriesComplete(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_duplicateEntriesComplete_test", nil, t)
 	docs := []interface{}{
 		&UserDocWithKey{
@@ -285,10 +301,6 @@ func TestImportDocumentsDuplicateEntriesComplete(t *testing.T) {
 	}); !driver.IsConflict(err) {
 		t.Errorf("Expected ConflictError, got %s", describe(err))
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportDocumentsDuplicateEntriesUpdate imports documents and then checks that it exists.
@@ -296,6 +308,12 @@ func TestImportDocumentsDuplicateEntriesUpdate(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_duplicateEntriesUpdate_test", nil, t)
 	docs := []interface{}{
 		&UserDocWithKey{
@@ -345,10 +363,6 @@ func TestImportDocumentsDuplicateEntriesUpdate(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportDocumentsDuplicateEntriesReplace imports documents and then checks that it exists.
@@ -356,6 +370,12 @@ func TestImportDocumentsDuplicateEntriesReplace(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_duplicateEntriesReplace_test", nil, t)
 	docs := []interface{}{
 		&UserDocWithKey{
@@ -405,10 +425,6 @@ func TestImportDocumentsDuplicateEntriesReplace(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportDocumentsDuplicateEntriesIgnore imports documents and then checks that it exists.
@@ -416,6 +432,12 @@ func TestImportDocumentsDuplicateEntriesIgnore(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_duplicateEntriesIgnore_test", nil, t)
 	docs := []interface{}{
 		&UserDocWithKey{
@@ -465,10 +487,6 @@ func TestImportDocumentsDuplicateEntriesIgnore(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportDocumentsDetails imports documents and then checks that it exists.
@@ -476,6 +494,12 @@ func TestImportDocumentsDetails(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_details_test", nil, t)
 	docs := []interface{}{
 		&UserDocWithKey{
@@ -519,10 +543,6 @@ func TestImportDocumentsDetails(t *testing.T) {
 			t.Errorf("Expected details[0] to be '%s', got '%s'", detailsExpected, details[0])
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportDocumentsOverwriteYes imports documents and then checks that it exists.
@@ -530,6 +550,12 @@ func TestImportDocumentsOverwriteYes(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_overwriteYes_test", nil, t)
 	docs := []interface{}{
 		&UserDoc{
@@ -563,10 +589,6 @@ func TestImportDocumentsOverwriteYes(t *testing.T) {
 			t.Errorf("Expected count to be %d in round %d, got %d", countExpected, i, count)
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportDocumentsOverwriteNo imports documents and then checks that it exists.
@@ -574,6 +596,12 @@ func TestImportDocumentsOverwriteNo(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_overwriteNo_test", nil, t)
 	docs := []interface{}{
 		&UserDoc{
@@ -607,10 +635,6 @@ func TestImportDocumentsOverwriteNo(t *testing.T) {
 			t.Errorf("Expected count to be %d in round %d, got %d", countExpected, i, count)
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportDocumentsWithKeysInWaitForSyncCollection imports documents into a collection with waitForSync enabled
@@ -618,6 +642,12 @@ func TestImportDocumentsOverwriteNo(t *testing.T) {
 func TestImportDocumentsWithKeysInWaitForSyncCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "TestImportDocumentsWithKeysInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)
@@ -654,9 +684,5 @@ func TestImportDocumentsWithKeysInWaitForSyncCollection(t *testing.T) {
 		if stats.Empty != 0 {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 0, stats.Empty, formatRawResponse(raw))
 		}
-	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/documents_import_test.go
+++ b/test/documents_import_test.go
@@ -126,7 +126,7 @@ func TestImportDocumentsEmptyEntries(t *testing.T) {
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
 	defer func() {
-		err := db.Remove(ctx)
+		err := db.Remove(nil)
 		if err != nil {
 			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 		}

--- a/test/documents_import_test.go
+++ b/test/documents_import_test.go
@@ -65,6 +65,10 @@ func TestImportDocumentsWithKeys(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 0, stats.Empty, formatRawResponse(raw))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportDocumentsWithoutKeys imports documents and then checks that it exists.
@@ -102,6 +106,10 @@ func TestImportDocumentsWithoutKeys(t *testing.T) {
 		if stats.Empty != 0 {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 0, stats.Empty, formatRawResponse(raw))
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -148,6 +156,10 @@ func TestImportDocumentsEmptyEntries(t *testing.T) {
 		if stats.Empty != 1 {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 1, stats.Empty, formatRawResponse(raw))
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -196,6 +208,10 @@ func TestImportDocumentsInvalidEntries(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 1, stats.Empty, formatRawResponse(raw))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportDocumentsDuplicateEntries imports documents and then checks that it exists.
@@ -238,6 +254,10 @@ func TestImportDocumentsDuplicateEntries(t *testing.T) {
 			t.Errorf("Expected %d ignored documents, got %d (json %s)", 0, stats.Ignored, formatRawResponse(raw))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportDocumentsDuplicateEntriesComplete imports documents and then checks that it exists.
@@ -264,6 +284,10 @@ func TestImportDocumentsDuplicateEntriesComplete(t *testing.T) {
 		Complete: true,
 	}); !driver.IsConflict(err) {
 		t.Errorf("Expected ConflictError, got %s", describe(err))
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -321,6 +345,10 @@ func TestImportDocumentsDuplicateEntriesUpdate(t *testing.T) {
 			}
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportDocumentsDuplicateEntriesReplace imports documents and then checks that it exists.
@@ -376,6 +404,10 @@ func TestImportDocumentsDuplicateEntriesReplace(t *testing.T) {
 				t.Errorf("Expected Age to be 0, got %d", user.Age)
 			}
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -433,6 +465,10 @@ func TestImportDocumentsDuplicateEntriesIgnore(t *testing.T) {
 			}
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportDocumentsDetails imports documents and then checks that it exists.
@@ -483,6 +519,10 @@ func TestImportDocumentsDetails(t *testing.T) {
 			t.Errorf("Expected details[0] to be '%s', got '%s'", detailsExpected, details[0])
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportDocumentsOverwriteYes imports documents and then checks that it exists.
@@ -523,6 +563,10 @@ func TestImportDocumentsOverwriteYes(t *testing.T) {
 			t.Errorf("Expected count to be %d in round %d, got %d", countExpected, i, count)
 		}
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportDocumentsOverwriteNo imports documents and then checks that it exists.
@@ -562,6 +606,10 @@ func TestImportDocumentsOverwriteNo(t *testing.T) {
 		} else if count != countExpected {
 			t.Errorf("Expected count to be %d in round %d, got %d", countExpected, i, count)
 		}
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -606,5 +654,9 @@ func TestImportDocumentsWithKeysInWaitForSyncCollection(t *testing.T) {
 		if stats.Empty != 0 {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 0, stats.Empty, formatRawResponse(raw))
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/documents_remove_test.go
+++ b/test/documents_remove_test.go
@@ -56,6 +56,10 @@ func TestRemoveDocuments(t *testing.T) {
 			t.Fatalf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveDocumentsReturnOld creates documents, removes them checks the ReturnOld value.
@@ -104,6 +108,10 @@ func TestRemoveDocumentsReturnOld(t *testing.T) {
 			t.Fatalf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveDocumentsSilent creates documents, removes them with Silent() and then checks the meta is indeed empty.
@@ -145,6 +153,10 @@ func TestRemoveDocumentsSilent(t *testing.T) {
 		if _, err := col.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 			t.Errorf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -214,6 +226,10 @@ func TestRemoveDocumentsRevision(t *testing.T) {
 			t.Errorf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveDocumentsKeyEmpty removes a document it with an empty key.
@@ -223,6 +239,10 @@ func TestRemoveDocumentsKeyEmpty(t *testing.T) {
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	if _, _, err := col.RemoveDocuments(nil, []string{""}); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -256,5 +276,9 @@ func TestRemoveDocumentsInWaitForSyncCollection(t *testing.T) {
 		if _, err := col.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 			t.Fatalf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/documents_remove_test.go
+++ b/test/documents_remove_test.go
@@ -33,6 +33,12 @@ func TestRemoveDocuments(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -56,10 +62,6 @@ func TestRemoveDocuments(t *testing.T) {
 			t.Fatalf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveDocumentsReturnOld creates documents, removes them checks the ReturnOld value.
@@ -67,6 +69,12 @@ func TestRemoveDocumentsReturnOld(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -108,10 +116,6 @@ func TestRemoveDocumentsReturnOld(t *testing.T) {
 			t.Fatalf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveDocumentsSilent creates documents, removes them with Silent() and then checks the meta is indeed empty.
@@ -119,6 +123,12 @@ func TestRemoveDocumentsSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -154,10 +164,6 @@ func TestRemoveDocumentsSilent(t *testing.T) {
 			t.Errorf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveDocumentsRevision creates documents, removes them with an incorrect revisions.
@@ -165,6 +171,12 @@ func TestRemoveDocumentsRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -226,23 +238,21 @@ func TestRemoveDocumentsRevision(t *testing.T) {
 			t.Errorf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveDocumentsKeyEmpty removes a document it with an empty key.
 func TestRemoveDocumentsKeyEmpty(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	if _, _, err := col.RemoveDocuments(nil, []string{""}); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -252,6 +262,12 @@ func TestRemoveDocumentsInWaitForSyncCollection(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "TestRemoveDocumentsInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)
@@ -276,9 +292,5 @@ func TestRemoveDocumentsInWaitForSyncCollection(t *testing.T) {
 		if _, err := col.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 			t.Fatalf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
-	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/documents_replace_test.go
+++ b/test/documents_replace_test.go
@@ -335,10 +335,6 @@ func TestReplaceDocumentsKeyEmpty(t *testing.T) {
 	if _, _, err := col.ReplaceDocuments(nil, []string{""}, replacement); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceDocumentsUpdateNil replaces a document it with a nil update.

--- a/test/documents_replace_test.go
+++ b/test/documents_replace_test.go
@@ -35,6 +35,12 @@ func TestReplaceDocuments(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -76,10 +82,6 @@ func TestReplaceDocuments(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, replacements[i], readDoc)
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceDocumentsReturnOld creates documents, replaces them checks the ReturnOld values.
@@ -87,6 +89,12 @@ func TestReplaceDocumentsReturnOld(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -124,10 +132,6 @@ func TestReplaceDocumentsReturnOld(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, oldDocs[i])
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceDocumentsReturnNew creates documents, replaces them checks the ReturnNew values.
@@ -135,6 +139,12 @@ func TestReplaceDocumentsReturnNew(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -173,10 +183,6 @@ func TestReplaceDocumentsReturnNew(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, expected, newDocs[i])
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceDocumentsSilent creates documents, replaces them with Silent() and then checks the meta is indeed empty.
@@ -184,6 +190,12 @@ func TestReplaceDocumentsSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -228,10 +240,6 @@ func TestReplaceDocumentsSilent(t *testing.T) {
 			t.Errorf("Expected 0 metas, got %d", len(metas))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceDocumentsRevision creates documents, replaces then with a specific (correct) revisions.
@@ -240,6 +248,12 @@ func TestReplaceDocumentsRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -301,16 +315,18 @@ func TestReplaceDocumentsRevision(t *testing.T) {
 	} else if err := errs.FirstNonNil(); err != nil {
 		t.Fatalf("Expected no errors, got first: %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceDocumentsKeyEmpty replaces a document it with an empty key.
 func TestReplaceDocumentsKeyEmpty(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	// Replacement document
 	replacement := map[string]interface{}{
@@ -333,16 +349,18 @@ func TestReplaceDocumentsUpdateNil(t *testing.T) {
 	if _, _, err := col.ReplaceDocuments(nil, []string{"validKey"}, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceDocumentsUpdateLenDiff replacements documents with a different number of documents, keys.
 func TestReplaceDocumentsUpdateLenDiff(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	replacements := []map[string]interface{}{
 		{
@@ -355,10 +373,6 @@ func TestReplaceDocumentsUpdateLenDiff(t *testing.T) {
 	if _, _, err := col.ReplaceDocuments(nil, []string{"only1"}, replacements); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceDocumentsInWaitForSyncCollection creates documents into a collection with waitForSync enabled,
@@ -368,6 +382,12 @@ func TestReplaceDocumentsInWaitForSyncCollection(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "TestReplaceDocumentsInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)
@@ -410,9 +430,5 @@ func TestReplaceDocumentsInWaitForSyncCollection(t *testing.T) {
 		if !reflect.DeepEqual(replacements[i], readDoc) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, replacements[i], readDoc)
 		}
-	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/documents_replace_test.go
+++ b/test/documents_replace_test.go
@@ -76,6 +76,10 @@ func TestReplaceDocuments(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, replacements[i], readDoc)
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceDocumentsReturnOld creates documents, replaces them checks the ReturnOld values.
@@ -119,6 +123,10 @@ func TestReplaceDocumentsReturnOld(t *testing.T) {
 		if !reflect.DeepEqual(doc, oldDocs[i]) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, oldDocs[i])
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -164,6 +172,10 @@ func TestReplaceDocumentsReturnNew(t *testing.T) {
 		if !reflect.DeepEqual(expected, newDocs[i]) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, expected, newDocs[i])
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -215,6 +227,10 @@ func TestReplaceDocumentsSilent(t *testing.T) {
 		if len(metas) > 0 {
 			t.Errorf("Expected 0 metas, got %d", len(metas))
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -285,6 +301,10 @@ func TestReplaceDocumentsRevision(t *testing.T) {
 	} else if err := errs.FirstNonNil(); err != nil {
 		t.Fatalf("Expected no errors, got first: %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceDocumentsKeyEmpty replaces a document it with an empty key.
@@ -299,6 +319,10 @@ func TestReplaceDocumentsKeyEmpty(t *testing.T) {
 	if _, _, err := col.ReplaceDocuments(nil, []string{""}, replacement); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceDocumentsUpdateNil replaces a document it with a nil update.
@@ -308,6 +332,10 @@ func TestReplaceDocumentsUpdateNil(t *testing.T) {
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	if _, _, err := col.ReplaceDocuments(nil, []string{"validKey"}, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -326,6 +354,10 @@ func TestReplaceDocumentsUpdateLenDiff(t *testing.T) {
 	}
 	if _, _, err := col.ReplaceDocuments(nil, []string{"only1"}, replacements); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -378,5 +410,9 @@ func TestReplaceDocumentsInWaitForSyncCollection(t *testing.T) {
 		if !reflect.DeepEqual(replacements[i], readDoc) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, replacements[i], readDoc)
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/documents_update_test.go
+++ b/test/documents_update_test.go
@@ -38,6 +38,12 @@ func TestUpdateDocuments1(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -79,10 +85,6 @@ func TestUpdateDocuments1(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, readDoc)
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentsReturnOld creates documents, updates them checks the ReturnOld values.
@@ -90,6 +92,12 @@ func TestUpdateDocumentsReturnOld(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -144,10 +152,6 @@ func TestUpdateDocumentsReturnOld(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, oldDocs[i])
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentsReturnNew creates documents, updates them checks the ReturnNew values.
@@ -155,6 +159,12 @@ func TestUpdateDocumentsReturnNew(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -201,10 +211,6 @@ func TestUpdateDocumentsReturnNew(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, expected, newDocs[i])
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentsKeepNullTrue creates documents, updates them with KeepNull(true) and then checks the updates have succeeded.
@@ -214,6 +220,12 @@ func TestUpdateDocumentsKeepNullTrue(t *testing.T) {
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	conn := c.Connection()
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []Account{
 		{
@@ -272,10 +284,6 @@ func TestUpdateDocumentsKeepNullTrue(t *testing.T) {
 			t.Errorf("Expected user to be found and nil, got %s", string(*raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentsKeepNullFalse creates documents, updates them with KeepNull(false) and then checks the updates have succeeded.
@@ -284,6 +292,12 @@ func TestUpdateDocumentsKeepNullFalse(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []Account{
 		{
@@ -331,10 +345,6 @@ func TestUpdateDocumentsKeepNullFalse(t *testing.T) {
 			t.Errorf("Expected user to be untouched, got %v", readDoc.User)
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentsSilent creates documents, updates them with Silent() and then checks the metas are indeed empty.
@@ -342,6 +352,12 @@ func TestUpdateDocumentsSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -374,10 +390,6 @@ func TestUpdateDocumentsSilent(t *testing.T) {
 	} else if strings.Join(metas.Keys(), "") != "" {
 		t.Errorf("Expected empty meta, got %v", metas)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentsRevision creates documents, updates them with a specific (correct) revisions.
@@ -386,6 +398,12 @@ func TestUpdateDocumentsRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -444,16 +462,18 @@ func TestUpdateDocumentsRevision(t *testing.T) {
 	if _, _, err := col.UpdateDocuments(updatedRevCtx, metas.Keys(), updates); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentsKeyEmpty updates documents with an empty key.
 func TestUpdateDocumentsKeyEmpty(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	// Update document
 	updates := []map[string]interface{}{
@@ -464,23 +484,21 @@ func TestUpdateDocumentsKeyEmpty(t *testing.T) {
 	if _, _, err := col.UpdateDocuments(nil, []string{""}, updates); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentsUpdateNil updates documents it with a nil update.
 func TestUpdateDocumentsUpdateNil(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	if _, _, err := col.UpdateDocuments(nil, []string{"validKey"}, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -488,6 +506,12 @@ func TestUpdateDocumentsUpdateNil(t *testing.T) {
 func TestUpdateDocumentsUpdateLenDiff(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	updates := []map[string]interface{}{
 		{
@@ -500,10 +524,6 @@ func TestUpdateDocumentsUpdateLenDiff(t *testing.T) {
 	if _, _, err := col.UpdateDocuments(nil, []string{"only1"}, updates); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateDocumentsInWaitForSyncCollection creates documents in a collection with waitForSync enabled,
@@ -513,6 +533,12 @@ func TestUpdateDocumentsInWaitForSyncCollection(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "TestUpdateDocumentsInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)
@@ -555,9 +581,5 @@ func TestUpdateDocumentsInWaitForSyncCollection(t *testing.T) {
 		if !reflect.DeepEqual(doc, readDoc) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, readDoc)
 		}
-	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/documents_update_test.go
+++ b/test/documents_update_test.go
@@ -79,6 +79,10 @@ func TestUpdateDocuments1(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, readDoc)
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateDocumentsReturnOld creates documents, updates them checks the ReturnOld values.
@@ -140,6 +144,10 @@ func TestUpdateDocumentsReturnOld(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, oldDocs[i])
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateDocumentsReturnNew creates documents, updates them checks the ReturnNew values.
@@ -192,6 +200,10 @@ func TestUpdateDocumentsReturnNew(t *testing.T) {
 		if !reflect.DeepEqual(expected, newDocs[i]) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, expected, newDocs[i])
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -260,6 +272,10 @@ func TestUpdateDocumentsKeepNullTrue(t *testing.T) {
 			t.Errorf("Expected user to be found and nil, got %s", string(*raw))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateDocumentsKeepNullFalse creates documents, updates them with KeepNull(false) and then checks the updates have succeeded.
@@ -315,6 +331,10 @@ func TestUpdateDocumentsKeepNullFalse(t *testing.T) {
 			t.Errorf("Expected user to be untouched, got %v", readDoc.User)
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateDocumentsSilent creates documents, updates them with Silent() and then checks the metas are indeed empty.
@@ -353,6 +373,10 @@ func TestUpdateDocumentsSilent(t *testing.T) {
 		t.Fatalf("Expected no errors, got first: %s", describe(err))
 	} else if strings.Join(metas.Keys(), "") != "" {
 		t.Errorf("Expected empty meta, got %v", metas)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -420,6 +444,10 @@ func TestUpdateDocumentsRevision(t *testing.T) {
 	if _, _, err := col.UpdateDocuments(updatedRevCtx, metas.Keys(), updates); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateDocumentsKeyEmpty updates documents with an empty key.
@@ -436,6 +464,10 @@ func TestUpdateDocumentsKeyEmpty(t *testing.T) {
 	if _, _, err := col.UpdateDocuments(nil, []string{""}, updates); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateDocumentsUpdateNil updates documents it with a nil update.
@@ -445,6 +477,10 @@ func TestUpdateDocumentsUpdateNil(t *testing.T) {
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	if _, _, err := col.UpdateDocuments(nil, []string{"validKey"}, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -463,6 +499,10 @@ func TestUpdateDocumentsUpdateLenDiff(t *testing.T) {
 	}
 	if _, _, err := col.UpdateDocuments(nil, []string{"only1"}, updates); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -515,5 +555,9 @@ func TestUpdateDocumentsInWaitForSyncCollection(t *testing.T) {
 		if !reflect.DeepEqual(doc, readDoc) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, readDoc)
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edge_collection_test.go
+++ b/test/edge_collection_test.go
@@ -105,6 +105,10 @@ func TestCreateEdgeCollection(t *testing.T) {
 	} else if ec.Name() != colName {
 		t.Errorf("EdgeCollection return invalid collection, expected '%s', got '%s'", colName, ec.Name())
 	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateSatelliteEdgeCollection creates a graph and then adds an Satellite edge collection in it
@@ -179,6 +183,10 @@ func TestCreateSatelliteEdgeCollection(t *testing.T) {
 
 	// revert
 	g.Remove(ctx)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveEdgeCollection creates a graph and then adds an edge collection in it and then removes the edge collection.
@@ -221,6 +229,10 @@ func TestRemoveEdgeCollection(t *testing.T) {
 
 	// Collection must still exist in database
 	assertCollection(nil, db, colName, t)
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestSetVertexConstraints creates a graph and then adds an edge collection in it and then removes the edge collection.
@@ -277,6 +289,10 @@ func TestSetVertexConstraints(t *testing.T) {
 			t.Errorf("Invalid to constraints. Expected ['colD'], got %q", constraints.To)
 		}
 	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRenameEdgeCollection creates a graph and then adds an edge collection in it and then renames the edge collection.
@@ -324,4 +340,8 @@ func TestRenameEdgeCollection(t *testing.T) {
 
 	// Collection must still exist in database
 	assertCollection(nil, db, newColName, t)
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/edge_collection_test.go
+++ b/test/edge_collection_test.go
@@ -47,6 +47,12 @@ func ensureEdgeCollection(ctx context.Context, g driver.Graph, collection string
 func TestCreateEdgeCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "edge_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_edge_collection"
 	g, err := db.CreateGraphV2(nil, name, nil)
 	if err != nil {
@@ -105,10 +111,6 @@ func TestCreateEdgeCollection(t *testing.T) {
 	} else if ec.Name() != colName {
 		t.Errorf("EdgeCollection return invalid collection, expected '%s', got '%s'", colName, ec.Name())
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateSatelliteEdgeCollection creates a graph and then adds an Satellite edge collection in it
@@ -119,6 +121,12 @@ func TestCreateSatelliteEdgeCollection(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.9.0")).Cluster().Enterprise()
 
 	db := ensureDatabase(nil, c, "edge_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	name := "test_create_sat_edge_collection"
 	options := driver.CreateGraphOptions{
@@ -129,6 +137,8 @@ func TestCreateSatelliteEdgeCollection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create graph '%s': %s", name, describe(err))
 	}
+	// revert
+	defer g.Remove(ctx)
 
 	// List edge collections, must be empty
 	if list, _, err := g.EdgeCollections(nil); err != nil {
@@ -181,18 +191,18 @@ func TestCreateSatelliteEdgeCollection(t *testing.T) {
 		}
 	}
 
-	// revert
-	g.Remove(ctx)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveEdgeCollection creates a graph and then adds an edge collection in it and then removes the edge collection.
 func TestRemoveEdgeCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "edge_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_remove_edge_collection"
 	g, err := db.CreateGraphV2(nil, name, nil)
 	if err != nil {
@@ -229,16 +239,18 @@ func TestRemoveEdgeCollection(t *testing.T) {
 
 	// Collection must still exist in database
 	assertCollection(nil, db, colName, t)
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestSetVertexConstraints creates a graph and then adds an edge collection in it and then removes the edge collection.
 func TestSetVertexConstraints(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "edge_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "set_vertex_constraints"
 	g, err := db.CreateGraphV2(nil, name, nil)
 	if err != nil {
@@ -289,10 +301,6 @@ func TestSetVertexConstraints(t *testing.T) {
 			t.Errorf("Invalid to constraints. Expected ['colD'], got %q", constraints.To)
 		}
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRenameEdgeCollection creates a graph and then adds an edge collection in it and then renames the edge collection.
@@ -303,6 +311,12 @@ func TestRenameEdgeCollection(t *testing.T) {
 	skipNoSingle(c, t)
 
 	db := ensureDatabase(nil, c, "edge_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_rename_edge_collection"
 	g, err := db.CreateGraphV2(nil, name, nil)
 	if err != nil {
@@ -340,8 +354,4 @@ func TestRenameEdgeCollection(t *testing.T) {
 
 	// Collection must still exist in database
 	assertCollection(nil, db, newColName, t)
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }

--- a/test/edge_create_test.go
+++ b/test/edge_create_test.go
@@ -63,6 +63,10 @@ func TestCreateEdge(t *testing.T) {
 			t.Errorf("Got invalid _to. Expected '%s', got '%s'", to.ID, readDoc.To)
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateCustomEdge creates an edge with a custom type and then checks that it exists.
@@ -93,6 +97,10 @@ func TestCreateCustomEdge(t *testing.T) {
 		t.Fatalf("Failed to read edge '%s': %s", meta.Key, describe(err))
 	} else if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got invalid return document. Expected '%+v', got '%+v'", doc, readDoc)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -132,6 +140,10 @@ func TestCreateEdgeReturnNew(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateEdgeSilent creates a document with WithSilent.
@@ -157,6 +169,10 @@ func TestCreateEdgeSilent(t *testing.T) {
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateEdgeNil creates a document with a nil document.
@@ -170,5 +186,9 @@ func TestCreateEdgeNil(t *testing.T) {
 
 	if _, err := ec.CreateDocument(nil, nil); !driver.IsInvalidArgument(err) {
 		t.Fatalf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edge_create_test.go
+++ b/test/edge_create_test.go
@@ -33,6 +33,12 @@ func TestCreateEdge(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edge_test_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -63,10 +69,6 @@ func TestCreateEdge(t *testing.T) {
 			t.Errorf("Got invalid _to. Expected '%s', got '%s'", to.ID, readDoc.To)
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateCustomEdge creates an edge with a custom type and then checks that it exists.
@@ -74,6 +76,12 @@ func TestCreateCustomEdge(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_custom_edge_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -98,10 +106,6 @@ func TestCreateCustomEdge(t *testing.T) {
 	} else if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got invalid return document. Expected '%+v', got '%+v'", doc, readDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateEdgeReturnNew creates a document and checks the document returned in in ReturnNew.
@@ -110,6 +114,12 @@ func TestCreateEdgeReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edge_return_new_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -140,10 +150,6 @@ func TestCreateEdgeReturnNew(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateEdgeSilent creates a document with WithSilent.
@@ -151,6 +157,12 @@ func TestCreateEdgeSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edge_silent_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -169,10 +181,6 @@ func TestCreateEdgeSilent(t *testing.T) {
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateEdgeNil creates a document with a nil document.
@@ -180,15 +188,17 @@ func TestCreateEdgeNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edge_nil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
 
 	if _, err := ec.CreateDocument(nil, nil); !driver.IsInvalidArgument(err) {
 		t.Fatalf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edge_remove_test.go
+++ b/test/edge_remove_test.go
@@ -59,6 +59,10 @@ func TestRemoveEdge(t *testing.T) {
 	if _, err := ec.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveEdgeReturnOld creates a document, removes it with ReturnOld, which is an invalid argument.
@@ -91,6 +95,10 @@ func TestRemoveEdgeReturnOld(t *testing.T) {
 
 	// Check an old document
 	require.Equal(t, doc, old)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveEdgeSilent creates a document, removes it with Silent() and then checks the meta is indeed empty.
@@ -125,6 +133,10 @@ func TestRemoveEdgeSilent(t *testing.T) {
 	var readDoc RouteEdge
 	if _, err := ec.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -186,6 +198,10 @@ func TestRemoveEdgeRevision(t *testing.T) {
 	} else if found {
 		t.Errorf("DocumentExists returned true for '%s', expected false", meta.Key)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveEdgeKeyEmpty removes a document it with an empty key.
@@ -199,5 +215,9 @@ func TestRemoveEdgeKeyEmpty(t *testing.T) {
 
 	if _, err := ec.RemoveDocument(nil, ""); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edge_remove_test.go
+++ b/test/edge_remove_test.go
@@ -34,6 +34,12 @@ func TestRemoveEdge(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edge_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -59,10 +65,6 @@ func TestRemoveEdge(t *testing.T) {
 	if _, err := ec.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveEdgeReturnOld creates a document, removes it with ReturnOld, which is an invalid argument.
@@ -71,6 +73,12 @@ func TestRemoveEdgeReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edge_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -95,10 +103,6 @@ func TestRemoveEdgeReturnOld(t *testing.T) {
 
 	// Check an old document
 	require.Equal(t, doc, old)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveEdgeSilent creates a document, removes it with Silent() and then checks the meta is indeed empty.
@@ -106,6 +110,12 @@ func TestRemoveEdgeSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edge_silent_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -134,10 +144,6 @@ func TestRemoveEdgeSilent(t *testing.T) {
 	if _, err := ec.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveEdgeRevision creates a document, removes it with an incorrect revision.
@@ -145,6 +151,12 @@ func TestRemoveEdgeRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edge_revision_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -198,10 +210,6 @@ func TestRemoveEdgeRevision(t *testing.T) {
 	} else if found {
 		t.Errorf("DocumentExists returned true for '%s', expected false", meta.Key)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveEdgeKeyEmpty removes a document it with an empty key.
@@ -209,15 +217,17 @@ func TestRemoveEdgeKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edge_nil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
 
 	if _, err := ec.RemoveDocument(nil, ""); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edge_replace_test.go
+++ b/test/edge_replace_test.go
@@ -33,6 +33,12 @@ func TestReplaceEdge(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edge_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -67,10 +73,6 @@ func TestReplaceEdge(t *testing.T) {
 	if !reflect.DeepEqual(replacement, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", replacement, readDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceEdgeReturnOld creates a document, replaces it checks the ReturnOld value.
@@ -79,6 +81,12 @@ func TestReplaceEdgeReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edge_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -111,10 +119,6 @@ func TestReplaceEdgeReturnOld(t *testing.T) {
 	if !reflect.DeepEqual(doc, old) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, old)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceEdgeReturnNew creates a document, replaces it checks the ReturnNew value.
@@ -123,6 +127,12 @@ func TestReplaceEdgeReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edge_returnNew_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -156,10 +166,6 @@ func TestReplaceEdgeReturnNew(t *testing.T) {
 	if !reflect.DeepEqual(expected, newDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", expected, newDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceEdgeSilent creates a document, replaces it with Silent() and then checks the meta is indeed empty.
@@ -167,6 +173,12 @@ func TestReplaceEdgeSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edge_returnNew_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -196,10 +208,6 @@ func TestReplaceEdgeSilent(t *testing.T) {
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceEdgeRevision creates a document, replaces it with a specific (correct) revision.
@@ -208,6 +216,12 @@ func TestReplaceEdgeRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edge_revision_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -254,10 +268,6 @@ func TestReplaceEdgeRevision(t *testing.T) {
 	if _, err := ec.ReplaceDocument(replacedRevCtx, meta.Key, replacement); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceEdgeKeyEmpty replaces a document it with an empty key.
@@ -265,6 +275,12 @@ func TestReplaceEdgeKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edge_keyEmpty_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -276,10 +292,6 @@ func TestReplaceEdgeKeyEmpty(t *testing.T) {
 	if _, err := ec.ReplaceDocument(nil, "", replacement); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceEdgeUpdateNil replaces a document it with a nil update.
@@ -287,15 +299,17 @@ func TestReplaceEdgeUpdateNil(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edge_updateNil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
 
 	if _, err := ec.ReplaceDocument(nil, "validKey", nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edge_replace_test.go
+++ b/test/edge_replace_test.go
@@ -67,6 +67,10 @@ func TestReplaceEdge(t *testing.T) {
 	if !reflect.DeepEqual(replacement, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", replacement, readDoc)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceEdgeReturnOld creates a document, replaces it checks the ReturnOld value.
@@ -106,6 +110,10 @@ func TestReplaceEdgeReturnOld(t *testing.T) {
 	// Check old document
 	if !reflect.DeepEqual(doc, old) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, old)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -148,6 +156,10 @@ func TestReplaceEdgeReturnNew(t *testing.T) {
 	if !reflect.DeepEqual(expected, newDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", expected, newDoc)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceEdgeSilent creates a document, replaces it with Silent() and then checks the meta is indeed empty.
@@ -183,6 +195,10 @@ func TestReplaceEdgeSilent(t *testing.T) {
 		t.Fatalf("Failed to replace document '%s': %s", meta.Key, describe(err))
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -238,6 +254,10 @@ func TestReplaceEdgeRevision(t *testing.T) {
 	if _, err := ec.ReplaceDocument(replacedRevCtx, meta.Key, replacement); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceEdgeKeyEmpty replaces a document it with an empty key.
@@ -256,6 +276,10 @@ func TestReplaceEdgeKeyEmpty(t *testing.T) {
 	if _, err := ec.ReplaceDocument(nil, "", replacement); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceEdgeUpdateNil replaces a document it with a nil update.
@@ -269,5 +293,9 @@ func TestReplaceEdgeUpdateNil(t *testing.T) {
 
 	if _, err := ec.ReplaceDocument(nil, "validKey", nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edge_update_test.go
+++ b/test/edge_update_test.go
@@ -66,6 +66,10 @@ func TestUpdateEdge(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateEdgeReturnOld creates a document, updates it checks the ReturnOld value.
@@ -103,6 +107,10 @@ func TestUpdateEdgeReturnOld(t *testing.T) {
 	// Check old document
 	if !reflect.DeepEqual(doc, old) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, old)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -143,6 +151,10 @@ func TestUpdateEdgeReturnNew(t *testing.T) {
 	expected.From = to.ID.String()
 	if !reflect.DeepEqual(expected, newDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", expected, newDoc)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -207,6 +219,10 @@ func TestUpdateEdgeKeepNullTrue(t *testing.T) {
 			t.Errorf("Expected user to be found and nil, got %s", string(*raw))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateEdgeKeepNullFalse creates a document, updates it with KeepNull(false) and then checks the update has succeeded.
@@ -250,6 +266,10 @@ func TestUpdateEdgeKeepNullFalse(t *testing.T) {
 	if readDoc.User == nil {
 		t.Errorf("Expected user to be untouched, got %v", readDoc.User)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateEdgeSilent creates a document, updates it with Silent() and then checks the meta is indeed empty.
@@ -283,6 +303,10 @@ func TestUpdateEdgeSilent(t *testing.T) {
 		t.Fatalf("Failed to update document '%s': %s", meta.Key, describe(err))
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -336,6 +360,10 @@ func TestUpdateEdgeRevision(t *testing.T) {
 	if _, err := ec.UpdateDocument(updatedRevCtx, meta.Key, update); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateEdgeKeyEmpty updates a document it with an empty key.
@@ -354,6 +382,10 @@ func TestUpdateEdgeKeyEmpty(t *testing.T) {
 	if _, err := ec.UpdateDocument(nil, "", update); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateEdgeUpdateNil updates a document it with a nil update.
@@ -367,5 +399,9 @@ func TestUpdateEdgeUpdateNil(t *testing.T) {
 
 	if _, err := ec.UpdateDocument(nil, "validKey", nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edge_update_test.go
+++ b/test/edge_update_test.go
@@ -33,6 +33,12 @@ func TestUpdateEdge(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -66,10 +72,6 @@ func TestUpdateEdge(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgeReturnOld creates a document, updates it checks the ReturnOld value.
@@ -78,6 +80,12 @@ func TestUpdateEdgeReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -108,10 +116,6 @@ func TestUpdateEdgeReturnOld(t *testing.T) {
 	if !reflect.DeepEqual(doc, old) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, old)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgeReturnNew creates a document, updates it checks the ReturnNew value.
@@ -120,6 +124,12 @@ func TestUpdateEdgeReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_returnNew_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -152,10 +162,6 @@ func TestUpdateEdgeReturnNew(t *testing.T) {
 	if !reflect.DeepEqual(expected, newDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", expected, newDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgeKeepNullTrue creates a document, updates it with KeepNull(true) and then checks the update has succeeded.
@@ -164,6 +170,12 @@ func TestUpdateEdgeKeepNullTrue(t *testing.T) {
 	c := createClient(t, nil)
 	conn := c.Connection()
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_keepNullTrue_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -219,10 +231,6 @@ func TestUpdateEdgeKeepNullTrue(t *testing.T) {
 			t.Errorf("Expected user to be found and nil, got %s", string(*raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgeKeepNullFalse creates a document, updates it with KeepNull(false) and then checks the update has succeeded.
@@ -230,6 +238,12 @@ func TestUpdateEdgeKeepNullFalse(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_keepNullFalse_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -266,10 +280,6 @@ func TestUpdateEdgeKeepNullFalse(t *testing.T) {
 	if readDoc.User == nil {
 		t.Errorf("Expected user to be untouched, got %v", readDoc.User)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgeSilent creates a document, updates it with Silent() and then checks the meta is indeed empty.
@@ -277,6 +287,12 @@ func TestUpdateEdgeSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_silent_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -304,10 +320,6 @@ func TestUpdateEdgeSilent(t *testing.T) {
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgeRevision creates a document, updates it with a specific (correct) revision.
@@ -316,6 +328,12 @@ func TestUpdateEdgeRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_revision_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -360,10 +378,6 @@ func TestUpdateEdgeRevision(t *testing.T) {
 	if _, err := ec.UpdateDocument(updatedRevCtx, meta.Key, update); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgeKeyEmpty updates a document it with an empty key.
@@ -371,6 +385,12 @@ func TestUpdateEdgeKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_keyEmpty_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -382,10 +402,6 @@ func TestUpdateEdgeKeyEmpty(t *testing.T) {
 	if _, err := ec.UpdateDocument(nil, "", update); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgeUpdateNil updates a document it with a nil update.
@@ -393,15 +409,17 @@ func TestUpdateEdgeUpdateNil(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_updateNil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
 
 	if _, err := ec.UpdateDocument(nil, "validKey", nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edges_create_test.go
+++ b/test/edges_create_test.go
@@ -33,6 +33,12 @@ func TestCreateEdges(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edges_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -94,10 +100,6 @@ func TestCreateEdges(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateEdgesReturnNew creates documents and checks the document returned in in ReturnNew.
@@ -107,6 +109,12 @@ func TestCreateEdgesReturnNew(t *testing.T) {
 	// TODO refactor ME
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edges_returnNew_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -157,10 +165,6 @@ func TestCreateEdgesReturnNew(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateEdgesSilent creates documents with WithSilent.
@@ -168,6 +172,12 @@ func TestCreateEdgesSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edges_silent_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -203,10 +213,6 @@ func TestCreateEdgesSilent(t *testing.T) {
 			t.Errorf("Expected 0 errors, got %d", len(errs))
 		}
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateEdgesNil creates multiple documents with a nil documents input.
@@ -214,15 +220,17 @@ func TestCreateEdgesNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edges_nil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
 	if _, _, err := ec.CreateDocuments(nil, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -231,6 +239,12 @@ func TestCreateEdgesNonSlice(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edges_nonSlice_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -242,9 +256,5 @@ func TestCreateEdgesNonSlice(t *testing.T) {
 	var m map[string]interface{}
 	if _, _, err := ec.CreateDocuments(nil, &m); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edges_create_test.go
+++ b/test/edges_create_test.go
@@ -94,6 +94,10 @@ func TestCreateEdges(t *testing.T) {
 			}
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateEdgesReturnNew creates documents and checks the document returned in in ReturnNew.
@@ -153,6 +157,10 @@ func TestCreateEdgesReturnNew(t *testing.T) {
 			}
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateEdgesSilent creates documents with WithSilent.
@@ -195,6 +203,10 @@ func TestCreateEdgesSilent(t *testing.T) {
 			t.Errorf("Expected 0 errors, got %d", len(errs))
 		}
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateEdgesNil creates multiple documents with a nil documents input.
@@ -207,6 +219,10 @@ func TestCreateEdgesNil(t *testing.T) {
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
 	if _, _, err := ec.CreateDocuments(nil, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -226,5 +242,9 @@ func TestCreateEdgesNonSlice(t *testing.T) {
 	var m map[string]interface{}
 	if _, _, err := ec.CreateDocuments(nil, &m); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edges_import_test.go
+++ b/test/edges_import_test.go
@@ -33,6 +33,12 @@ func TestImportEdgesWithKeys(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -78,10 +84,6 @@ func TestImportEdgesWithKeys(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 0, stats.Empty, formatRawResponse(raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportEdgesWithoutKeys imports documents and then checks that it exists.
@@ -89,6 +91,12 @@ func TestImportEdgesWithoutKeys(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_withhoutKeys_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -134,10 +142,6 @@ func TestImportEdgesWithoutKeys(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 0, stats.Empty, formatRawResponse(raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportEdgesEmptyEntries imports documents and then checks that it exists.
@@ -148,6 +152,12 @@ func TestImportEdgesEmptyEntries(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_emptyEntries_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -194,10 +204,6 @@ func TestImportEdgesEmptyEntries(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 1, stats.Empty, formatRawResponse(raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportEdgesInvalidEntries imports documents and then checks that it exists.
@@ -208,6 +214,12 @@ func TestImportEdgesInvalidEntries(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_invalidEntries_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -256,10 +268,6 @@ func TestImportEdgesInvalidEntries(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 1, stats.Empty, formatRawResponse(raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportEdgesDuplicateEntries imports documents and then checks that it exists.
@@ -267,6 +275,12 @@ func TestImportEdgesDuplicateEntries(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_duplicateEntries_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -312,10 +326,6 @@ func TestImportEdgesDuplicateEntries(t *testing.T) {
 			t.Errorf("Expected %d ignored documents, got %d (json %s)", 0, stats.Ignored, formatRawResponse(raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportEdgesDuplicateEntriesComplete imports documents and then checks that it exists.
@@ -326,6 +336,12 @@ func TestImportEdgesDuplicateEntriesComplete(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_duplicateEntriesComplete_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -357,10 +373,6 @@ func TestImportEdgesDuplicateEntriesComplete(t *testing.T) {
 	}); !driver.IsConflict(err) {
 		t.Errorf("Expected ConflictError, got %s", describe(err))
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportEdgesDuplicateEntriesUpdate imports documents and then checks that it exists.
@@ -368,6 +380,12 @@ func TestImportEdgesDuplicateEntriesUpdate(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_duplicateEntriesUpdate_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -426,10 +444,6 @@ func TestImportEdgesDuplicateEntriesUpdate(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportEdgesDuplicateEntriesReplace imports documents and then checks that it exists.
@@ -437,6 +451,12 @@ func TestImportEdgesDuplicateEntriesReplace(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_duplicateEntriesReplace_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -495,10 +515,6 @@ func TestImportEdgesDuplicateEntriesReplace(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportEdgesDuplicateEntriesIgnore imports documents and then checks that it exists.
@@ -506,6 +522,12 @@ func TestImportEdgesDuplicateEntriesIgnore(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_duplicateEntriesIgnore_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -564,10 +586,6 @@ func TestImportEdgesDuplicateEntriesIgnore(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportEdgesDetails imports documents and then checks that it exists.
@@ -575,6 +593,12 @@ func TestImportEdgesDetails(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_details_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -627,10 +651,6 @@ func TestImportEdgesDetails(t *testing.T) {
 			t.Errorf("Expected details[0] to be '%s', got '%s'", detailsExpected, details[0])
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportEdgesOverwriteYes imports documents and then checks that it exists.
@@ -639,6 +659,12 @@ func TestImportEdgesOverwriteYes(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_overwriteYes_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -681,10 +707,6 @@ func TestImportEdgesOverwriteYes(t *testing.T) {
 			t.Errorf("Expected count to be %d in round %d, got %d", countExpected, i, count)
 		}
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportEdgesOverwriteNo imports documents and then checks that it exists.
@@ -693,6 +715,12 @@ func TestImportEdgesOverwriteNo(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_overwriteNo_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -735,10 +763,6 @@ func TestImportEdgesOverwriteNo(t *testing.T) {
 			t.Errorf("Expected count to be %d in round %d, got %d", countExpected, i, count)
 		}
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportEdgesPrefix imports documents and then checks that it exists.
@@ -747,6 +771,12 @@ func TestImportEdgesPrefix(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_prefix_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -787,9 +817,5 @@ func TestImportEdgesPrefix(t *testing.T) {
 		t.Errorf("Failed to count documents: %s", describe(err))
 	} else if count != countExpected {
 		t.Errorf("Expected count to be %d, got %d", countExpected, count)
-	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edges_import_test.go
+++ b/test/edges_import_test.go
@@ -78,6 +78,10 @@ func TestImportEdgesWithKeys(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 0, stats.Empty, formatRawResponse(raw))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportEdgesWithoutKeys imports documents and then checks that it exists.
@@ -129,6 +133,10 @@ func TestImportEdgesWithoutKeys(t *testing.T) {
 		if stats.Empty != 0 {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 0, stats.Empty, formatRawResponse(raw))
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -185,6 +193,10 @@ func TestImportEdgesEmptyEntries(t *testing.T) {
 		if stats.Empty != 1 {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 1, stats.Empty, formatRawResponse(raw))
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -244,6 +256,10 @@ func TestImportEdgesInvalidEntries(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 1, stats.Empty, formatRawResponse(raw))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportEdgesDuplicateEntries imports documents and then checks that it exists.
@@ -296,6 +312,10 @@ func TestImportEdgesDuplicateEntries(t *testing.T) {
 			t.Errorf("Expected %d ignored documents, got %d (json %s)", 0, stats.Ignored, formatRawResponse(raw))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportEdgesDuplicateEntriesComplete imports documents and then checks that it exists.
@@ -336,6 +356,10 @@ func TestImportEdgesDuplicateEntriesComplete(t *testing.T) {
 		Complete: true,
 	}); !driver.IsConflict(err) {
 		t.Errorf("Expected ConflictError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -402,6 +426,10 @@ func TestImportEdgesDuplicateEntriesUpdate(t *testing.T) {
 			}
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportEdgesDuplicateEntriesReplace imports documents and then checks that it exists.
@@ -466,6 +494,10 @@ func TestImportEdgesDuplicateEntriesReplace(t *testing.T) {
 				t.Errorf("Expected Distance to be 0, got %d", edge.Distance)
 			}
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -532,6 +564,10 @@ func TestImportEdgesDuplicateEntriesIgnore(t *testing.T) {
 			}
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportEdgesDetails imports documents and then checks that it exists.
@@ -591,6 +627,10 @@ func TestImportEdgesDetails(t *testing.T) {
 			t.Errorf("Expected details[0] to be '%s', got '%s'", detailsExpected, details[0])
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportEdgesOverwriteYes imports documents and then checks that it exists.
@@ -640,6 +680,10 @@ func TestImportEdgesOverwriteYes(t *testing.T) {
 		} else if count != countExpected {
 			t.Errorf("Expected count to be %d in round %d, got %d", countExpected, i, count)
 		}
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -691,6 +735,10 @@ func TestImportEdgesOverwriteNo(t *testing.T) {
 			t.Errorf("Expected count to be %d in round %d, got %d", countExpected, i, count)
 		}
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportEdgesPrefix imports documents and then checks that it exists.
@@ -739,5 +787,9 @@ func TestImportEdgesPrefix(t *testing.T) {
 		t.Errorf("Failed to count documents: %s", describe(err))
 	} else if count != countExpected {
 		t.Errorf("Expected count to be %d, got %d", countExpected, count)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edges_remove_test.go
+++ b/test/edges_remove_test.go
@@ -75,6 +75,10 @@ func TestRemoveEdges(t *testing.T) {
 			t.Fatalf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveEdgesReturnOld creates documents, removes them checks the ReturnOld value.
@@ -123,6 +127,10 @@ func TestRemoveEdgesReturnOld(t *testing.T) {
 	// Check old documents
 	for i, doc := range docs {
 		require.Equal(t, doc, oldDocs[i])
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -174,6 +182,10 @@ func TestRemoveEdgesSilent(t *testing.T) {
 		if _, err := ec.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 			t.Errorf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -256,6 +268,10 @@ func TestRemoveEdgesRevision(t *testing.T) {
 			t.Errorf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveEdgesKeyEmpty removes a document it with an empty key.
@@ -269,5 +285,9 @@ func TestRemoveEdgesKeyEmpty(t *testing.T) {
 
 	if _, _, err := ec.RemoveDocuments(nil, []string{""}); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edges_remove_test.go
+++ b/test/edges_remove_test.go
@@ -34,6 +34,12 @@ func TestRemoveEdges(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edges_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -75,10 +81,6 @@ func TestRemoveEdges(t *testing.T) {
 			t.Fatalf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveEdgesReturnOld creates documents, removes them checks the ReturnOld value.
@@ -86,6 +88,12 @@ func TestRemoveEdgesReturnOld(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	prefix := "remove_edges_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
@@ -128,10 +136,6 @@ func TestRemoveEdgesReturnOld(t *testing.T) {
 	for i, doc := range docs {
 		require.Equal(t, doc, oldDocs[i])
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveEdgesSilent creates documents, removes them with Silent() and then checks the meta is indeed empty.
@@ -139,6 +143,12 @@ func TestRemoveEdgesSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edges_silent_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -183,10 +193,6 @@ func TestRemoveEdgesSilent(t *testing.T) {
 			t.Errorf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveEdgesRevision creates documents, removes them with an incorrect revisions.
@@ -194,6 +200,12 @@ func TestRemoveEdgesRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edges_revision_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -268,10 +280,6 @@ func TestRemoveEdgesRevision(t *testing.T) {
 			t.Errorf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveEdgesKeyEmpty removes a document it with an empty key.
@@ -279,15 +287,17 @@ func TestRemoveEdgesKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edges_keyEmpty_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
 
 	if _, _, err := ec.RemoveDocuments(nil, []string{""}); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edges_replace_test.go
+++ b/test/edges_replace_test.go
@@ -34,6 +34,12 @@ func TestReplaceEdges(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -84,10 +90,6 @@ func TestReplaceEdges(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, replacements[i], readDoc)
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceEdgesReturnOld creates documents, replaces them checks the ReturnOld values.
@@ -96,6 +98,12 @@ func TestReplaceEdgesReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -144,10 +152,6 @@ func TestReplaceEdgesReturnOld(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, oldDocs[i])
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceEdgesReturnNew creates documents, replaces them checks the ReturnNew values.
@@ -156,6 +160,12 @@ func TestReplaceEdgesReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_returnNew_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -205,10 +215,6 @@ func TestReplaceEdgesReturnNew(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, expected, newDocs[i])
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceEdgesSilent creates documents, replaces them with Silent() and then checks the meta is indeed empty.
@@ -216,6 +222,12 @@ func TestReplaceEdgesSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_silent_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -264,10 +276,6 @@ func TestReplaceEdgesSilent(t *testing.T) {
 			t.Errorf("Expected 0 metas, got %d", len(metas))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceEdgesRevision creates documents, replaces then with a specific (correct) revisions.
@@ -276,6 +284,12 @@ func TestReplaceEdgesRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_revision_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -350,10 +364,6 @@ func TestReplaceEdgesRevision(t *testing.T) {
 	} else if err := errs.FirstNonNil(); err != nil {
 		t.Fatalf("Expected no errors, got first: %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceEdgesKeyEmpty replaces a document it with an empty key.
@@ -361,6 +371,12 @@ func TestReplaceEdgesKeyEmpty(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_updateNil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -371,10 +387,6 @@ func TestReplaceEdgesKeyEmpty(t *testing.T) {
 	if _, _, err := ec.ReplaceDocuments(nil, []string{""}, replacement); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceEdgesUpdateNil replaces a document it with a nil update.
@@ -382,16 +394,18 @@ func TestReplaceEdgesUpdateNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_updateNil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
 
 	if _, _, err := ec.ReplaceDocuments(nil, []string{"validKey"}, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -400,6 +414,12 @@ func TestReplaceEdgesUpdateLenDiff(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_updateNil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -414,9 +434,5 @@ func TestReplaceEdgesUpdateLenDiff(t *testing.T) {
 	}
 	if _, _, err := ec.ReplaceDocuments(nil, []string{"only1"}, replacements); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edges_replace_test.go
+++ b/test/edges_replace_test.go
@@ -84,6 +84,10 @@ func TestReplaceEdges(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, replacements[i], readDoc)
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceEdgesReturnOld creates documents, replaces them checks the ReturnOld values.
@@ -139,6 +143,10 @@ func TestReplaceEdgesReturnOld(t *testing.T) {
 		if !reflect.DeepEqual(doc, oldDocs[i]) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, oldDocs[i])
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -197,6 +205,10 @@ func TestReplaceEdgesReturnNew(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, expected, newDocs[i])
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceEdgesSilent creates documents, replaces them with Silent() and then checks the meta is indeed empty.
@@ -251,6 +263,10 @@ func TestReplaceEdgesSilent(t *testing.T) {
 		if len(metas) > 0 {
 			t.Errorf("Expected 0 metas, got %d", len(metas))
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -334,6 +350,10 @@ func TestReplaceEdgesRevision(t *testing.T) {
 	} else if err := errs.FirstNonNil(); err != nil {
 		t.Fatalf("Expected no errors, got first: %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceEdgesKeyEmpty replaces a document it with an empty key.
@@ -351,6 +371,10 @@ func TestReplaceEdgesKeyEmpty(t *testing.T) {
 	if _, _, err := ec.ReplaceDocuments(nil, []string{""}, replacement); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceEdgesUpdateNil replaces a document it with a nil update.
@@ -364,6 +388,10 @@ func TestReplaceEdgesUpdateNil(t *testing.T) {
 
 	if _, _, err := ec.ReplaceDocuments(nil, []string{"validKey"}, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -386,5 +414,9 @@ func TestReplaceEdgesUpdateLenDiff(t *testing.T) {
 	}
 	if _, _, err := ec.ReplaceDocuments(nil, []string{"only1"}, replacements); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edges_update_test.go
+++ b/test/edges_update_test.go
@@ -85,6 +85,10 @@ func TestUpdateEdges(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, readDoc)
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateEdgesReturnOld creates documents, updates them checks the ReturnOld values.
@@ -138,6 +142,10 @@ func TestUpdateEdgesReturnOld(t *testing.T) {
 		if !reflect.DeepEqual(doc, oldDocs[i]) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, oldDocs[i])
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -194,6 +202,10 @@ func TestUpdateEdgesReturnNew(t *testing.T) {
 		if !reflect.DeepEqual(expected, newDocs[i]) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, expected, newDocs[i])
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -280,6 +292,10 @@ func TestUpdateEdgesKeepNullTrue(t *testing.T) {
 			}
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateEdgesKeepNullFalse creates documents, updates them with KeepNull(false) and then checks the updates have succeeded.
@@ -344,6 +360,10 @@ func TestUpdateEdgesKeepNullFalse(t *testing.T) {
 			t.Errorf("Expected user to be untouched, got %v", readDoc.User)
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateEdgesSilent creates documents, updates them with Silent() and then checks the metas are indeed empty.
@@ -391,6 +411,10 @@ func TestUpdateEdgesSilent(t *testing.T) {
 		t.Fatalf("Expected no errors, got first: %s", describe(err))
 	} else if strings.Join(metas.Keys(), "") != "" {
 		t.Errorf("Expected empty meta, got %v", metas)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -467,6 +491,10 @@ func TestUpdateEdgesRevision(t *testing.T) {
 	if _, _, err := ec.UpdateDocuments(updatedRevCtx, metas.Keys(), updates); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateEdgesKeyEmpty updates documents with an empty key.
@@ -487,6 +515,10 @@ func TestUpdateEdgesKeyEmpty(t *testing.T) {
 	if _, _, err := ec.UpdateDocuments(nil, []string{""}, updates); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateEdgesUpdateNil updates documents it with a nil update.
@@ -500,6 +532,10 @@ func TestUpdateEdgesUpdateNil(t *testing.T) {
 
 	if _, _, err := ec.UpdateDocuments(nil, []string{"validKey"}, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -522,5 +558,9 @@ func TestUpdateEdgesUpdateLenDiff(t *testing.T) {
 	}
 	if _, _, err := ec.UpdateDocuments(nil, []string{"only1"}, updates); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/edges_update_test.go
+++ b/test/edges_update_test.go
@@ -35,6 +35,12 @@ func TestUpdateEdges(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -85,10 +91,6 @@ func TestUpdateEdges(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, readDoc)
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgesReturnOld creates documents, updates them checks the ReturnOld values.
@@ -97,6 +99,12 @@ func TestUpdateEdgesReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -143,10 +151,6 @@ func TestUpdateEdgesReturnOld(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, oldDocs[i])
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgesReturnNew creates documents, updates them checks the ReturnNew values.
@@ -155,6 +159,12 @@ func TestUpdateEdgesReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -203,10 +213,6 @@ func TestUpdateEdgesReturnNew(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, expected, newDocs[i])
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgesKeepNullTrue creates documents, updates them with KeepNull(true) and then checks the updates have succeeded.
@@ -215,6 +221,12 @@ func TestUpdateEdgesKeepNullTrue(t *testing.T) {
 	c := createClient(t, nil)
 	conn := c.Connection()
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_keepNullTrue_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -292,10 +304,6 @@ func TestUpdateEdgesKeepNullTrue(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgesKeepNullFalse creates documents, updates them with KeepNull(false) and then checks the updates have succeeded.
@@ -303,6 +311,12 @@ func TestUpdateEdgesKeepNullFalse(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_keepNullFalse_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -360,10 +374,6 @@ func TestUpdateEdgesKeepNullFalse(t *testing.T) {
 			t.Errorf("Expected user to be untouched, got %v", readDoc.User)
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgesSilent creates documents, updates them with Silent() and then checks the metas are indeed empty.
@@ -371,6 +381,12 @@ func TestUpdateEdgesSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_silent_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -412,10 +428,6 @@ func TestUpdateEdgesSilent(t *testing.T) {
 	} else if strings.Join(metas.Keys(), "") != "" {
 		t.Errorf("Expected empty meta, got %v", metas)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgesRevision creates documents, updates them with a specific (correct) revisions.
@@ -424,6 +436,12 @@ func TestUpdateEdgesRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_revision_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -491,10 +509,6 @@ func TestUpdateEdgesRevision(t *testing.T) {
 	if _, _, err := ec.UpdateDocuments(updatedRevCtx, metas.Keys(), updates); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgesKeyEmpty updates documents with an empty key.
@@ -502,6 +516,12 @@ func TestUpdateEdgesKeyEmpty(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_keyEmpty_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -515,10 +535,6 @@ func TestUpdateEdgesKeyEmpty(t *testing.T) {
 	if _, _, err := ec.UpdateDocuments(nil, []string{""}, updates); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateEdgesUpdateNil updates documents it with a nil update.
@@ -526,16 +542,18 @@ func TestUpdateEdgesUpdateNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_updateNil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
 
 	if _, _, err := ec.UpdateDocuments(nil, []string{"validKey"}, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -544,6 +562,12 @@ func TestUpdateEdgesUpdateLenDiff(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_updateLenDiff_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -558,9 +582,5 @@ func TestUpdateEdgesUpdateLenDiff(t *testing.T) {
 	}
 	if _, _, err := ec.UpdateDocuments(nil, []string{"only1"}, updates); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/graph_creation_test.go
+++ b/test/graph_creation_test.go
@@ -135,6 +135,10 @@ func Test_Graph_AdvancedCreate(t *testing.T) {
 			}
 		}
 	})
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // Test_Graph_AdvancedCreate_Defaults will check if graph created have properly set replication factor
@@ -176,6 +180,10 @@ func Test_Graph_AdvancedCreate_Defaults(t *testing.T) {
 			}
 		}
 	})
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 func TestGraphCreation(t *testing.T) {
@@ -313,6 +321,11 @@ func TestGraphCreation(t *testing.T) {
 		require.Equal(t, g.Name(), graphs[0].Name())
 		require.True(t, graphs[0].IsDisjoint())
 	})
+	db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 func TestHybridSmartGraphCreation(t *testing.T) {
@@ -365,5 +378,9 @@ func TestHybridSmartGraphCreation(t *testing.T) {
 		} else {
 			require.True(t, prop.IsSatellite())
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/graph_creation_test.go
+++ b/test/graph_creation_test.go
@@ -155,7 +155,8 @@ func Test_Graph_AdvancedCreate_Defaults(t *testing.T) {
 
 	skipNoCluster(c, t)
 
-	db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+	db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults1"), nil, t)
+	t.Logf(" drop database %s", db.Name())
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -195,17 +196,16 @@ func TestGraphCreation(t *testing.T) {
 	ctx := context.Background()
 
 	c := createClient(t, nil)
-	defer func() {
-		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
-		err := db.Remove(ctx)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
-	}()
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.7.0")).Cluster().Enterprise()
 
 	t.Run("Satellite", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -227,6 +227,12 @@ func TestGraphCreation(t *testing.T) {
 
 	t.Run("Satellite - list", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -253,6 +259,12 @@ func TestGraphCreation(t *testing.T) {
 
 	t.Run("Standard", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -270,6 +282,12 @@ func TestGraphCreation(t *testing.T) {
 
 	t.Run("Standard - list", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -292,6 +310,12 @@ func TestGraphCreation(t *testing.T) {
 
 	t.Run("Disjoint", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -311,6 +335,12 @@ func TestGraphCreation(t *testing.T) {
 
 	t.Run("Disjoint - list", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"

--- a/test/graph_creation_test.go
+++ b/test/graph_creation_test.go
@@ -156,7 +156,6 @@ func Test_Graph_AdvancedCreate_Defaults(t *testing.T) {
 	skipNoCluster(c, t)
 
 	db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults1"), nil, t)
-	t.Logf(" drop database %s", db.Name())
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {

--- a/test/graph_creation_test.go
+++ b/test/graph_creation_test.go
@@ -105,6 +105,12 @@ func Test_Graph_AdvancedCreate(t *testing.T) {
 	skipNoCluster(c, t)
 
 	db := ensureDatabase(ctx, c, databaseName("graph", "create", "replication"), nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	// Create
 	graphID := db.Name() + "_graph"
@@ -135,10 +141,6 @@ func Test_Graph_AdvancedCreate(t *testing.T) {
 			}
 		}
 	})
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // Test_Graph_AdvancedCreate_Defaults will check if graph created have properly set replication factor
@@ -154,6 +156,12 @@ func Test_Graph_AdvancedCreate_Defaults(t *testing.T) {
 	skipNoCluster(c, t)
 
 	db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	// Create
 	graphID := db.Name() + "_graph"
@@ -180,10 +188,6 @@ func Test_Graph_AdvancedCreate_Defaults(t *testing.T) {
 			}
 		}
 	})
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestGraphCreation(t *testing.T) {
@@ -191,6 +195,13 @@ func TestGraphCreation(t *testing.T) {
 	ctx := context.Background()
 
 	c := createClient(t, nil)
+	defer func() {
+		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.7.0")).Cluster().Enterprise()
 
 	t.Run("Satellite", func(t *testing.T) {
@@ -321,11 +332,6 @@ func TestGraphCreation(t *testing.T) {
 		require.Equal(t, g.Name(), graphs[0].Name())
 		require.True(t, graphs[0].IsDisjoint())
 	})
-	db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestHybridSmartGraphCreation(t *testing.T) {
@@ -335,6 +341,12 @@ func TestHybridSmartGraphCreation(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.9.0")).Cluster().Enterprise()
 
 	db := ensureDatabase(ctx, c, databaseName("graph", "create", "hybrid"), nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	name := db.Name() + "_test_create_hybrid_graph"
 	colName := db.Name() + "_create_hybrid_edge_col"
@@ -378,9 +390,5 @@ func TestHybridSmartGraphCreation(t *testing.T) {
 		} else {
 			require.True(t, prop.IsSatellite())
 		}
-	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/graph_creation_v2_test.go
+++ b/test/graph_creation_v2_test.go
@@ -71,6 +71,10 @@ func Test_Graph_AdvancedCreateV2(t *testing.T) {
 			}
 		}
 	})
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // Test_Graph_AdvancedCreateV2_Defaults will check if graph created have properly set replication factor and write concern by default
@@ -111,6 +115,10 @@ func Test_Graph_AdvancedCreateV2_Defaults(t *testing.T) {
 			}
 		}
 	})
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 func TestGraphCreationV2(t *testing.T) {
@@ -250,6 +258,11 @@ func TestGraphCreationV2(t *testing.T) {
 		require.Equal(t, g.Name(), graphs[0].Name())
 		require.True(t, graphs[0].IsDisjoint())
 	})
+	db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 func TestHybridSmartGraphCreationV2(t *testing.T) {
@@ -302,6 +315,10 @@ func TestHybridSmartGraphCreationV2(t *testing.T) {
 		} else {
 			require.True(t, prop.IsSatellite())
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -359,4 +376,8 @@ func TestHybridSmartGraphCreationConditions(t *testing.T) {
 		require.Empty(t, g.SmartGraphAttribute())
 		require.True(t, g.IsSmart())
 	})
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/graph_creation_v2_test.go
+++ b/test/graph_creation_v2_test.go
@@ -41,6 +41,12 @@ func Test_Graph_AdvancedCreateV2(t *testing.T) {
 	skipNoCluster(c, t)
 
 	db := ensureDatabase(ctx, c, databaseName("graph", "create", "replication"), nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	// Create
 	graphID := db.Name() + "_graph"
@@ -71,10 +77,6 @@ func Test_Graph_AdvancedCreateV2(t *testing.T) {
 			}
 		}
 	})
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // Test_Graph_AdvancedCreateV2_Defaults will check if graph created have properly set replication factor and write concern by default
@@ -89,6 +91,12 @@ func Test_Graph_AdvancedCreateV2_Defaults(t *testing.T) {
 	skipNoCluster(c, t)
 
 	db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	// Create
 	graphID := db.Name() + "_graph"
@@ -115,10 +123,6 @@ func Test_Graph_AdvancedCreateV2_Defaults(t *testing.T) {
 			}
 		}
 	})
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestGraphCreationV2(t *testing.T) {
@@ -126,6 +130,13 @@ func TestGraphCreationV2(t *testing.T) {
 	ctx := context.Background()
 
 	c := createClient(t, nil)
+	defer func() {
+		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.7.0")).Cluster().Enterprise()
 
 	t.Run("Satellite", func(t *testing.T) {
@@ -258,11 +269,6 @@ func TestGraphCreationV2(t *testing.T) {
 		require.Equal(t, g.Name(), graphs[0].Name())
 		require.True(t, graphs[0].IsDisjoint())
 	})
-	db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestHybridSmartGraphCreationV2(t *testing.T) {
@@ -272,6 +278,12 @@ func TestHybridSmartGraphCreationV2(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.9.0")).Cluster().Enterprise()
 
 	db := ensureDatabase(ctx, c, databaseName("graph", "create", "hybrid"), nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	name := db.Name() + "_test_create_hybrid_graph"
 	colName := db.Name() + "_create_hybrid_edge_col"
@@ -316,10 +328,6 @@ func TestHybridSmartGraphCreationV2(t *testing.T) {
 			require.True(t, prop.IsSatellite())
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestHybridSmartGraphCreationConditions(t *testing.T) {
@@ -329,6 +337,12 @@ func TestHybridSmartGraphCreationConditions(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.10.0")).Cluster().Enterprise()
 
 	db := ensureDatabase(ctx, c, databaseName("graph", "create", "hybrid", "options"), nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	t.Run("General Graph - isSmart is False and no smartGraphAttribute", func(t *testing.T) {
 		graphID := db.Name() + "_graph_smart_no_conditions"
@@ -376,8 +390,4 @@ func TestHybridSmartGraphCreationConditions(t *testing.T) {
 		require.Empty(t, g.SmartGraphAttribute())
 		require.True(t, g.IsSmart())
 	})
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }

--- a/test/graph_creation_v2_test.go
+++ b/test/graph_creation_v2_test.go
@@ -130,17 +130,16 @@ func TestGraphCreationV2(t *testing.T) {
 	ctx := context.Background()
 
 	c := createClient(t, nil)
-	defer func() {
-		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
-		err := db.Remove(ctx)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
-	}()
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.7.0")).Cluster().Enterprise()
 
 	t.Run("Satellite", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -163,6 +162,12 @@ func TestGraphCreationV2(t *testing.T) {
 
 	t.Run("Satellite - list", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -190,6 +195,12 @@ func TestGraphCreationV2(t *testing.T) {
 
 	t.Run("Standard", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -207,6 +218,12 @@ func TestGraphCreationV2(t *testing.T) {
 
 	t.Run("Standard - list", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -229,6 +246,12 @@ func TestGraphCreationV2(t *testing.T) {
 
 	t.Run("Disjoint", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -248,6 +271,12 @@ func TestGraphCreationV2(t *testing.T) {
 
 	t.Run("Disjoint - list", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"

--- a/test/graph_test.go
+++ b/test/graph_test.go
@@ -49,6 +49,12 @@ func TestCreateGraph(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "graph_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_graph"
 
 	if _, err := db.CreateGraphV2(ctx, name, nil); err != nil {
@@ -81,10 +87,6 @@ func TestCreateGraph(t *testing.T) {
 	} else if g.Name() != name {
 		t.Errorf("Graph.Name wrong. Expected '%s', got '%s'", name, g.Name())
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateGraphWithOptions creates a graph with options then checks if each options is set correctly.
@@ -95,6 +97,12 @@ func TestCreateGraphWithOptions(t *testing.T) {
 	skipNoCluster(c, t)
 
 	db := ensureDatabase(ctx, c, "graph_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_graph_2"
 
 	options := &driver.CreateGraphOptions{
@@ -166,10 +174,6 @@ func TestCreateGraphWithOptions(t *testing.T) {
 	if g.OrphanCollections()[0] != options.OrphanVertexCollections[0] && g.OrphanCollections()[1] != options.OrphanVertexCollections[1] {
 		t.Errorf("Graph.IsSmart wrong. Expected '%v', got '%v'", options.OrphanVertexCollections, g.OrphanCollections())
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveGraph creates a graph and then removes it.
@@ -177,6 +181,12 @@ func TestRemoveGraph(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "graph_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_remove_graph"
 	g, err := db.CreateGraphV2(ctx, name, nil)
 	if err != nil {
@@ -198,10 +208,6 @@ func TestRemoveGraph(t *testing.T) {
 	} else if found {
 		t.Errorf("GraphExists('%s') return true, expected false", name)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveGraphWithOpts creates a graph with collection and then removes it.
@@ -209,6 +215,12 @@ func TestRemoveGraphWithOpts(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "graph_test_remove", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_remove_graph_opts"
 	colName := "remove_graph_col"
 
@@ -236,8 +248,4 @@ func TestRemoveGraphWithOpts(t *testing.T) {
 	found, err = db.GraphExists(ctx, name)
 	require.NoError(t, err)
 	require.False(t, found)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }

--- a/test/graph_test.go
+++ b/test/graph_test.go
@@ -81,6 +81,10 @@ func TestCreateGraph(t *testing.T) {
 	} else if g.Name() != name {
 		t.Errorf("Graph.Name wrong. Expected '%s', got '%s'", name, g.Name())
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateGraphWithOptions creates a graph with options then checks if each options is set correctly.
@@ -162,6 +166,10 @@ func TestCreateGraphWithOptions(t *testing.T) {
 	if g.OrphanCollections()[0] != options.OrphanVertexCollections[0] && g.OrphanCollections()[1] != options.OrphanVertexCollections[1] {
 		t.Errorf("Graph.IsSmart wrong. Expected '%v', got '%v'", options.OrphanVertexCollections, g.OrphanCollections())
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveGraph creates a graph and then removes it.
@@ -189,6 +197,10 @@ func TestRemoveGraph(t *testing.T) {
 		t.Errorf("GraphExists('%s') failed: %s", name, describe(err))
 	} else if found {
 		t.Errorf("GraphExists('%s') return true, expected false", name)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -224,4 +236,8 @@ func TestRemoveGraphWithOpts(t *testing.T) {
 	found, err = db.GraphExists(ctx, name)
 	require.NoError(t, err)
 	require.False(t, found)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/index_ensure_test.go
+++ b/test/index_ensure_test.go
@@ -88,6 +88,10 @@ func TestEnsureFullTextIndex(t *testing.T) {
 			t.Errorf("Index '%s' does exist, expected it not to exist", idx.Name())
 		}
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestEnsureGeoIndex creates a collection with a geo index.
@@ -146,6 +150,10 @@ func TestEnsureGeoIndex(t *testing.T) {
 			t.Errorf("Index '%s' does exist, expected it not to exist", idx.Name())
 		}
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestEnsureGeoIndexLegacyPolygons creates a collection with a Geo index and additional LegacyPolygons options.
@@ -175,6 +183,10 @@ func TestEnsureGeoIndexLegacyPolygons(t *testing.T) {
 	require.True(t, created)
 	require.Equal(t, driver.GeoIndex, idx.Type())
 	require.False(t, idxDefault.LegacyPolygons())
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestEnsureHashIndex creates a collection with a hash index.
@@ -237,6 +249,10 @@ func TestEnsureHashIndex(t *testing.T) {
 		} else if found {
 			t.Errorf("Index '%s' does exist, expected it not to exist", idx.Name())
 		}
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -301,6 +317,10 @@ func TestEnsurePersistentIndex(t *testing.T) {
 			t.Errorf("Index '%s' does exist, expected it not to exist", idx.Name())
 		}
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestEnsurePersistentIndexOptions creates a collection with a persistent index and additional options.
@@ -330,6 +350,10 @@ func TestEnsurePersistentIndexOptions(t *testing.T) {
 	require.Equal(t, "extra2", idx.StoredValues()[1])
 
 	require.True(t, idx.CacheEnabled())
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestEnsureSkipListIndex creates a collection with a skiplist index.
@@ -396,6 +420,10 @@ func TestEnsureSkipListIndex(t *testing.T) {
 			t.Errorf("Index '%s' does exist, expected it not to exist", idx.Name())
 		}
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestEnsureTTLIndex creates a collection with a ttl index.
@@ -461,6 +489,10 @@ func TestEnsureTTLIndex(t *testing.T) {
 	if idx.ExpireAfter() != 0 {
 		t.Errorf("Expected ExpireAfter to be 0, found `%d`", idx.ExpireAfter())
 	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestEnsureZKDIndex creates a collection with a ZKD index.
@@ -485,6 +517,10 @@ func TestEnsureZKDIndex(t *testing.T) {
 
 	err = idx.Remove(nil)
 	require.NoError(t, err)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestEnsureZKDIndexWithOptions creates a collection with a ZKD index and additional options
@@ -514,6 +550,10 @@ func TestEnsureZKDIndexWithOptions(t *testing.T) {
 
 	err = idx.Remove(nil)
 	require.NoError(t, err)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestEnsureInvertedIndex creates a collection with an inverted index
@@ -641,5 +681,9 @@ func TestEnsureInvertedIndex(t *testing.T) {
 			err = idx.Remove(ctx)
 			require.NoError(t, err)
 		})
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/index_ensure_test.go
+++ b/test/index_ensure_test.go
@@ -36,6 +36,12 @@ import (
 func TestEnsureFullTextIndex(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	testOptions := []*driver.EnsureFullTextIndexOptions{
 		nil,
@@ -88,16 +94,18 @@ func TestEnsureFullTextIndex(t *testing.T) {
 			t.Errorf("Index '%s' does exist, expected it not to exist", idx.Name())
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestEnsureGeoIndex creates a collection with a geo index.
 func TestEnsureGeoIndex(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	testOptions := []*driver.EnsureGeoIndexOptions{
 		nil,
@@ -150,10 +158,6 @@ func TestEnsureGeoIndex(t *testing.T) {
 			t.Errorf("Index '%s' does exist, expected it not to exist", idx.Name())
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestEnsureGeoIndexLegacyPolygons creates a collection with a Geo index and additional LegacyPolygons options.
@@ -163,6 +167,12 @@ func TestEnsureGeoIndexLegacyPolygons(t *testing.T) {
 	skipBelowVersion(c, "3.10", t)
 
 	db := ensureDatabase(ctx, c, "index_geo_LegacyPolygons_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, fmt.Sprintf("persistent_index_options_test_"), nil, t)
 
 	options := &driver.EnsureGeoIndexOptions{
@@ -183,16 +193,18 @@ func TestEnsureGeoIndexLegacyPolygons(t *testing.T) {
 	require.True(t, created)
 	require.Equal(t, driver.GeoIndex, idx.Type())
 	require.False(t, idxDefault.LegacyPolygons())
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestEnsureHashIndex creates a collection with a hash index.
 func TestEnsureHashIndex(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	testOptions := []*driver.EnsureHashIndexOptions{
 		nil,
@@ -250,16 +262,18 @@ func TestEnsureHashIndex(t *testing.T) {
 			t.Errorf("Index '%s' does exist, expected it not to exist", idx.Name())
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestEnsurePersistentIndex creates a collection with a persistent index.
 func TestEnsurePersistentIndex(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	testOptions := []*driver.EnsurePersistentIndexOptions{
 		nil,
@@ -317,10 +331,6 @@ func TestEnsurePersistentIndex(t *testing.T) {
 			t.Errorf("Index '%s' does exist, expected it not to exist", idx.Name())
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestEnsurePersistentIndexOptions creates a collection with a persistent index and additional options.
@@ -330,6 +340,12 @@ func TestEnsurePersistentIndexOptions(t *testing.T) {
 	skipBelowVersion(c, "3.10", t)
 
 	db := ensureDatabase(ctx, c, "index_persistent_options_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, fmt.Sprintf("persistent_index_options_test_"), nil, t)
 
 	options := &driver.EnsurePersistentIndexOptions{
@@ -350,16 +366,18 @@ func TestEnsurePersistentIndexOptions(t *testing.T) {
 	require.Equal(t, "extra2", idx.StoredValues()[1])
 
 	require.True(t, idx.CacheEnabled())
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestEnsureSkipListIndex creates a collection with a skiplist index.
 func TestEnsureSkipListIndex(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	testOptions := []*driver.EnsureSkipListIndexOptions{
 		nil,
@@ -420,16 +438,18 @@ func TestEnsureSkipListIndex(t *testing.T) {
 			t.Errorf("Index '%s' does exist, expected it not to exist", idx.Name())
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestEnsureTTLIndex creates a collection with a ttl index.
 func TestEnsureTTLIndex(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	skipBelowVersion(c, "3.5", t)
 
 	col := ensureCollection(nil, db, "ttl_index_test", nil, t)
@@ -489,10 +509,6 @@ func TestEnsureTTLIndex(t *testing.T) {
 	if idx.ExpireAfter() != 0 {
 		t.Errorf("Expected ExpireAfter to be 0, found `%d`", idx.ExpireAfter())
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestEnsureZKDIndex creates a collection with a ZKD index.
@@ -503,6 +519,12 @@ func TestEnsureZKDIndex(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.9.0"))
 
 	db := ensureDatabase(ctx, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, fmt.Sprintf("zkd_index_test"), nil, t)
 
 	f1 := "field-zkd-index_1"
@@ -517,10 +539,6 @@ func TestEnsureZKDIndex(t *testing.T) {
 
 	err = idx.Remove(nil)
 	require.NoError(t, err)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestEnsureZKDIndexWithOptions creates a collection with a ZKD index and additional options
@@ -531,6 +549,12 @@ func TestEnsureZKDIndexWithOptions(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.9.0"))
 
 	db := ensureDatabase(ctx, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, fmt.Sprintf("zkd_index_opt_test"), nil, t)
 
 	f1 := "field-zkd-index1-opt"
@@ -550,10 +574,6 @@ func TestEnsureZKDIndexWithOptions(t *testing.T) {
 
 	err = idx.Remove(nil)
 	require.NoError(t, err)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestEnsureInvertedIndex creates a collection with an inverted index
@@ -564,6 +584,12 @@ func TestEnsureInvertedIndex(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.10.0"))
 
 	db := ensureDatabase(ctx, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, fmt.Sprintf("inverted_index_opt_test"), nil, t)
 
 	type testCase struct {
@@ -681,9 +707,5 @@ func TestEnsureInvertedIndex(t *testing.T) {
 			err = idx.Remove(ctx)
 			require.NoError(t, err)
 		})
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/indexes_test.go
+++ b/test/indexes_test.go
@@ -46,6 +46,10 @@ func TestDefaultIndexes(t *testing.T) {
 			t.Errorf("Expected 1 index, got %d", len(idxs))
 		}
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestDefaultEdgeIndexes creates a edge collection without any custom index.
@@ -75,6 +79,10 @@ func TestDefaultEdgeIndexes(t *testing.T) {
 		if !existed {
 			t.Errorf("Expected `%s` index presents, got no", driver.EdgeIndex)
 		}
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -127,6 +135,10 @@ func TestIndexes(t *testing.T) {
 		// 3 because 1 system index + 2 created above
 		t.Errorf("Expected 3 indexes, got %d", stats.Figures.Indexes.Count)
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestMultipleIndexes creates a collection with a full text index.
@@ -168,6 +180,10 @@ func TestMultipleIndexes(t *testing.T) {
 	} else if stats.Figures.Indexes.Count != 3 {
 		// 3 because 1 system index + 2 created above
 		t.Errorf("Expected 3 indexes, got %d", stats.Figures.Indexes.Count)
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -224,6 +240,10 @@ func TestIndexesDeduplicateHash(t *testing.T) {
 			if _, err := col.CreateDocument(nil, doc); err != nil {
 				t.Errorf("Expected success, got %s", describe(err))
 			}
+		}
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 		}
 	}
 }
@@ -282,6 +302,10 @@ func TestIndexesDeduplicateSkipList(t *testing.T) {
 				t.Errorf("Expected success, got %s", describe(err))
 			}
 		}
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
 	}
 }
 
@@ -336,6 +360,10 @@ func TestIndexesTTL(t *testing.T) {
 
 	if !wasThere {
 		t.Fatalf("Document never existed")
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -488,6 +516,10 @@ func TestNamedIndexes(t *testing.T) {
 			}
 		})
 	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 func TestNamedIndexesClusterInventory(t *testing.T) {
@@ -539,6 +571,10 @@ func TestNamedIndexesClusterInventory(t *testing.T) {
 				t.Errorf("Index with id %s not found", idx.ID())
 			}
 		})
+	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -600,7 +636,10 @@ func TestTTLIndexesClusterInventory(t *testing.T) {
 			t.Fatalf("Index not created: %s", describe(ctx.Err()))
 		}
 	}
-
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 func TestPersistentIndexCreation(t *testing.T) {
@@ -630,5 +669,9 @@ func TestPersistentIndexCreation(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.NotNil(t, index)
+	}
+	err := db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/indexes_test.go
+++ b/test/indexes_test.go
@@ -64,12 +64,6 @@ func TestDefaultEdgeIndexes(t *testing.T) {
 			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 		}
 	}()
-	defer func() {
-		err := db.Remove(nil)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
-	}()
 	col := ensureCollection(nil, db, "def_indexes_edge_test", &driver.CreateCollectionOptions{Type: driver.CollectionTypeEdge}, t)
 
 	// Get list of indexes

--- a/test/indexes_test.go
+++ b/test/indexes_test.go
@@ -35,6 +35,12 @@ import (
 func TestDefaultIndexes(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "def_indexes_test", nil, t)
 
 	// Get list of indexes
@@ -46,16 +52,24 @@ func TestDefaultIndexes(t *testing.T) {
 			t.Errorf("Expected 1 index, got %d", len(idxs))
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestDefaultEdgeIndexes creates a edge collection without any custom index.
 func TestDefaultEdgeIndexes(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "def_indexes_edge_test", &driver.CreateCollectionOptions{Type: driver.CollectionTypeEdge}, t)
 
 	// Get list of indexes
@@ -80,16 +94,18 @@ func TestDefaultEdgeIndexes(t *testing.T) {
 			t.Errorf("Expected `%s` index presents, got no", driver.EdgeIndex)
 		}
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateFullTextIndex creates a collection with a full text index.
 func TestIndexes(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "indexes_test", nil, t)
 
 	// Create some indexes
@@ -135,16 +151,18 @@ func TestIndexes(t *testing.T) {
 		// 3 because 1 system index + 2 created above
 		t.Errorf("Expected 3 indexes, got %d", stats.Figures.Indexes.Count)
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestMultipleIndexes creates a collection with a full text index.
 func TestMultipleIndexes(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "multiple_indexes_test", nil, t)
 
 	// Create some indexes of same type & fields, but different options
@@ -181,10 +199,6 @@ func TestMultipleIndexes(t *testing.T) {
 		// 3 because 1 system index + 2 created above
 		t.Errorf("Expected 3 indexes, got %d", stats.Figures.Indexes.Count)
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestIndexesDeduplicateHash tests no-deduplicate on hash index.
@@ -199,6 +213,12 @@ func TestIndexesDeduplicateHash(t *testing.T) {
 		t.Skip("Test requires 3.2")
 	} else {
 		db := ensureDatabase(nil, c, "index_test", nil, t)
+		defer func() {
+			err := db.Remove(nil)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		{
 			// Create some indexes with de-duplication off
@@ -241,10 +261,6 @@ func TestIndexesDeduplicateHash(t *testing.T) {
 				t.Errorf("Expected success, got %s", describe(err))
 			}
 		}
-		err := db.Remove(nil)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
 	}
 }
 
@@ -260,6 +276,12 @@ func TestIndexesDeduplicateSkipList(t *testing.T) {
 		t.Skip("Test requires 3.2")
 	} else {
 		db := ensureDatabase(nil, c, "index_test", nil, t)
+		defer func() {
+			err := db.Remove(nil)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		{
 			// Create some indexes with de-duplication off
@@ -302,10 +324,6 @@ func TestIndexesDeduplicateSkipList(t *testing.T) {
 				t.Errorf("Expected success, got %s", describe(err))
 			}
 		}
-		err := db.Remove(nil)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
 	}
 }
 
@@ -315,6 +333,12 @@ func TestIndexesTTL(t *testing.T) {
 	skipBelowVersion(c, "3.5", t)
 
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	// Create some indexes with de-duplication off
 	col := ensureCollection(nil, db, "indexes_ttl_test", nil, t)
@@ -360,10 +384,6 @@ func TestIndexesTTL(t *testing.T) {
 
 	if !wasThere {
 		t.Fatalf("Document never existed")
-	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -466,6 +486,12 @@ func TestNamedIndexes(t *testing.T) {
 	skipBelowVersion(c, "3.5", t)
 
 	db := ensureDatabase(nil, c, "named_index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "named_index_test_col", nil, t)
 
 	for _, testCase := range namedIndexTestCases {
@@ -516,10 +542,6 @@ func TestNamedIndexes(t *testing.T) {
 			}
 		})
 	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestNamedIndexesClusterInventory(t *testing.T) {
@@ -528,6 +550,12 @@ func TestNamedIndexesClusterInventory(t *testing.T) {
 	skipNoCluster(c, t)
 	colname := "named_index_test_col_inv"
 	db := ensureDatabase(nil, c, "named_index_test_inv", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, colname, nil, t)
 
 	cc, err := c.Cluster(nil)
@@ -572,10 +600,6 @@ func TestNamedIndexesClusterInventory(t *testing.T) {
 			}
 		})
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestTTLIndexesClusterInventory(t *testing.T) {
@@ -585,6 +609,12 @@ func TestTTLIndexesClusterInventory(t *testing.T) {
 	ttl := 3600
 	colname := "ttl_index_test_col_inv"
 	db := ensureDatabase(nil, c, "index_test_inv", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, colname, nil, t)
 
 	cc, err := c.Cluster(nil)
@@ -636,10 +666,6 @@ func TestTTLIndexesClusterInventory(t *testing.T) {
 			t.Fatalf("Index not created: %s", describe(ctx.Err()))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestPersistentIndexCreation(t *testing.T) {
@@ -647,6 +673,12 @@ func TestPersistentIndexCreation(t *testing.T) {
 	skipBelowVersion(c, "3.7", t)
 
 	db := ensureDatabase(nil, c, "index_test_creation", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	coll := ensureCollection(nil, db, "index_creation_test_col", nil, t)
 
 	for i := 0; i < 16; i++ {
@@ -669,9 +701,5 @@ func TestPersistentIndexCreation(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.NotNil(t, index)
-	}
-	err := db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/pregel_test.go
+++ b/test/pregel_test.go
@@ -91,4 +91,8 @@ func TestCreatePregelJob(t *testing.T) {
 	require.Greater(t, docResult.ResultField, 0.0)
 
 	t.Logf("resultField value: %f", docResult.ResultField)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/pregel_test.go
+++ b/test/pregel_test.go
@@ -37,6 +37,12 @@ func TestCreatePregelJob(t *testing.T) {
 	skipNoCluster(c, t)
 
 	db := ensureDatabase(ctx, c, "pregel_job_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "pregel_graph_test", nil, t)
 
 	nameVertex := "test_pregel_vertex"
@@ -91,8 +97,4 @@ func TestCreatePregelJob(t *testing.T) {
 	require.Greater(t, docResult.ResultField, 0.0)
 
 	t.Logf("resultField value: %f", docResult.ResultField)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }

--- a/test/query_test.go
+++ b/test/query_test.go
@@ -91,13 +91,6 @@ func prepareQueryDatabase(t *testing.T, ctx context.Context, c driver.Client, na
 func TestValidateQuery(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "validate_query_test", nil, t)
-	defer func() {
-		err := db.Remove(ctx)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
-	}()
 	db, clean := prepareQueryDatabase(t, ctx, c, "validate_query_test")
 	defer clean(t)
 
@@ -144,13 +137,6 @@ func TestValidateQuery(t *testing.T) {
 func TestExplainQuery(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "explain_query_test", nil, t)
-	defer func() {
-		err := db.Remove(ctx)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
-	}()
 	db, clean := prepareQueryDatabase(t, ctx, c, "explain_query_test")
 	defer clean(t)
 
@@ -245,14 +231,6 @@ func TestValidateQueryOptionShardIds(t *testing.T) {
 func TestProfileQuery(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "validate_query_test", nil, t)
-	defer func() {
-		err := db.Remove(ctx)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
-	}()
-
 	db, clean := prepareQueryDatabase(t, ctx, c, "validate_query_test")
 	defer clean(t)
 
@@ -350,14 +328,6 @@ func TestForceOneShardAttributeValue(t *testing.T) {
 
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.9.0")).Cluster().Enterprise()
 
-	db := ensureDatabase(ctx, c, "force_one_shard_attribute_value", nil, t)
-	defer func() {
-		err := db.Remove(ctx)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
-	}()
-
 	db, clean := prepareQueryDatabase(t, ctx, c, "force_one_shard_attribute_value")
 	defer clean(t)
 
@@ -393,14 +363,6 @@ func TestFillBlockCache(t *testing.T) {
 	c := createClient(t, nil)
 
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.8.1")).Cluster().Enterprise()
-
-	db := ensureDatabase(ctx, c, "fill_block_cache", nil, t)
-	defer func() {
-		err := db.Remove(ctx)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
-	}()
 
 	db, clean := prepareQueryDatabase(t, ctx, c, "fill_block_cache")
 	defer clean(t)
@@ -451,7 +413,6 @@ func TestOptimizerRulesForQueries(t *testing.T) {
 			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 		}
 	}()
-
 	t.Run(fmt.Sprintf("Fake shards"), func(t *testing.T) {
 		rules, err := db.OptimizerRulesForQueries(ctx)
 		require.Nil(t, err)
@@ -479,13 +440,6 @@ func TestRetryReadDocument(t *testing.T) {
 
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.11.0"))
 
-	db := ensureDatabase(ctx, c, "query_retry_test", nil, t)
-	defer func() {
-		err := db.Remove(ctx)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
-	}()
 	db, clean := prepareQueryDatabase(t, ctx, c, "query_retry_test")
 	defer clean(t)
 

--- a/test/query_test.go
+++ b/test/query_test.go
@@ -92,7 +92,12 @@ func TestValidateQuery(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "validate_query_test", nil, t)
-
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	db, clean := prepareQueryDatabase(t, ctx, c, "validate_query_test")
 	defer clean(t)
 
@@ -133,10 +138,6 @@ func TestValidateQuery(t *testing.T) {
 			}
 		})
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestExplainQuery tries to explain several AQL queries.
@@ -144,7 +145,12 @@ func TestExplainQuery(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "explain_query_test", nil, t)
-
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	db, clean := prepareQueryDatabase(t, ctx, c, "explain_query_test")
 	defer clean(t)
 
@@ -200,10 +206,6 @@ func TestExplainQuery(t *testing.T) {
 			}
 		})
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestValidateQuery validates several AQL queries.
@@ -250,6 +252,12 @@ func TestProfileQuery(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "validate_query_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	db, clean := prepareQueryDatabase(t, ctx, c, "validate_query_test")
 	defer clean(t)
@@ -337,10 +345,6 @@ func TestProfileQuery(t *testing.T) {
 			})
 		}
 	})
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestForceOneShardAttributeValue test ForceOneShardAttributeValue query attribute.
@@ -353,6 +357,12 @@ func TestForceOneShardAttributeValue(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.9.0")).Cluster().Enterprise()
 
 	db := ensureDatabase(ctx, c, "force_one_shard_attribute_value", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	db, clean := prepareQueryDatabase(t, ctx, c, "force_one_shard_attribute_value")
 	defer clean(t)
@@ -379,10 +389,6 @@ func TestForceOneShardAttributeValue(t *testing.T) {
 			})
 		}
 	})
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestFillBlockCache test FillBlockCache query attribute
@@ -395,6 +401,12 @@ func TestFillBlockCache(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.8.1")).Cluster().Enterprise()
 
 	db := ensureDatabase(ctx, c, "fill_block_cache", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	db, clean := prepareQueryDatabase(t, ctx, c, "fill_block_cache")
 	defer clean(t)
@@ -431,10 +443,6 @@ func TestFillBlockCache(t *testing.T) {
 			})
 		}
 	})
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestOptimizerRulesForQueries optimizer rules for AQL queries endpoint
@@ -443,6 +451,12 @@ func TestOptimizerRulesForQueries(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.10", t)
 	db := ensureDatabase(ctx, c, "optimizer_rules_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	t.Run(fmt.Sprintf("Fake shards"), func(t *testing.T) {
 		rules, err := db.OptimizerRulesForQueries(ctx)
@@ -460,10 +474,6 @@ func TestOptimizerRulesForQueries(t *testing.T) {
 		require.NotNil(t, ruleToFind)
 		require.True(t, ruleToFind.Flags.CanBeDisabled)
 	})
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRetryReadDocument test retry read document query attribute
@@ -476,6 +486,12 @@ func TestRetryReadDocument(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.11.0"))
 
 	db := ensureDatabase(ctx, c, "query_retry_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	db, clean := prepareQueryDatabase(t, ctx, c, "query_retry_test")
 	defer clean(t)
 
@@ -584,8 +600,4 @@ func TestRetryReadDocument(t *testing.T) {
 			})
 		}
 	})
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }

--- a/test/query_test.go
+++ b/test/query_test.go
@@ -133,6 +133,10 @@ func TestValidateQuery(t *testing.T) {
 			}
 		})
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestExplainQuery tries to explain several AQL queries.
@@ -196,6 +200,10 @@ func TestExplainQuery(t *testing.T) {
 			}
 		})
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestValidateQuery validates several AQL queries.
@@ -227,6 +235,10 @@ func TestValidateQueryOptionShardIds(t *testing.T) {
 			_, err = db.Query(ctx, "FOR doc in c RETURN doc", map[string]interface{}{})
 			require.NotNil(t, err)
 		})
+		err = db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
 	}
 
 	return
@@ -325,6 +337,10 @@ func TestProfileQuery(t *testing.T) {
 			})
 		}
 	})
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestForceOneShardAttributeValue test ForceOneShardAttributeValue query attribute.
@@ -363,6 +379,10 @@ func TestForceOneShardAttributeValue(t *testing.T) {
 			})
 		}
 	})
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestFillBlockCache test FillBlockCache query attribute
@@ -411,6 +431,10 @@ func TestFillBlockCache(t *testing.T) {
 			})
 		}
 	})
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestOptimizerRulesForQueries optimizer rules for AQL queries endpoint
@@ -436,6 +460,10 @@ func TestOptimizerRulesForQueries(t *testing.T) {
 		require.NotNil(t, ruleToFind)
 		require.True(t, ruleToFind.Flags.CanBeDisabled)
 	})
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRetryReadDocument test retry read document query attribute
@@ -556,4 +584,8 @@ func TestRetryReadDocument(t *testing.T) {
 			})
 		}
 	})
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/query_test.go
+++ b/test/query_test.go
@@ -217,11 +217,9 @@ func TestValidateQueryOptionShardIds(t *testing.T) {
 	if driver.IsPreconditionFailed(err) {
 		t.Skip("Not a cluster")
 	} else {
-		db := ensureDatabase(ctx, c, "validate_query_options_test", nil, t)
-		col := ensureCollection(ctx, db, "c", nil, t)
-
 		db, clean := prepareQueryDatabase(t, ctx, c, "validate_query_options_test")
 		defer clean(t)
+		col := ensureCollection(ctx, db, "c", nil, t)
 
 		t.Run(fmt.Sprintf("Real shards"), func(t *testing.T) {
 			shards, err := col.Shards(ctx, true)
@@ -237,10 +235,6 @@ func TestValidateQueryOptionShardIds(t *testing.T) {
 			_, err = db.Query(ctx, "FOR doc in c RETURN doc", map[string]interface{}{})
 			require.NotNil(t, err)
 		})
-		err = db.Remove(ctx)
-		if err != nil {
-			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-		}
 	}
 
 	return

--- a/test/revisions_test.go
+++ b/test/revisions_test.go
@@ -142,4 +142,8 @@ func TestRevisionTree(t *testing.T) {
 		json.Unmarshal(bytes, &user)
 		require.Equalf(t, user, expectedDocuments[i], "Documents should be the same")
 	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/revisions_test.go
+++ b/test/revisions_test.go
@@ -41,6 +41,12 @@ func TestRevisionTree(t *testing.T) {
 	skipBelowVersion(c, "3.8", t)
 
 	db := ensureDatabase(nil, c, "revision_tree", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "revision_tree", nil, t)
 
 	var noOfDocuments int = 80000
@@ -141,9 +147,5 @@ func TestRevisionTree(t *testing.T) {
 		bytes, _ := json.Marshal(d)
 		json.Unmarshal(bytes, &user)
 		require.Equalf(t, user, expectedDocuments[i], "Documents should be the same")
-	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/server_license_test.go
+++ b/test/server_license_test.go
@@ -44,7 +44,7 @@ func Test_License(t *testing.T) {
 
 	if version.IsEnterprise() {
 		assert.Equalf(t, driver.LicenseStatusExpiring, license.Status, "by default status should be expiring")
-		assert.Equalf(t, 1, license.Version, "excpected version should be 1")
+		assert.EqualValuesf(t, 1, license.Version, "excpected version should be 1")
 	} else {
 		assert.Equalf(t, driver.LicenseStatus(""), license.Status, "license status should be empty")
 		assert.Equalf(t, 0, license.Version, "license version should be empty")

--- a/test/server_license_test.go
+++ b/test/server_license_test.go
@@ -34,7 +34,7 @@ import (
 func Test_License(t *testing.T) {
 	c := createClient(t, nil)
 	ctx := context.Background()
-	skipBelowVersion(c, "3.10.0", t)
+	skipVersionNotInRange(c, "3.10.0", "3.12.4", t)
 
 	version, err := c.Version(ctx)
 	require.NoError(t, err)

--- a/test/server_mode_auth_test.go
+++ b/test/server_mode_auth_test.go
@@ -156,5 +156,9 @@ func TestServerModeAndGrants(t *testing.T) {
 		} else if grant != defaultDBAccess {
 			t.Errorf("Collection access using WithConfigured differs, got '%s', expected '%s'", grant, defaultColAccess)
 		}
+		err = db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
 	}
 }

--- a/test/server_mode_test.go
+++ b/test/server_mode_test.go
@@ -83,5 +83,9 @@ func TestServerMode(t *testing.T) {
 		if err := col.Remove(ctx); err != nil {
 			t.Fatalf("Collection remove failed: %s", describe(err))
 		}
+		err = db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
 	}
 }

--- a/test/server_statistics_test.go
+++ b/test/server_statistics_test.go
@@ -177,6 +177,13 @@ func TestServerStatisticsTraffic(t *testing.T) {
 	}
 
 	doSomeWrites(t, nil, c)
+	defer func() {
+		db := ensureDatabase(ctx, c, "statistics_test", nil, t)
+		err = db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	time.Sleep(time.Second) // Wait until statistics updated
 
@@ -209,11 +216,6 @@ func TestServerStatisticsTraffic(t *testing.T) {
 		}
 	} else {
 		t.Log("Skipping ClientUser tests for statistics, since API is not present.")
-	}
-	db := ensureDatabase(ctx, c, "statistics_test", nil, t)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -262,6 +264,13 @@ func TestServerStatisticsForwarding(t *testing.T) {
 
 	// At least 5000 documents in the collection:
 	doSomeWrites(t, ctx1, c)
+	defer func() {
+		db := ensureDatabase(ctx, c, "statistics_test", nil, t)
+		err = db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	doSomeWrites(t, ctx1, c)
 	doSomeWrites(t, ctx1, c)
 	doSomeWrites(t, ctx1, c)
@@ -359,10 +368,5 @@ func TestServerStatisticsForwarding(t *testing.T) {
 		checkTrafficAtMost(t, &statsBefore1, &statsAfter1, user,
 			&limits{Recv: 0.1, Sent: 0.1,
 				RecvCount: 0, SentCount: 0}, "Mango")
-	}
-	db := ensureDatabase(ctx, c, "statistics_test", nil, t)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/server_statistics_test.go
+++ b/test/server_statistics_test.go
@@ -210,6 +210,11 @@ func TestServerStatisticsTraffic(t *testing.T) {
 	} else {
 		t.Log("Skipping ClientUser tests for statistics, since API is not present.")
 	}
+	db := ensureDatabase(ctx, c, "statistics_test", nil, t)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // myQueryRequest is used below for a special query test for forwarding.
@@ -354,5 +359,10 @@ func TestServerStatisticsForwarding(t *testing.T) {
 		checkTrafficAtMost(t, &statsBefore1, &statsAfter1, user,
 			&limits{Recv: 0.1, Sent: 0.1,
 				RecvCount: 0, SentCount: 0}, "Mango")
+	}
+	db := ensureDatabase(ctx, c, "statistics_test", nil, t)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/user_auth_test.go
+++ b/test/user_auth_test.go
@@ -120,8 +120,8 @@ func TestUpdateUserPasswordOtherUser(t *testing.T) {
 		t.Skip("Cannot update other password using VST in 3.1")
 	} else {
 		// Right now user1 has no right to access user2
-		if _, err := authClient.User(nil, "user2"); !driver.IsForbidden(err) {
-			t.Fatalf("Expected ForbiddenError, got %s", describe(err))
+		if tst, err := authClient.User(nil, "user2"); !driver.IsForbidden(err) {
+			t.Fatalf("Expected ForbiddenError, got %s %s", describe(err), tst)
 		}
 
 		// Grant user1 access to _system db, then it should be able to access user2

--- a/test/user_auth_test.go
+++ b/test/user_auth_test.go
@@ -207,6 +207,10 @@ func TestGrantUserDatabase(t *testing.T) {
 	} else {
 		t.Logf("SetDatabaseAccess(ReadOnly) is not supported on versions below 3.2 (got version %s)", version.Version)
 	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestGrantUserDefaultDatabase creates a user & database and granting the user access to the "default" database.
@@ -333,6 +337,10 @@ func TestGrantUserDefaultDatabase(t *testing.T) {
 			}
 			break
 		}
+	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -526,6 +534,10 @@ func TestGrantUserCollection(t *testing.T) {
 	if _, err := authCol.ReadDocument(nil, meta1.Key, &doc); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUserAccessibleDatabases creates a user & databases and checks the list of accessible databases.
@@ -635,6 +647,19 @@ func TestUserAccessibleDatabases(t *testing.T) {
 	} else {
 		t.Logf("Last part of test fails on version < 3.2 (got version %s)", version.Version)
 	}
+	err = u.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to delete user %s: %s ...", u.Name(), err)
+	}
+	err = db1.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db1.Name(), err)
+	}
+	err = db2.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db2.Name(), err)
+	}
+	
 }
 
 func waitForDatabaseAccess(authClient driver.Client, dbname string, t *testing.T) driver.Database {

--- a/test/user_test.go
+++ b/test/user_test.go
@@ -157,7 +157,12 @@ func TestCreateUser(t *testing.T) {
 func TestUpdateUser(t *testing.T) {
 	c := createClient(t, nil)
 	u := ensureUser(nil, c, "update_user", nil, t)
-
+	defer func() {
+		err := u.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to delete user %s: %s ...", u.Name(), err)
+		}
+	}()
 	if err := u.Update(context.TODO(), driver.UserOptions{}); err != nil {
 		t.Errorf("Cannot update user with empty options: %s", describe(err))
 	}
@@ -201,6 +206,12 @@ func TestUpdateUser(t *testing.T) {
 func TestReplaceUser(t *testing.T) {
 	c := createClient(t, nil)
 	u := ensureUser(nil, c, "replace_user", nil, t)
+	defer func() {
+	err := u.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to delete user %s: %s ...", u.Name(), err)
+		}
+	}()
 
 	if err := u.Replace(context.TODO(), driver.UserOptions{}); err != nil {
 		t.Errorf("Cannot replace user with empty options: %s", describe(err))

--- a/test/user_test.go
+++ b/test/user_test.go
@@ -207,7 +207,7 @@ func TestReplaceUser(t *testing.T) {
 	c := createClient(t, nil)
 	u := ensureUser(nil, c, "replace_user", nil, t)
 	defer func() {
-	err := u.Remove(nil)
+		err := u.Remove(nil)
 		if err != nil {
 			t.Logf("Failed to delete user %s: %s ...", u.Name(), err)
 		}

--- a/test/vertex_collection_test.go
+++ b/test/vertex_collection_test.go
@@ -90,6 +90,10 @@ func TestCreateVertexCollection(t *testing.T) {
 	} else if vc.Name() != "person" {
 		t.Errorf("VertexCollection return invalid collection, expected 'person', got '%s'", vc.Name())
 	}
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateSatelliteVertexCollection creates a graph and then adds a Satellite vertex collection in it
@@ -148,6 +152,10 @@ func TestCreateSatelliteVertexCollection(t *testing.T) {
 	// revert
 	err = g.Remove(ctx)
 	require.NoError(t, err)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveVertexCollection creates a graph and then adds an vertex collection in it and then removes the vertex collection.
@@ -189,7 +197,10 @@ func TestRemoveVertexCollection(t *testing.T) {
 
 	// Collection must still exist in database
 	assertCollection(nil, db, "friends", t)
-
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRenameVertexCollection creates a graph and then adds an vertex collection in it and then renames the vertex collection.
@@ -237,5 +248,8 @@ func TestRenameVertexCollection(t *testing.T) {
 
 	// Collection must still exist in database
 	assertCollection(nil, db, newName, t)
-
+	err = db.Remove(nil)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/vertex_collection_test.go
+++ b/test/vertex_collection_test.go
@@ -48,6 +48,12 @@ func ensureVertexCollection(ctx context.Context, g driver.Graph, collection stri
 func TestCreateVertexCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "vertex_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_vertex_collection"
 	g, err := db.CreateGraphV2(nil, name, nil)
 	if err != nil {
@@ -90,10 +96,6 @@ func TestCreateVertexCollection(t *testing.T) {
 	} else if vc.Name() != "person" {
 		t.Errorf("VertexCollection return invalid collection, expected 'person', got '%s'", vc.Name())
 	}
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateSatelliteVertexCollection creates a graph and then adds a Satellite vertex collection in it
@@ -104,6 +106,12 @@ func TestCreateSatelliteVertexCollection(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.9.0")).Cluster().Enterprise()
 
 	db := ensureDatabase(ctx, c, "vertex_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	name := "test_create_satellite_vertex_collection"
 	options := driver.CreateGraphOptions{
@@ -152,16 +160,18 @@ func TestCreateSatelliteVertexCollection(t *testing.T) {
 	// revert
 	err = g.Remove(ctx)
 	require.NoError(t, err)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveVertexCollection creates a graph and then adds an vertex collection in it and then removes the vertex collection.
 func TestRemoveVertexCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "vertex_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_remove_vertex_collection"
 	g, err := db.CreateGraphV2(nil, name, nil)
 	if err != nil {
@@ -197,10 +207,6 @@ func TestRemoveVertexCollection(t *testing.T) {
 
 	// Collection must still exist in database
 	assertCollection(nil, db, "friends", t)
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRenameVertexCollection creates a graph and then adds an vertex collection in it and then renames the vertex collection.
@@ -211,6 +217,12 @@ func TestRenameVertexCollection(t *testing.T) {
 	skipNoSingle(c, t)
 
 	db := ensureDatabase(nil, c, "vertex_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_rename_vertex_collection"
 	g, err := db.CreateGraphV2(nil, name, nil)
 	if err != nil {
@@ -248,8 +260,4 @@ func TestRenameVertexCollection(t *testing.T) {
 
 	// Collection must still exist in database
 	assertCollection(nil, db, newName, t)
-	err = db.Remove(nil)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }

--- a/test/vertex_create_test.go
+++ b/test/vertex_create_test.go
@@ -57,6 +57,10 @@ func TestCreateVertex(t *testing.T) {
 			t.Errorf("Got invalid document. Expected '%+v', got '%+v'", book, readDoc)
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateVertexReturnNew creates a document and checks the document returned in in ReturnNew.
@@ -89,6 +93,10 @@ func TestCreateVertexReturnNew(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateVertexSilent creates a document with WithSilent.
@@ -108,6 +116,10 @@ func TestCreateVertexSilent(t *testing.T) {
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateVertexNil creates a document with a nil document.
@@ -120,5 +132,9 @@ func TestCreateVertexNil(t *testing.T) {
 
 	if _, err := vc.CreateDocument(nil, nil); !driver.IsInvalidArgument(err) {
 		t.Fatalf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertex_create_test.go
+++ b/test/vertex_create_test.go
@@ -33,6 +33,12 @@ func TestCreateVertex(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertex_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -57,10 +63,6 @@ func TestCreateVertex(t *testing.T) {
 			t.Errorf("Got invalid document. Expected '%+v', got '%+v'", book, readDoc)
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateVertexReturnNew creates a document and checks the document returned in in ReturnNew.
@@ -69,6 +71,12 @@ func TestCreateVertexReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertex_return_new_est", nil, t)
 	vc := ensureVertexCollection(ctx, g, "users", t)
 
@@ -93,10 +101,6 @@ func TestCreateVertexReturnNew(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateVertexSilent creates a document with WithSilent.
@@ -104,6 +108,12 @@ func TestCreateVertexSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertex_silent_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "users", t)
 
@@ -116,10 +126,6 @@ func TestCreateVertexSilent(t *testing.T) {
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateVertexNil creates a document with a nil document.
@@ -127,14 +133,16 @@ func TestCreateVertexNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertex_nil_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "users", t)
 
 	if _, err := vc.CreateDocument(nil, nil); !driver.IsInvalidArgument(err) {
 		t.Fatalf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertex_remove_test.go
+++ b/test/vertex_remove_test.go
@@ -60,6 +60,10 @@ func TestRemoveVertex(t *testing.T) {
 	} else if found {
 		t.Errorf("DocumentExists returned true for '%s', expected false", meta.Key)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveVertexReturnOld creates a document, removes it checks the ReturnOld value.
@@ -84,6 +88,10 @@ func TestRemoveVertexReturnOld(t *testing.T) {
 
 	// Check an old document
 	require.Equal(t, doc, old)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveVertexSilent creates a document, removes it with Silent() and then checks the meta is indeed empty.
@@ -111,6 +119,10 @@ func TestRemoveVertexSilent(t *testing.T) {
 	var readDoc Book
 	if _, err := vc.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -157,6 +169,10 @@ func TestRemoveVertexRevision(t *testing.T) {
 	if _, err := vc.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveVertexKeyEmpty removes a document it with an empty key.
@@ -169,5 +185,9 @@ func TestRemoveVertexKeyEmpty(t *testing.T) {
 
 	if _, err := vc.RemoveDocument(nil, ""); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertex_remove_test.go
+++ b/test/vertex_remove_test.go
@@ -34,6 +34,12 @@ func TestRemoveVertex(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertex_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "users", t)
 
@@ -60,10 +66,6 @@ func TestRemoveVertex(t *testing.T) {
 	} else if found {
 		t.Errorf("DocumentExists returned true for '%s', expected false", meta.Key)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveVertexReturnOld creates a document, removes it checks the ReturnOld value.
@@ -72,6 +74,12 @@ func TestRemoveVertexReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertex_returnOld_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -88,10 +96,6 @@ func TestRemoveVertexReturnOld(t *testing.T) {
 
 	// Check an old document
 	require.Equal(t, doc, old)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveVertexSilent creates a document, removes it with Silent() and then checks the meta is indeed empty.
@@ -99,6 +103,12 @@ func TestRemoveVertexSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertex_silent_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -120,10 +130,6 @@ func TestRemoveVertexSilent(t *testing.T) {
 	if _, err := vc.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveVertexRevision creates a document, removes it with an incorrect revision.
@@ -131,6 +137,12 @@ func TestRemoveVertexRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertex_revision_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "persons", t)
 
@@ -169,10 +181,6 @@ func TestRemoveVertexRevision(t *testing.T) {
 	if _, err := vc.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 		t.Fatalf("Expected NotFoundError, got  %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveVertexKeyEmpty removes a document it with an empty key.
@@ -180,14 +188,16 @@ func TestRemoveVertexKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertex_nil_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "hobby", t)
 
 	if _, err := vc.RemoveDocument(nil, ""); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertex_replace_test.go
+++ b/test/vertex_replace_test.go
@@ -33,6 +33,12 @@ func TestReplaceVertex(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertex_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "friend", t)
 
@@ -59,10 +65,6 @@ func TestReplaceVertex(t *testing.T) {
 	if !reflect.DeepEqual(replacement, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", replacement, readDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceVertexReturnOld creates a document, replaces it checks the ReturnOld value.
@@ -71,6 +73,12 @@ func TestReplaceVertexReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertex_returnOld_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -95,10 +103,6 @@ func TestReplaceVertexReturnOld(t *testing.T) {
 	if !reflect.DeepEqual(doc, old) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, old)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceVertexReturnNew creates a document, replaces it checks the ReturnNew value.
@@ -107,6 +111,12 @@ func TestReplaceVertexReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertex_returnNew_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "users", t)
 
@@ -132,10 +142,6 @@ func TestReplaceVertexReturnNew(t *testing.T) {
 	if !reflect.DeepEqual(expected, newDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", expected, newDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceVertexSilent creates a document, replaces it with Silent() and then checks the meta is indeed empty.
@@ -143,6 +149,12 @@ func TestReplaceVertexSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertex_returnNew_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "person", t)
 
@@ -163,10 +175,6 @@ func TestReplaceVertexSilent(t *testing.T) {
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceVertexRevision creates a document, replaces it with a specific (correct) revision.
@@ -175,6 +183,12 @@ func TestReplaceVertexRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertex_revision_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -212,10 +226,6 @@ func TestReplaceVertexRevision(t *testing.T) {
 	if _, err := vc.ReplaceDocument(replacedRevCtx, meta.Key, replacement); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceVertexKeyEmpty replaces a document it with an empty key.
@@ -223,6 +233,12 @@ func TestReplaceVertexKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertex_keyEmpty_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "names", t)
 
@@ -233,10 +249,6 @@ func TestReplaceVertexKeyEmpty(t *testing.T) {
 	if _, err := vc.ReplaceDocument(nil, "", replacement); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceVertexUpdateNil replaces a document it with a nil update.
@@ -244,14 +256,16 @@ func TestReplaceVertexUpdateNil(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertex_updateNil_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "names", t)
 
 	if _, err := vc.ReplaceDocument(nil, "validKey", nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertex_replace_test.go
+++ b/test/vertex_replace_test.go
@@ -59,6 +59,10 @@ func TestReplaceVertex(t *testing.T) {
 	if !reflect.DeepEqual(replacement, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", replacement, readDoc)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceVertexReturnOld creates a document, replaces it checks the ReturnOld value.
@@ -90,6 +94,10 @@ func TestReplaceVertexReturnOld(t *testing.T) {
 	// Check old document
 	if !reflect.DeepEqual(doc, old) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, old)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -124,6 +132,10 @@ func TestReplaceVertexReturnNew(t *testing.T) {
 	if !reflect.DeepEqual(expected, newDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", expected, newDoc)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceVertexSilent creates a document, replaces it with Silent() and then checks the meta is indeed empty.
@@ -150,6 +162,10 @@ func TestReplaceVertexSilent(t *testing.T) {
 		t.Fatalf("Failed to replace document '%s': %s", meta.Key, describe(err))
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -196,6 +212,10 @@ func TestReplaceVertexRevision(t *testing.T) {
 	if _, err := vc.ReplaceDocument(replacedRevCtx, meta.Key, replacement); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceVertexKeyEmpty replaces a document it with an empty key.
@@ -213,6 +233,10 @@ func TestReplaceVertexKeyEmpty(t *testing.T) {
 	if _, err := vc.ReplaceDocument(nil, "", replacement); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceVertexUpdateNil replaces a document it with a nil update.
@@ -225,5 +249,9 @@ func TestReplaceVertexUpdateNil(t *testing.T) {
 
 	if _, err := vc.ReplaceDocument(nil, "validKey", nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertex_update_test.go
+++ b/test/vertex_update_test.go
@@ -60,6 +60,10 @@ func TestUpdateVertex(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateVertexReturnOld creates a document, updates it checks the ReturnOld value.
@@ -90,6 +94,10 @@ func TestUpdateVertexReturnOld(t *testing.T) {
 	// Check old document
 	if !reflect.DeepEqual(doc, old) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, old)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -124,6 +132,10 @@ func TestUpdateVertexReturnNew(t *testing.T) {
 	expected.Age = 45
 	if !reflect.DeepEqual(expected, newDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", expected, newDoc)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -182,6 +194,10 @@ func TestUpdateVertexKeepNullTrue(t *testing.T) {
 			t.Errorf("Expected user to be found and nil, got %s", string(*raw))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateVertexKeepNullFalse creates a document, updates it with KeepNull(false) and then checks the update has succeeded.
@@ -219,6 +235,10 @@ func TestUpdateVertexKeepNullFalse(t *testing.T) {
 	if readDoc.User == nil {
 		t.Errorf("Expected user to be untouched, got %v", readDoc.User)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateVertexSilent creates a document, updates it with Silent() and then checks the meta is indeed empty.
@@ -245,6 +265,10 @@ func TestUpdateVertexSilent(t *testing.T) {
 		t.Fatalf("Failed to update document '%s': %s", meta.Key, describe(err))
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -291,6 +315,10 @@ func TestUpdateVertexRevision(t *testing.T) {
 	if _, err := vc.UpdateDocument(updatedRevCtx, meta.Key, update); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateVertexKeyEmpty updates a document it with an empty key.
@@ -308,6 +336,10 @@ func TestUpdateVertexKeyEmpty(t *testing.T) {
 	if _, err := vc.UpdateDocument(nil, "", update); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateVertexUpdateNil updates a document it with a nil update.
@@ -320,5 +352,9 @@ func TestUpdateVertexUpdateNil(t *testing.T) {
 
 	if _, err := vc.UpdateDocument(nil, "validKey", nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertex_update_test.go
+++ b/test/vertex_update_test.go
@@ -33,6 +33,12 @@ func TestUpdateVertex(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "user", t)
 
@@ -60,10 +66,6 @@ func TestUpdateVertex(t *testing.T) {
 	if !reflect.DeepEqual(doc, readDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, readDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVertexReturnOld creates a document, updates it checks the ReturnOld value.
@@ -72,6 +74,12 @@ func TestUpdateVertexReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_returnOld_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -95,10 +103,6 @@ func TestUpdateVertexReturnOld(t *testing.T) {
 	if !reflect.DeepEqual(doc, old) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", doc, old)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVertexReturnNew creates a document, updates it checks the ReturnNew value.
@@ -107,6 +111,12 @@ func TestUpdateVertexReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_returnNew_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "person", t)
 
@@ -133,10 +143,6 @@ func TestUpdateVertexReturnNew(t *testing.T) {
 	if !reflect.DeepEqual(expected, newDoc) {
 		t.Errorf("Got wrong document. Expected %+v, got %+v", expected, newDoc)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVertexKeepNullTrue creates a document, updates it with KeepNull(true) and then checks the update has succeeded.
@@ -145,6 +151,12 @@ func TestUpdateVertexKeepNullTrue(t *testing.T) {
 	c := createClient(t, nil)
 	conn := c.Connection()
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_keepNullTrue_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "accounts", t)
 
@@ -194,10 +206,6 @@ func TestUpdateVertexKeepNullTrue(t *testing.T) {
 			t.Errorf("Expected user to be found and nil, got %s", string(*raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVertexKeepNullFalse creates a document, updates it with KeepNull(false) and then checks the update has succeeded.
@@ -205,6 +213,12 @@ func TestUpdateVertexKeepNullFalse(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_keepNullFalse_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "accounts", t)
 
@@ -235,10 +249,6 @@ func TestUpdateVertexKeepNullFalse(t *testing.T) {
 	if readDoc.User == nil {
 		t.Errorf("Expected user to be untouched, got %v", readDoc.User)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVertexSilent creates a document, updates it with Silent() and then checks the meta is indeed empty.
@@ -246,6 +256,12 @@ func TestUpdateVertexSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_silent_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "moments", t)
 
@@ -266,10 +282,6 @@ func TestUpdateVertexSilent(t *testing.T) {
 	} else if meta.Key != "" {
 		t.Errorf("Expected empty meta, got %v", meta)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVertexRevision creates a document, updates it with a specific (correct) revision.
@@ -278,6 +290,12 @@ func TestUpdateVertexRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_revision_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -315,10 +333,6 @@ func TestUpdateVertexRevision(t *testing.T) {
 	if _, err := vc.UpdateDocument(updatedRevCtx, meta.Key, update); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVertexKeyEmpty updates a document it with an empty key.
@@ -326,6 +340,12 @@ func TestUpdateVertexKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_keyEmpty_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "tests", t)
 
@@ -336,10 +356,6 @@ func TestUpdateVertexKeyEmpty(t *testing.T) {
 	if _, err := vc.UpdateDocument(nil, "", update); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVertexUpdateNil updates a document it with a nil update.
@@ -347,14 +363,16 @@ func TestUpdateVertexUpdateNil(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_updateNil_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "errors", t)
 
 	if _, err := vc.UpdateDocument(nil, "validKey", nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertices_create_test.go
+++ b/test/vertices_create_test.go
@@ -83,6 +83,10 @@ func TestCreateVertices(t *testing.T) {
 			}
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateVerticesReturnNew creates documents and checks the document returned in in ReturnNew.
@@ -130,6 +134,10 @@ func TestCreateVerticesReturnNew(t *testing.T) {
 			}
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateVerticesSilent creates documents with WithSilent.
@@ -160,6 +168,10 @@ func TestCreateVerticesSilent(t *testing.T) {
 			t.Errorf("Expected 0 errors, got %d", len(errs))
 		}
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateVerticesNil creates multiple documents with a nil documents input.
@@ -171,6 +183,10 @@ func TestCreateVerticesNil(t *testing.T) {
 	vc := ensureVertexCollection(ctx, g, "rivers", t)
 	if _, _, err := vc.CreateDocuments(nil, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -189,5 +205,9 @@ func TestCreateVerticesNonSlice(t *testing.T) {
 	var m map[string]interface{}
 	if _, _, err := vc.CreateDocuments(nil, &m); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertices_create_test.go
+++ b/test/vertices_create_test.go
@@ -33,6 +33,12 @@ func TestCreateVertices(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertices_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -83,10 +89,6 @@ func TestCreateVertices(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateVerticesReturnNew creates documents and checks the document returned in in ReturnNew.
@@ -95,6 +97,12 @@ func TestCreateVerticesReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertices_returnNew_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -134,10 +142,6 @@ func TestCreateVerticesReturnNew(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateVerticesSilent creates documents with WithSilent.
@@ -145,6 +149,12 @@ func TestCreateVerticesSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertices_silent_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "users", t)
 
@@ -168,10 +178,6 @@ func TestCreateVerticesSilent(t *testing.T) {
 			t.Errorf("Expected 0 errors, got %d", len(errs))
 		}
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateVerticesNil creates multiple documents with a nil documents input.
@@ -179,14 +185,16 @@ func TestCreateVerticesNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertices_nil_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "rivers", t)
 	if _, _, err := vc.CreateDocuments(nil, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -195,6 +203,12 @@ func TestCreateVerticesNonSlice(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertices_nonSlice_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "failures", t)
 
@@ -205,9 +219,5 @@ func TestCreateVerticesNonSlice(t *testing.T) {
 	var m map[string]interface{}
 	if _, _, err := vc.CreateDocuments(nil, &m); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertices_create_test.go
+++ b/test/vertices_create_test.go
@@ -32,7 +32,7 @@ import (
 func TestCreateVertices(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_create_test1", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -96,7 +96,7 @@ func TestCreateVerticesReturnNew(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_create_test2", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -148,7 +148,7 @@ func TestCreateVerticesReturnNew(t *testing.T) {
 func TestCreateVerticesSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_create_test3", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -184,7 +184,7 @@ func TestCreateVerticesSilent(t *testing.T) {
 func TestCreateVerticesNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_create_test4", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -202,7 +202,7 @@ func TestCreateVerticesNil(t *testing.T) {
 func TestCreateVerticesNonSlice(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_create_test5", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {

--- a/test/vertices_import_test.go
+++ b/test/vertices_import_test.go
@@ -32,6 +32,12 @@ func TestImportVerticesWithKeys(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_withKeys_test", t)
 	docs := []UserDocWithKey{
@@ -68,10 +74,6 @@ func TestImportVerticesWithKeys(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 0, stats.Empty, formatRawResponse(raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportVerticesWithoutKeys imports documents and then checks that it exists.
@@ -79,6 +81,12 @@ func TestImportVerticesWithoutKeys(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_withoutKeys_test", t)
 	docs := []UserDoc{
@@ -112,10 +120,6 @@ func TestImportVerticesWithoutKeys(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 0, stats.Empty, formatRawResponse(raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportVerticesEmptyEntries imports documents and then checks that it exists.
@@ -126,6 +130,12 @@ func TestImportVerticesEmptyEntries(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_emptyEntries_test", t)
 	docs := []*UserDocWithKey{
@@ -163,10 +173,6 @@ func TestImportVerticesEmptyEntries(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 1, stats.Empty, formatRawResponse(raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportVerticesInvalidEntries imports documents and then checks that it exists.
@@ -177,6 +183,12 @@ func TestImportVerticesInvalidEntries(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_invalidEntries_test", t)
 	docs := []interface{}{
@@ -216,10 +228,6 @@ func TestImportVerticesInvalidEntries(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 1, stats.Empty, formatRawResponse(raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportVerticesDuplicateEntries imports documents and then checks that it exists.
@@ -227,6 +235,12 @@ func TestImportVerticesDuplicateEntries(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_duplicateEntries_test", t)
 	docs := []interface{}{
@@ -264,10 +278,6 @@ func TestImportVerticesDuplicateEntries(t *testing.T) {
 			t.Errorf("Expected %d ignored documents, got %d (json %s)", 0, stats.Ignored, formatRawResponse(raw))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportVerticesDuplicateEntriesComplete imports documents and then checks that it exists.
@@ -275,6 +285,12 @@ func TestImportVerticesDuplicateEntriesComplete(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_duplicateEntriesComplete_test", t)
 	docs := []interface{}{
@@ -297,10 +313,6 @@ func TestImportVerticesDuplicateEntriesComplete(t *testing.T) {
 	}); !driver.IsConflict(err) {
 		t.Errorf("Expected ConflictError, got %s", describe(err))
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportVerticesDuplicateEntriesUpdate imports documents and then checks that it exists.
@@ -308,6 +320,12 @@ func TestImportVerticesDuplicateEntriesUpdate(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_duplicateEntriesUpdate_test", t)
 	docs := []interface{}{
@@ -358,10 +376,6 @@ func TestImportVerticesDuplicateEntriesUpdate(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportVerticesDuplicateEntriesReplace imports documents and then checks that it exists.
@@ -369,6 +383,12 @@ func TestImportVerticesDuplicateEntriesReplace(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_duplicateEntriesReplace_test", t)
 	docs := []interface{}{
@@ -419,10 +439,6 @@ func TestImportVerticesDuplicateEntriesReplace(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportVerticesDuplicateEntriesIgnore imports documents and then checks that it exists.
@@ -430,6 +446,12 @@ func TestImportVerticesDuplicateEntriesIgnore(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_duplicateEntriesIgnore_test", t)
 	docs := []interface{}{
@@ -480,10 +502,6 @@ func TestImportVerticesDuplicateEntriesIgnore(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportVerticesDetails imports documents and then checks that it exists.
@@ -491,6 +509,12 @@ func TestImportVerticesDetails(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_details_test", t)
 	docs := []interface{}{
@@ -535,10 +559,6 @@ func TestImportVerticesDetails(t *testing.T) {
 			t.Errorf("Expected details[0] to be '%s', got '%s'", detailsExpected, details[0])
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportVerticesOverwriteYes imports documents and then checks that it exists.
@@ -547,6 +567,12 @@ func TestImportVerticesOverwriteYes(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_overwriteYes_test", t)
 	docs := []interface{}{
@@ -581,10 +607,6 @@ func TestImportVerticesOverwriteYes(t *testing.T) {
 			t.Errorf("Expected count to be %d in round %d, got %d", countExpected, i, count)
 		}
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestImportVerticesOverwriteNo imports documents and then checks that it exists.
@@ -593,6 +615,12 @@ func TestImportVerticesOverwriteNo(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_overwriteNo_test", t)
 	docs := []interface{}{
@@ -626,9 +654,5 @@ func TestImportVerticesOverwriteNo(t *testing.T) {
 		} else if count != countExpected {
 			t.Errorf("Expected count to be %d in round %d, got %d", countExpected, i, count)
 		}
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertices_import_test.go
+++ b/test/vertices_import_test.go
@@ -68,6 +68,10 @@ func TestImportVerticesWithKeys(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 0, stats.Empty, formatRawResponse(raw))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportVerticesWithoutKeys imports documents and then checks that it exists.
@@ -107,6 +111,10 @@ func TestImportVerticesWithoutKeys(t *testing.T) {
 		if stats.Empty != 0 {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 0, stats.Empty, formatRawResponse(raw))
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -154,6 +162,10 @@ func TestImportVerticesEmptyEntries(t *testing.T) {
 		if stats.Empty != 1 {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 1, stats.Empty, formatRawResponse(raw))
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -204,6 +216,10 @@ func TestImportVerticesInvalidEntries(t *testing.T) {
 			t.Errorf("Expected %d empty documents, got %d (json %s)", 1, stats.Empty, formatRawResponse(raw))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportVerticesDuplicateEntries imports documents and then checks that it exists.
@@ -248,6 +264,10 @@ func TestImportVerticesDuplicateEntries(t *testing.T) {
 			t.Errorf("Expected %d ignored documents, got %d (json %s)", 0, stats.Ignored, formatRawResponse(raw))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportVerticesDuplicateEntriesComplete imports documents and then checks that it exists.
@@ -276,6 +296,10 @@ func TestImportVerticesDuplicateEntriesComplete(t *testing.T) {
 		Complete: true,
 	}); !driver.IsConflict(err) {
 		t.Errorf("Expected ConflictError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -334,6 +358,10 @@ func TestImportVerticesDuplicateEntriesUpdate(t *testing.T) {
 			}
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportVerticesDuplicateEntriesReplace imports documents and then checks that it exists.
@@ -390,6 +418,10 @@ func TestImportVerticesDuplicateEntriesReplace(t *testing.T) {
 				t.Errorf("Expected Age to be 0, got %d", user.Age)
 			}
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -448,6 +480,10 @@ func TestImportVerticesDuplicateEntriesIgnore(t *testing.T) {
 			}
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportVerticesDetails imports documents and then checks that it exists.
@@ -499,6 +535,10 @@ func TestImportVerticesDetails(t *testing.T) {
 			t.Errorf("Expected details[0] to be '%s', got '%s'", detailsExpected, details[0])
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportVerticesOverwriteYes imports documents and then checks that it exists.
@@ -541,6 +581,10 @@ func TestImportVerticesOverwriteYes(t *testing.T) {
 			t.Errorf("Expected count to be %d in round %d, got %d", countExpected, i, count)
 		}
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestImportVerticesOverwriteNo imports documents and then checks that it exists.
@@ -582,5 +626,9 @@ func TestImportVerticesOverwriteNo(t *testing.T) {
 		} else if count != countExpected {
 			t.Errorf("Expected count to be %d in round %d, got %d", countExpected, i, count)
 		}
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertices_remove_test.go
+++ b/test/vertices_remove_test.go
@@ -33,7 +33,7 @@ import (
 func TestRemoveVertices(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_remove_test1", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -76,7 +76,7 @@ func TestRemoveVertices(t *testing.T) {
 func TestRemoveVerticesReturnOld(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_remove_test2", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -118,7 +118,7 @@ func TestRemoveVerticesReturnOld(t *testing.T) {
 func TestRemoveVerticesSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_remove_test3", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -166,7 +166,7 @@ func TestRemoveVerticesSilent(t *testing.T) {
 func TestRemoveVerticesRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_remove_test4", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -240,7 +240,7 @@ func TestRemoveVerticesRevision(t *testing.T) {
 func TestRemoveVerticesKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_remove_test5", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {

--- a/test/vertices_remove_test.go
+++ b/test/vertices_remove_test.go
@@ -64,6 +64,10 @@ func TestRemoveVertices(t *testing.T) {
 			t.Fatalf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveVerticesReturnOld creates documents, removes them checks the ReturnOld value.
@@ -99,6 +103,10 @@ func TestRemoveVerticesReturnOld(t *testing.T) {
 	// Check old documents
 	for i, doc := range docs {
 		require.Equal(t, doc, oldDocs[i])
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -141,6 +149,10 @@ func TestRemoveVerticesSilent(t *testing.T) {
 		if _, err := vc.ReadDocument(ctx, meta.Key, &readDoc); !driver.IsNotFound(err) {
 			t.Errorf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -210,6 +222,10 @@ func TestRemoveVerticesRevision(t *testing.T) {
 			t.Errorf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestRemoveVerticesKeyEmpty removes a document it with an empty key.
@@ -222,5 +238,9 @@ func TestRemoveVerticesKeyEmpty(t *testing.T) {
 
 	if _, _, err := vc.RemoveDocuments(nil, []string{""}); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertices_remove_test.go
+++ b/test/vertices_remove_test.go
@@ -34,6 +34,12 @@ func TestRemoveVertices(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertices_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "places", t)
 
@@ -64,10 +70,6 @@ func TestRemoveVertices(t *testing.T) {
 			t.Fatalf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveVerticesReturnOld creates documents, removes them checks the ReturnOld value.
@@ -75,6 +77,12 @@ func TestRemoveVerticesReturnOld(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	g := ensureGraph(ctx, db, "remove_vertices_returnOld_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
@@ -104,10 +112,6 @@ func TestRemoveVerticesReturnOld(t *testing.T) {
 	for i, doc := range docs {
 		require.Equal(t, doc, oldDocs[i])
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveVerticesSilent creates documents, removes them with Silent() and then checks the meta is indeed empty.
@@ -115,6 +119,12 @@ func TestRemoveVerticesSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertices_silent_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "silence", t)
 
@@ -150,10 +160,6 @@ func TestRemoveVerticesSilent(t *testing.T) {
 			t.Errorf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveVerticesRevision creates documents, removes them with an incorrect revisions.
@@ -161,6 +167,12 @@ func TestRemoveVerticesRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertices_revision_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -222,10 +234,6 @@ func TestRemoveVerticesRevision(t *testing.T) {
 			t.Errorf("Expected NotFoundError at %d, got  %s", i, describe(err))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRemoveVerticesKeyEmpty removes a document it with an empty key.
@@ -233,14 +241,16 @@ func TestRemoveVerticesKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertices_keyEmpty_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "failures", t)
 
 	if _, _, err := vc.RemoveDocuments(nil, []string{""}); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertices_replace_test.go
+++ b/test/vertices_replace_test.go
@@ -34,6 +34,12 @@ func TestReplaceVertices(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "male", t)
 
@@ -73,10 +79,6 @@ func TestReplaceVertices(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, replacements[i], readDoc)
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceVerticesReturnOld creates documents, replaces them checks the ReturnOld values.
@@ -85,6 +87,12 @@ func TestReplaceVerticesReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_returnOld_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "pensions", t)
 
@@ -122,10 +130,6 @@ func TestReplaceVerticesReturnOld(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, oldDocs[i])
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceVerticesReturnNew creates documents, replaces them checks the ReturnNew values.
@@ -134,6 +138,12 @@ func TestReplaceVerticesReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_returnNew_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -172,10 +182,6 @@ func TestReplaceVerticesReturnNew(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, expected, newDocs[i])
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceVerticesSilent creates documents, replaces them with Silent() and then checks the meta is indeed empty.
@@ -183,6 +189,12 @@ func TestReplaceVerticesSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_silent_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "moments", t)
 
@@ -220,10 +232,6 @@ func TestReplaceVerticesSilent(t *testing.T) {
 			t.Errorf("Expected 0 metas, got %d", len(metas))
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceVerticesRevision creates documents, replaces then with a specific (correct) revisions.
@@ -232,6 +240,12 @@ func TestReplaceVerticesRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_revision_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "planets", t)
 
@@ -293,10 +307,6 @@ func TestReplaceVerticesRevision(t *testing.T) {
 	} else if err := errs.FirstNonNil(); err != nil {
 		t.Fatalf("Expected no errors, got first: %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceVerticesKeyEmpty replaces a document it with an empty key.
@@ -304,6 +314,12 @@ func TestReplaceVerticesKeyEmpty(t *testing.T) {
 	ctx := context.TODO()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_keyEmpty_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "planets", t)
 
@@ -314,10 +330,6 @@ func TestReplaceVerticesKeyEmpty(t *testing.T) {
 	if _, _, err := vc.ReplaceDocuments(nil, []string{""}, replacement); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestReplaceVerticesUpdateNil replaces a document it with a nil update.
@@ -325,15 +337,17 @@ func TestReplaceVerticesUpdateNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_updateNil_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "relations", t)
 
 	if _, _, err := vc.ReplaceDocuments(nil, []string{"validKey"}, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -342,6 +356,12 @@ func TestReplaceVerticesUpdateLenDiff(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_updateNil_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "failures", t)
 
@@ -355,9 +375,5 @@ func TestReplaceVerticesUpdateLenDiff(t *testing.T) {
 	}
 	if _, _, err := vc.ReplaceDocuments(nil, []string{"only1"}, replacements); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertices_replace_test.go
+++ b/test/vertices_replace_test.go
@@ -73,6 +73,10 @@ func TestReplaceVertices(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, replacements[i], readDoc)
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceVerticesReturnOld creates documents, replaces them checks the ReturnOld values.
@@ -117,6 +121,10 @@ func TestReplaceVerticesReturnOld(t *testing.T) {
 		if !reflect.DeepEqual(doc, oldDocs[i]) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, oldDocs[i])
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -164,6 +172,10 @@ func TestReplaceVerticesReturnNew(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, expected, newDocs[i])
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceVerticesSilent creates documents, replaces them with Silent() and then checks the meta is indeed empty.
@@ -207,6 +219,10 @@ func TestReplaceVerticesSilent(t *testing.T) {
 		if len(metas) > 0 {
 			t.Errorf("Expected 0 metas, got %d", len(metas))
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -277,6 +293,10 @@ func TestReplaceVerticesRevision(t *testing.T) {
 	} else if err := errs.FirstNonNil(); err != nil {
 		t.Fatalf("Expected no errors, got first: %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceVerticesKeyEmpty replaces a document it with an empty key.
@@ -294,6 +314,10 @@ func TestReplaceVerticesKeyEmpty(t *testing.T) {
 	if _, _, err := vc.ReplaceDocuments(nil, []string{""}, replacement); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestReplaceVerticesUpdateNil replaces a document it with a nil update.
@@ -306,6 +330,10 @@ func TestReplaceVerticesUpdateNil(t *testing.T) {
 
 	if _, _, err := vc.ReplaceDocuments(nil, []string{"validKey"}, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -327,5 +355,9 @@ func TestReplaceVerticesUpdateLenDiff(t *testing.T) {
 	}
 	if _, _, err := vc.ReplaceDocuments(nil, []string{"only1"}, replacements); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertices_replace_test.go
+++ b/test/vertices_replace_test.go
@@ -33,7 +33,7 @@ import (
 func TestReplaceVertices(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_replace_test1", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -86,7 +86,7 @@ func TestReplaceVerticesReturnOld(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_test2", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -137,7 +137,7 @@ func TestReplaceVerticesReturnNew(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_replace_test3", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -188,7 +188,7 @@ func TestReplaceVerticesReturnNew(t *testing.T) {
 func TestReplaceVerticesSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_replace_test4", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -239,7 +239,7 @@ func TestReplaceVerticesSilent(t *testing.T) {
 func TestReplaceVerticesRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_replace_test5", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -313,7 +313,7 @@ func TestReplaceVerticesRevision(t *testing.T) {
 func TestReplaceVerticesKeyEmpty(t *testing.T) {
 	ctx := context.TODO()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_replace_test6", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -336,7 +336,7 @@ func TestReplaceVerticesKeyEmpty(t *testing.T) {
 func TestReplaceVerticesUpdateNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_replace_test7", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -355,7 +355,7 @@ func TestReplaceVerticesUpdateNil(t *testing.T) {
 func TestReplaceVerticesUpdateLenDiff(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_replace_test8", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {

--- a/test/vertices_update_test.go
+++ b/test/vertices_update_test.go
@@ -34,7 +34,7 @@ import (
 func TestUpdateVertices(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test1", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -89,7 +89,7 @@ func TestUpdateVerticesReturnOld(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test2", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -140,7 +140,7 @@ func TestUpdateVerticesReturnNew(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test3", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -193,7 +193,7 @@ func TestUpdateVerticesKeepNullTrue(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	conn := c.Connection()
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test4", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -276,7 +276,7 @@ func TestUpdateVerticesKeepNullTrue(t *testing.T) {
 func TestUpdateVerticesKeepNullFalse(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test5", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -339,7 +339,7 @@ func TestUpdateVerticesKeepNullFalse(t *testing.T) {
 func TestUpdateVerticesSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test6", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -385,7 +385,7 @@ func TestUpdateVerticesSilent(t *testing.T) {
 func TestUpdateVerticesRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test7", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -456,7 +456,7 @@ func TestUpdateVerticesRevision(t *testing.T) {
 func TestUpdateVerticesKeyEmpty(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test8", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -481,7 +481,7 @@ func TestUpdateVerticesKeyEmpty(t *testing.T) {
 func TestUpdateVerticesUpdateNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test9", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {
@@ -500,7 +500,7 @@ func TestUpdateVerticesUpdateNil(t *testing.T) {
 func TestUpdateVerticesUpdateLenDiff(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test10", nil, t)
 	defer func() {
 		err := db.Remove(ctx)
 		if err != nil {

--- a/test/vertices_update_test.go
+++ b/test/vertices_update_test.go
@@ -35,6 +35,12 @@ func TestUpdateVertices(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "relations", t)
 
@@ -76,10 +82,6 @@ func TestUpdateVertices(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, readDoc)
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVerticesReturnOld creates documents, updates them checks the ReturnOld values.
@@ -88,6 +90,12 @@ func TestUpdateVerticesReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_returnOld_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "books", t)
 
@@ -125,10 +133,6 @@ func TestUpdateVerticesReturnOld(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, oldDocs[i])
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVerticesReturnNew creates documents, updates them checks the ReturnNew values.
@@ -137,6 +141,12 @@ func TestUpdateVerticesReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_returnOld_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "users", t)
 
@@ -176,10 +186,6 @@ func TestUpdateVerticesReturnNew(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, expected, newDocs[i])
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVerticesKeepNullTrue creates documents, updates them with KeepNull(true) and then checks the updates have succeeded.
@@ -188,6 +194,12 @@ func TestUpdateVerticesKeepNullTrue(t *testing.T) {
 	c := createClient(t, nil)
 	conn := c.Connection()
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_keepNullTrue_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "keepers", t)
 
@@ -258,10 +270,6 @@ func TestUpdateVerticesKeepNullTrue(t *testing.T) {
 			}
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVerticesKeepNullFalse creates documents, updates them with KeepNull(false) and then checks the updates have succeeded.
@@ -269,6 +277,12 @@ func TestUpdateVerticesKeepNullFalse(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_keepNullFalse_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "accounts", t)
 
@@ -319,10 +333,6 @@ func TestUpdateVerticesKeepNullFalse(t *testing.T) {
 			t.Errorf("Expected user to be untouched, got %v", readDoc.User)
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVerticesSilent creates documents, updates them with Silent() and then checks the metas are indeed empty.
@@ -330,6 +340,12 @@ func TestUpdateVerticesSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_silent_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "moments", t)
 
@@ -362,10 +378,6 @@ func TestUpdateVerticesSilent(t *testing.T) {
 	} else if strings.Join(metas.Keys(), "") != "" {
 		t.Errorf("Expected empty meta, got %v", metas)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVerticesRevision creates documents, updates them with a specific (correct) revisions.
@@ -374,6 +386,12 @@ func TestUpdateVerticesRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_revision_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "revisions", t)
 
@@ -432,10 +450,6 @@ func TestUpdateVerticesRevision(t *testing.T) {
 	if _, _, err := ec.UpdateDocuments(updatedRevCtx, metas.Keys(), updates); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVerticesKeyEmpty updates documents with an empty key.
@@ -443,6 +457,12 @@ func TestUpdateVerticesKeyEmpty(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_keyEmpty_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "lonely", t)
 
@@ -455,10 +475,6 @@ func TestUpdateVerticesKeyEmpty(t *testing.T) {
 	if _, _, err := ec.UpdateDocuments(nil, []string{""}, updates); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUpdateVerticesUpdateNil updates documents it with a nil update.
@@ -466,15 +482,17 @@ func TestUpdateVerticesUpdateNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_updateNil_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "nilAndSome", t)
 
 	if _, _, err := ec.UpdateDocuments(nil, []string{"validKey"}, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -483,6 +501,12 @@ func TestUpdateVerticesUpdateLenDiff(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_updateLenDiff_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "diffs", t)
 
@@ -496,9 +520,5 @@ func TestUpdateVerticesUpdateLenDiff(t *testing.T) {
 	}
 	if _, _, err := ec.UpdateDocuments(nil, []string{"only1"}, updates); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/vertices_update_test.go
+++ b/test/vertices_update_test.go
@@ -76,6 +76,10 @@ func TestUpdateVertices(t *testing.T) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, readDoc)
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateVerticesReturnOld creates documents, updates them checks the ReturnOld values.
@@ -120,6 +124,10 @@ func TestUpdateVerticesReturnOld(t *testing.T) {
 		if !reflect.DeepEqual(doc, oldDocs[i]) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, doc, oldDocs[i])
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -167,6 +175,10 @@ func TestUpdateVerticesReturnNew(t *testing.T) {
 		if !reflect.DeepEqual(expected, newDocs[i]) {
 			t.Errorf("Got wrong document %d. Expected %+v, got %+v", i, expected, newDocs[i])
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -246,6 +258,10 @@ func TestUpdateVerticesKeepNullTrue(t *testing.T) {
 			}
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateVerticesKeepNullFalse creates documents, updates them with KeepNull(false) and then checks the updates have succeeded.
@@ -303,6 +319,10 @@ func TestUpdateVerticesKeepNullFalse(t *testing.T) {
 			t.Errorf("Expected user to be untouched, got %v", readDoc.User)
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateVerticesSilent creates documents, updates them with Silent() and then checks the metas are indeed empty.
@@ -341,6 +361,10 @@ func TestUpdateVerticesSilent(t *testing.T) {
 		t.Fatalf("Expected no errors, got first: %s", describe(err))
 	} else if strings.Join(metas.Keys(), "") != "" {
 		t.Errorf("Expected empty meta, got %v", metas)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -408,6 +432,10 @@ func TestUpdateVerticesRevision(t *testing.T) {
 	if _, _, err := ec.UpdateDocuments(updatedRevCtx, metas.Keys(), updates); err != nil {
 		t.Errorf("Expected success, got %s", describe(err))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateVerticesKeyEmpty updates documents with an empty key.
@@ -427,6 +455,10 @@ func TestUpdateVerticesKeyEmpty(t *testing.T) {
 	if _, _, err := ec.UpdateDocuments(nil, []string{""}, updates); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUpdateVerticesUpdateNil updates documents it with a nil update.
@@ -439,6 +471,10 @@ func TestUpdateVerticesUpdateNil(t *testing.T) {
 
 	if _, _, err := ec.UpdateDocuments(nil, []string{"validKey"}, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -460,5 +496,9 @@ func TestUpdateVerticesUpdateLenDiff(t *testing.T) {
 	}
 	if _, _, err := ec.UpdateDocuments(nil, []string{"only1"}, updates); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }

--- a/test/view_alias_test.go
+++ b/test/view_alias_test.go
@@ -132,4 +132,8 @@ func TestSearchViewsAlias(t *testing.T) {
 	views, err = db.Views(ctx)
 	require.NoError(t, err)
 	require.Len(t, views, 0)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/view_alias_test.go
+++ b/test/view_alias_test.go
@@ -56,6 +56,12 @@ func TestSearchViewsAlias(t *testing.T) {
 	skipBelowVersion(c, "3.10", t)
 	skipBelowVersion(c, "3.10", t)
 	db := ensureDatabase(ctx, c, "search_view_test_basic", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	nameAlias := "test_add_collection_view_alias"
 	nameCol := "col_in_alias_view"
@@ -132,8 +138,4 @@ func TestSearchViewsAlias(t *testing.T) {
 	views, err = db.Views(ctx)
 	require.NoError(t, err)
 	require.Len(t, views, 0)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }

--- a/test/view_test.go
+++ b/test/view_test.go
@@ -85,6 +85,12 @@ func TestCreateArangoSearchView(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	ensureCollection(ctx, db, "someCol", nil, t)
 	name := "test_create_asview"
 	opts := &driver.ArangoSearchViewProperties{
@@ -114,10 +120,6 @@ func TestCreateArangoSearchView(t *testing.T) {
 	if len(p.Links) != 1 {
 		t.Errorf("Expected 1 link, got %d", len(p.Links))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateArangoSearchViewInvalidLinks attempts to create an arangosearch view with invalid links and then checks that it does not exists.
@@ -126,6 +128,12 @@ func TestCreateArangoSearchViewInvalidLinks(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_inv_view"
 	opts := &driver.ArangoSearchViewProperties{
 		Links: driver.ArangoSearchLinks{
@@ -146,10 +154,6 @@ func TestCreateArangoSearchViewInvalidLinks(t *testing.T) {
 	if v, err := db.View(ctx, name); !driver.IsNotFound(err) {
 		t.Errorf("Expected NotFound error from View('%s'), got %s instead (%#v)", name, describe(err), v)
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateEmptyArangoSearchView creates an arangosearch view without any links.
@@ -158,6 +162,12 @@ func TestCreateEmptyArangoSearchView(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_empty_asview"
 	v, err := db.CreateArangoSearchView(ctx, name, nil)
 	if err != nil {
@@ -177,14 +187,6 @@ func TestCreateEmptyArangoSearchView(t *testing.T) {
 	if len(p.Links) != 0 {
 		t.Errorf("Expected 0 links, got %d", len(p.Links))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateDuplicateArangoSearchView creates an arangosearch view twice and then checks that it exists.
@@ -193,6 +195,12 @@ func TestCreateDuplicateArangoSearchView(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_dup_asview"
 	if _, err := db.CreateArangoSearchView(ctx, name, nil); err != nil {
 		t.Fatalf("Failed to create view '%s': %s", name, describe(err))
@@ -207,10 +215,6 @@ func TestCreateDuplicateArangoSearchView(t *testing.T) {
 	if _, err := db.CreateArangoSearchView(ctx, name, nil); !driver.IsConflict(err) {
 		t.Fatalf("Expect a Conflict error from CreateArangoSearchView, got %s", describe(err))
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestCreateArangoSearchViewThenRemoveCollection creates an arangosearch view
@@ -220,6 +224,12 @@ func TestCreateArangoSearchViewThenRemoveCollection(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "someViewTmpCol", nil, t)
 	name := "test_create_view_then_rem_col"
 	opts := &driver.ArangoSearchViewProperties{
@@ -264,10 +274,6 @@ func TestCreateArangoSearchViewThenRemoveCollection(t *testing.T) {
 		// TODO is the really the correct expected behavior.
 		t.Errorf("Expected 0 links, got %d", len(p.Links))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestAddCollectionMultipleViews creates a collection and two view. adds the collection to both views
@@ -277,6 +283,12 @@ func TestAddCollectionMultipleViews(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "col_in_multi_view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	ensureCollection(ctx, db, "col_in_multi_view", nil, t)
 	v1 := ensureArangoSearchView(ctx, db, "col_in_multi_view_view1", nil, t)
 	if !tryAddArangoSearchLink(ctx, db, v1, "col_in_multi_view", t) {
@@ -285,10 +297,6 @@ func TestAddCollectionMultipleViews(t *testing.T) {
 	v2 := ensureArangoSearchView(ctx, db, "col_in_multi_view_view2", nil, t)
 	if !tryAddArangoSearchLink(ctx, db, v2, "col_in_multi_view", t) {
 		t.Error("Link does not exists")
-	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -299,6 +307,12 @@ func TestAddCollectionMultipleViewsViaCreate(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "col_in_multi_view_create_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	ensureCollection(ctx, db, "col_in_multi_view_create", nil, t)
 	opts := &driver.ArangoSearchViewProperties{
 		Links: driver.ArangoSearchLinks{
@@ -313,10 +327,6 @@ func TestAddCollectionMultipleViewsViaCreate(t *testing.T) {
 	if !checkLinkExists(ctx, v2, "col_in_multi_view_create", t) {
 		t.Error("Link does not exists")
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestGetArangoSearchOptimizeTopK creates an ArangoSearch view with OptimizeTopK and checks if it is set.
@@ -326,6 +336,12 @@ func TestGetArangoSearchOptimizeTopK(t *testing.T) {
 	skipBelowVersion(c, "3.12.0", t)
 	skipNoEnterprise(t)
 	db := ensureDatabase(ctx, c, "view_test_optimize_top_k", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_get_asview"
 	optimizeTopK := []string{"BM25(@doc) DESC", "TFIDF(@doc) DESC"}
 	opts := &driver.ArangoSearchViewProperties{
@@ -353,10 +369,6 @@ func TestGetArangoSearchOptimizeTopK(t *testing.T) {
 		t.Fatalf("Properties failed: %s", describe(err))
 	}
 	assert.Equal(t, optimizeTopK, p.OptimizeTopK)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestGetArangoSearchView creates an ArangoSearch view and then gets it again.
@@ -365,6 +377,12 @@ func TestGetArangoSearchView(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "someCol", nil, t)
 	name := "test_get_asview"
 	opts := &driver.ArangoSearchViewProperties{
@@ -405,10 +423,6 @@ func TestGetArangoSearchView(t *testing.T) {
 		// 1 is always added by the system
 		t.Errorf("Expected 1 index, got %d", len(indexes))
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestGetArangoSearchViews creates several arangosearch views and then gets all of them.
@@ -417,6 +431,12 @@ func TestGetArangoSearchViews(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	// Get views before adding some
 	before, err := db.Views(ctx)
 	if err != nil {
@@ -452,10 +472,6 @@ func TestGetArangoSearchViews(t *testing.T) {
 			t.Errorf("Expected view '%s' is not found", n)
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestRenameAndRemoveArangoSearchView creates an arangosearch view, renames it and then removes it.
@@ -465,6 +481,12 @@ func TestRenameAndRemoveArangoSearchView(t *testing.T) {
 	skipBelowVersion(c, "3.4", t)
 
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_rename_view"
 	renamedView := "test_rename_view_new"
 	v, err := db.CreateArangoSearchView(ctx, name, nil)
@@ -505,11 +527,6 @@ func TestRenameAndRemoveArangoSearchView(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, found)
 	})
-
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUseArangoSearchView tries to create a view and actually use it in
@@ -520,6 +537,12 @@ func TestUseArangoSearchView(t *testing.T) {
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(nil, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "some_collection", nil, t)
 
 	ensureArangoSearchView(ctx, db, "some_view", &driver.ArangoSearchViewProperties{
@@ -593,10 +616,6 @@ func TestUseArangoSearchView(t *testing.T) {
 			t.Fatalf("Expected result `John`, found `%s`", doc.Name)
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUseArangoSearchViewWithNested tries to create a view with nested fields and actually use it in an AQL query.
@@ -607,6 +626,12 @@ func TestUseArangoSearchViewWithNested(t *testing.T) {
 	skipBelowVersion(c, "3.10", t)
 	skipNoEnterprise(t)
 	db := ensureDatabase(nil, c, "view_nested_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "some_collection", nil, t)
 
 	ensureArangoSearchView(ctx, db, "some_nested_view", &driver.ArangoSearchViewProperties{
@@ -665,10 +690,6 @@ func TestUseArangoSearchViewWithNested(t *testing.T) {
 			t.Fatalf("Wrong number of return values: expected 1, found %d", cur.Count())
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestUseArangoSearchViewWithPipelineAnalyzer tries to create a view and analyzer and then actually use it in an AQL query.
@@ -678,6 +699,12 @@ func TestUseArangoSearchViewWithPipelineAnalyzer(t *testing.T) {
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	skipBelowVersion(c, "3.8", t)
 	db := ensureDatabase(nil, c, "view_with_pipeline_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "some_collection_with_analyzer", nil, t)
 
 	analyzer := driver.ArangoSearchAnalyzerDefinition{
@@ -767,10 +794,6 @@ func TestUseArangoSearchViewWithPipelineAnalyzer(t *testing.T) {
 			t.Fatalf("Expected result `John`, found `%s`", doc.Name)
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestGetArangoSearchView creates an arangosearch view and then gets it again.
@@ -779,6 +802,12 @@ func TestArangoSearchViewProperties35(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.7.1", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	ensureCollection(ctx, db, "someCol", nil, t)
 	commitInterval := int64(100)
 	sortDir := driver.ArangoSearchSortDirectionDesc
@@ -839,10 +868,6 @@ func TestArangoSearchViewProperties35(t *testing.T) {
 			t.Errorf("StoredValues Compression is wrong: %s, expected %s", sv.Compression, storedValuesCompression)
 		}
 	}
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestArangoSearchPrimarySort
@@ -851,6 +876,12 @@ func TestArangoSearchPrimarySort(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.5", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	ensureCollection(ctx, db, "primary_col_sort", nil, t)
 
 	boolTrue := true
@@ -986,10 +1017,6 @@ func TestArangoSearchPrimarySort(t *testing.T) {
 			}
 		})
 	}
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 // TestArangoSearchViewProperties353 tests for custom analyzers.
@@ -999,6 +1026,12 @@ func TestArangoSearchViewProperties353(t *testing.T) {
 	skipBelowVersion(c, "3.5.3", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	colname := "someCol"
 	ensureCollection(ctx, db, colname, nil, t)
 	name := "test_get_asview_353"
@@ -1057,10 +1090,6 @@ func TestArangoSearchViewProperties353(t *testing.T) {
 	require.EqualValues(t, analyzer.Properties.Locale, "en_US")
 	require.EqualValues(t, analyzer.Properties.Case, driver.ArangoSearchCaseLower)
 	require.Equal(t, util.NewType(true), link.IncludeAllFields)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestArangoSearchViewLinkAndStoredValueCache(t *testing.T) {
@@ -1071,6 +1100,12 @@ func TestArangoSearchViewLinkAndStoredValueCache(t *testing.T) {
 	skipBetweenVersions(c, "3.10.0", "3.10.1", t)
 	skipNoEnterprise(t)
 	db := ensureDatabase(ctx, c, "view_test_links_stored_value_cache", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	linkedColName := "linkedColumn"
 	ensureCollection(ctx, db, linkedColName, nil, t)
 	name := "test_create_asview"
@@ -1109,10 +1144,6 @@ func TestArangoSearchViewLinkAndStoredValueCache(t *testing.T) {
 	linkedColumnProps = p.Links[linkedColName]
 	require.NotNil(t, linkedColumnProps)
 	require.Equal(t, util.NewType(true), linkedColumnProps.Cache)
-	err = db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }
 
 func TestArangoSearchViewInMemoryCache(t *testing.T) {
@@ -1121,6 +1152,12 @@ func TestArangoSearchViewInMemoryCache(t *testing.T) {
 
 	skipNoEnterprise(t)
 	db := ensureDatabase(ctx, c, "view_test_in_memory_cache", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	t.Run("primarySortCache", func(t *testing.T) {
 		// feature was introduced in 3.9.5 and in 3.10.2:
@@ -1159,8 +1196,4 @@ func TestArangoSearchViewInMemoryCache(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, util.NewType(true), p.PrimaryKeyCache)
 	})
-	err := db.Remove(ctx)
-	if err != nil {
-		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
-	}
 }

--- a/test/view_test.go
+++ b/test/view_test.go
@@ -114,6 +114,10 @@ func TestCreateArangoSearchView(t *testing.T) {
 	if len(p.Links) != 1 {
 		t.Errorf("Expected 1 link, got %d", len(p.Links))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateArangoSearchViewInvalidLinks attempts to create an arangosearch view with invalid links and then checks that it does not exists.
@@ -142,6 +146,10 @@ func TestCreateArangoSearchViewInvalidLinks(t *testing.T) {
 	if v, err := db.View(ctx, name); !driver.IsNotFound(err) {
 		t.Errorf("Expected NotFound error from View('%s'), got %s instead (%#v)", name, describe(err), v)
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateEmptyArangoSearchView creates an arangosearch view without any links.
@@ -169,6 +177,14 @@ func TestCreateEmptyArangoSearchView(t *testing.T) {
 	if len(p.Links) != 0 {
 		t.Errorf("Expected 0 links, got %d", len(p.Links))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestCreateDuplicateArangoSearchView creates an arangosearch view twice and then checks that it exists.
@@ -190,6 +206,10 @@ func TestCreateDuplicateArangoSearchView(t *testing.T) {
 	// Try to create again. Must fail
 	if _, err := db.CreateArangoSearchView(ctx, name, nil); !driver.IsConflict(err) {
 		t.Fatalf("Expect a Conflict error from CreateArangoSearchView, got %s", describe(err))
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -244,6 +264,10 @@ func TestCreateArangoSearchViewThenRemoveCollection(t *testing.T) {
 		// TODO is the really the correct expected behavior.
 		t.Errorf("Expected 0 links, got %d", len(p.Links))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestAddCollectionMultipleViews creates a collection and two view. adds the collection to both views
@@ -261,6 +285,10 @@ func TestAddCollectionMultipleViews(t *testing.T) {
 	v2 := ensureArangoSearchView(ctx, db, "col_in_multi_view_view2", nil, t)
 	if !tryAddArangoSearchLink(ctx, db, v2, "col_in_multi_view", t) {
 		t.Error("Link does not exists")
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -284,6 +312,10 @@ func TestAddCollectionMultipleViewsViaCreate(t *testing.T) {
 	v2 := ensureArangoSearchView(ctx, db, "col_in_multi_view_view2", opts, t)
 	if !checkLinkExists(ctx, v2, "col_in_multi_view_create", t) {
 		t.Error("Link does not exists")
+	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -321,6 +353,10 @@ func TestGetArangoSearchOptimizeTopK(t *testing.T) {
 		t.Fatalf("Properties failed: %s", describe(err))
 	}
 	assert.Equal(t, optimizeTopK, p.OptimizeTopK)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestGetArangoSearchView creates an ArangoSearch view and then gets it again.
@@ -369,6 +405,10 @@ func TestGetArangoSearchView(t *testing.T) {
 		// 1 is always added by the system
 		t.Errorf("Expected 1 index, got %d", len(indexes))
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestGetArangoSearchViews creates several arangosearch views and then gets all of them.
@@ -411,6 +451,10 @@ func TestGetArangoSearchViews(t *testing.T) {
 		if !found {
 			t.Errorf("Expected view '%s' is not found", n)
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -462,6 +506,10 @@ func TestRenameAndRemoveArangoSearchView(t *testing.T) {
 		require.False(t, found)
 	})
 
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUseArangoSearchView tries to create a view and actually use it in
@@ -545,6 +593,10 @@ func TestUseArangoSearchView(t *testing.T) {
 			t.Fatalf("Expected result `John`, found `%s`", doc.Name)
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestUseArangoSearchViewWithNested tries to create a view with nested fields and actually use it in an AQL query.
@@ -612,6 +664,10 @@ func TestUseArangoSearchViewWithNested(t *testing.T) {
 		} else if cur.Count() != 2 || !cur.HasMore() {
 			t.Fatalf("Wrong number of return values: expected 1, found %d", cur.Count())
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -711,6 +767,10 @@ func TestUseArangoSearchViewWithPipelineAnalyzer(t *testing.T) {
 			t.Fatalf("Expected result `John`, found `%s`", doc.Name)
 		}
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestGetArangoSearchView creates an arangosearch view and then gets it again.
@@ -778,6 +838,10 @@ func TestArangoSearchViewProperties35(t *testing.T) {
 		} else if sv.Compression != storedValuesCompression {
 			t.Errorf("StoredValues Compression is wrong: %s, expected %s", sv.Compression, storedValuesCompression)
 		}
+	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
 	}
 }
 
@@ -922,6 +986,10 @@ func TestArangoSearchPrimarySort(t *testing.T) {
 			}
 		})
 	}
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 // TestArangoSearchViewProperties353 tests for custom analyzers.
@@ -989,6 +1057,10 @@ func TestArangoSearchViewProperties353(t *testing.T) {
 	require.EqualValues(t, analyzer.Properties.Locale, "en_US")
 	require.EqualValues(t, analyzer.Properties.Case, driver.ArangoSearchCaseLower)
 	require.Equal(t, util.NewType(true), link.IncludeAllFields)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 func TestArangoSearchViewLinkAndStoredValueCache(t *testing.T) {
@@ -1037,6 +1109,10 @@ func TestArangoSearchViewLinkAndStoredValueCache(t *testing.T) {
 	linkedColumnProps = p.Links[linkedColName]
 	require.NotNil(t, linkedColumnProps)
 	require.Equal(t, util.NewType(true), linkedColumnProps.Cache)
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }
 
 func TestArangoSearchViewInMemoryCache(t *testing.T) {
@@ -1083,4 +1159,8 @@ func TestArangoSearchViewInMemoryCache(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, util.NewType(true), p.PrimaryKeyCache)
 	})
+	err := db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/v2/tests/admin_cluster_test.go
+++ b/v2/tests/admin_cluster_test.go
@@ -36,7 +36,7 @@ func Test_ClusterHealth(t *testing.T) {
 
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
-
+			requireClusterMode(t)
 			health, err := client.Health(ctx)
 			require.NoError(t, err, "Health failed")
 			require.NotNil(t, health, "Health did not return a health")
@@ -74,6 +74,7 @@ func Test_ClusterDatabaseInventory(t *testing.T) {
 	requireClusterMode(t)
 
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
+		requireClusterMode(t)
 		t.Run("DatabaseInventory simple checks", func(t *testing.T) {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
 

--- a/v2/tests/admin_license_test.go
+++ b/v2/tests/admin_license_test.go
@@ -33,10 +33,7 @@ import (
 func Test_License(t *testing.T) {
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {
-			skipBelowVersion(client, ctx, "3.10.0", t)
-
-			version, err := client.Version(ctx)
-			require.NoError(t, err)
+			version := skipVersionNotInRange(client, ctx, "3.10.0", "3.12.4", t)
 
 			license, err := client.GetLicense(ctx)
 			require.NoError(t, err)

--- a/v2/tests/asyncjob_test.go
+++ b/v2/tests/asyncjob_test.go
@@ -122,8 +122,8 @@ func TestAsyncJobListPending(t *testing.T) {
 						require.Len(t, jobs, 1)
 					})
 
-					t.Run("wait fot the async jobs to be done", func(t *testing.T) {
-						time.Sleep(4 * time.Second)
+					t.Run("wait for the async jobs to be done", func(t *testing.T) {
+						time.Sleep(12 * time.Second)
 
 						jobs, err := client.AsyncJobList(ctx, arangodb.JobPending, nil)
 						require.NoError(t, err)
@@ -179,7 +179,7 @@ func TestAsyncJobCancel(t *testing.T) {
 					})
 
 					t.Run("cancelled job should move from pending to done state", func(t *testing.T) {
-						time.Sleep(5 * time.Second)
+						time.Sleep(10 * time.Second)
 
 						jobs, err := client.AsyncJobList(ctx, arangodb.JobPending, nil)
 						require.NoError(t, err)

--- a/v2/tests/database_collection_indexes_test.go
+++ b/v2/tests/database_collection_indexes_test.go
@@ -219,6 +219,10 @@ func Test_TTLIndex(t *testing.T) {
 					t.Run("Removing documents at a fixed period after creation", func(t *testing.T) {
 						idx, created, err := col.EnsureTTLIndex(ctx, []string{"createdAt"}, 5, nil)
 						require.NoError(t, err)
+						defer func() {
+							err := col.DeleteIndexByID(ctx, idx.ID)
+							require.NoError(t, err)
+						}()
 						require.True(t, created)
 						require.Equal(t, *idx.RegularIndex.ExpireAfter, 5)
 						require.Equal(t, arangodb.TTLIndexType, idx.Type)
@@ -248,13 +252,15 @@ func Test_TTLIndex(t *testing.T) {
 							}
 						})
 
-						err = col.DeleteIndexByID(ctx, idx.ID)
-						require.NoError(t, err)
 					})
 
 					t.Run("Removing documents at certain points in time", func(t *testing.T) {
 						idx, created, err := col.EnsureTTLIndex(ctx, []string{"expireDate"}, 0, nil)
 						require.NoError(t, err)
+						defer func() {
+							err := col.DeleteIndexByID(ctx, idx.ID)
+							require.NoError(t, err)
+						}()
 						require.True(t, created)
 						require.Equal(t, *idx.RegularIndex.ExpireAfter, 0)
 						require.Equal(t, arangodb.TTLIndexType, idx.Type)
@@ -283,9 +289,6 @@ func Test_TTLIndex(t *testing.T) {
 								time.Sleep(1 * time.Second)
 							}
 						})
-
-						err = col.DeleteIndexByID(ctx, idx.ID)
-						require.NoError(t, err)
 					})
 				})
 			})

--- a/v2/tests/database_transactions_test.go
+++ b/v2/tests/database_transactions_test.go
@@ -285,7 +285,13 @@ func ensureTransactionStatus(t testing.TB, db arangodb.Database, tid arangodb.Tr
 	withContextT(t, 30*time.Second, func(ctx context.Context, t testing.TB) {
 		transaction, err := db.Transaction(ctx, tid)
 		require.NoError(t, err)
-		defer abortTransaction(t, transaction)
+		defer func() {
+			status, err := transaction.Status(ctx)
+			require.NoError(t, err)
+			if status.Status != arangodb.TransactionCommitted {
+				abortTransaction(t, transaction)
+			}
+		}()
 
 		s, err := transaction.Status(ctx)
 		require.NoError(t, err)

--- a/v2/tests/database_transactions_test.go
+++ b/v2/tests/database_transactions_test.go
@@ -225,7 +225,7 @@ func Test_DatabaseTransactions_DocumentLock(t *testing.T) {
 						LockTimeoutDuration: 1 * time.Second,
 					})
 					require.NoError(t, err)
-					defer abortTransaction(t, t1)
+					defer abortTransaction(t, t2)
 
 					col2, err := t2.GetCollection(ctx, col.Name(), nil)
 					require.NoError(t, err)
@@ -251,10 +251,13 @@ func Test_DatabaseTransactions_List(t *testing.T) {
 				t.Run("List all transactions", func(t *testing.T) {
 					t1, err := db.BeginTransaction(ctx, arangodb.TransactionCollections{}, nil)
 					require.NoError(t, err)
+					defer abortTransaction(t, t1)
 					t2, err := db.BeginTransaction(ctx, arangodb.TransactionCollections{}, nil)
 					require.NoError(t, err)
+					defer abortTransaction(t, t2)
 					t3, err := db.BeginTransaction(ctx, arangodb.TransactionCollections{}, nil)
 					require.NoError(t, err)
+					defer abortTransaction(t, t3)
 
 					transactions, err := db.ListTransactions(ctx)
 					require.NoError(t, err)
@@ -282,6 +285,7 @@ func ensureTransactionStatus(t testing.TB, db arangodb.Database, tid arangodb.Tr
 	withContextT(t, 30*time.Second, func(ctx context.Context, t testing.TB) {
 		transaction, err := db.Transaction(ctx, tid)
 		require.NoError(t, err)
+		defer abortTransaction(t, transaction)
 
 		s, err := transaction.Status(ctx)
 		require.NoError(t, err)

--- a/v2/tests/helper_test.go
+++ b/v2/tests/helper_test.go
@@ -65,8 +65,10 @@ func WithDatabase(t testing.TB, client arangodb.Client, opts *arangodb.CreateDat
 
 		defer func() {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, _ testing.TB) {
-				t.Logf("Removing DB %s, time: %s", db.Name(), time.Now())
-				require.NoError(t, db.Remove(ctx))
+				err := db.Remove(ctx)
+				if err != nil {
+					t.Logf("Removing DB %s failed, time: %s with %s", db.Name(), time.Now(), err)
+				}
 			})
 		}()
 

--- a/v2/tests/helper_test.go
+++ b/v2/tests/helper_test.go
@@ -65,7 +65,8 @@ func WithDatabase(t testing.TB, client arangodb.Client, opts *arangodb.CreateDat
 
 		defer func() {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, _ testing.TB) {
-				err := db.Remove(ctx)
+				timeoutCtx, _ := context.WithTimeout(ctx, time.Minute*2)
+				err := db.Remove(timeoutCtx)
 				if err != nil {
 					t.Logf("Removing DB %s failed, time: %s with %s", db.Name(), time.Now(), err)
 				}

--- a/v2/tests/helper_test.go
+++ b/v2/tests/helper_test.go
@@ -61,7 +61,7 @@ func WithDatabase(t testing.TB, client arangodb.Client, opts *arangodb.CreateDat
 
 	withContextT(t, defaultTestTimeout, func(ctx context.Context, _ testing.TB) {
 		db, err := client.CreateDatabase(ctx, name, opts)
-		require.NoError(t, err, fmt.Sprintf("Failed to create DB %s", name))
+		require.NoError(t, err, fmt.Sprintf("Failed to create DB %s: %s", name, err))
 
 		defer func() {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, _ testing.TB) {

--- a/v2/tests/run_wrap_test.go
+++ b/v2/tests/run_wrap_test.go
@@ -261,10 +261,10 @@ func waitForConnection(t testing.TB, client arangodb.Client) arangodb.Client {
 					return nil
 				}
 			}
-
+			current := time.Now()
 			resp, err := client.Get(ctx, nil, "_admin", "server", "availability")
 			if err != nil {
-				log.Warn().Err(err).Msgf("Unable to get cluster health")
+				log.Warn().Err(err).Msgf("Unable to get SUT health, deadline: %s", time.Since(current))
 				return nil
 			}
 

--- a/v2/tests/users_permissions_test.go
+++ b/v2/tests/users_permissions_test.go
@@ -65,6 +65,13 @@ func Test_UserPermission(t *testing.T) {
 				t.Run("Test custom user", func(t *testing.T) {
 					WithCollectionV2(t, db, nil, func(col arangodb.Collection) {
 						userCustom, err := client.CreateUser(ctx, "custom"+GenerateUUID("user-db"), nil)
+						defer func() {
+							err := client.RemoveUser(ctx, userCustom.Name())
+							if err != nil {
+								t.Logf("Failed to delete user %s: %s ...", userCustom.Name(), err)
+							}
+						}()
+
 						require.NoError(t, err)
 						require.NotNil(t, userCustom)
 

--- a/v2/tests/users_test.go
+++ b/v2/tests/users_test.go
@@ -48,6 +48,12 @@ func Test_Users(t *testing.T) {
 				require.GreaterOrEqual(t, len(users), 1)
 			})
 
+			defer func() {
+				err := client.RemoveUser(ctx, user1Name)
+				if err != nil {
+					t.Logf("Failed to delete user %s: %s ...", user1Name, err)
+				}
+			}()
 			t.Run("Test created user", func(t *testing.T) {
 				u, err := client.CreateUser(ctx, user1Name, nil)
 				require.NoError(t, err)
@@ -61,6 +67,12 @@ func Test_Users(t *testing.T) {
 				require.Equal(t, user1Name, ur.Name())
 			})
 
+			defer func() {
+				err := client.RemoveUser(ctx, user2Name)
+				if err != nil {
+					t.Logf("Failed to delete user %s: %s ...", user2Name, err)
+				}
+			}()
 			t.Run("Test created user with options", func(t *testing.T) {
 				opts := &arangodb.UserOptions{
 					Extra: doc,

--- a/v2/tests/util_test.go
+++ b/v2/tests/util_test.go
@@ -120,3 +120,20 @@ func skipBetweenVersions(c arangodb.Client, ctx context.Context, minVersion, max
 	}
 	return x
 }
+
+
+// skipVersionNotInRange skips the test if the current server version is less than
+// the min version or higher/equal max version
+func skipVersionNotInRange(c arangodb.Client, ctx context.Context, minVersion, maxVersion arangodb.Version, t testing.TB) arangodb.VersionInfo {
+	x, err := c.Version(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get version info: %s", err)
+	}
+	if x.Version.CompareTo(minVersion) < 0 {
+		t.Skipf("Skipping below version '%s', got version '%s'", minVersion, x.Version)
+	}
+	if x.Version.CompareTo(maxVersion) >= 0 {
+		t.Skipf("Skipping above version '%s', got version '%s'", maxVersion, x.Version)
+	}
+	return x
+}

--- a/v2/tests/util_test.go
+++ b/v2/tests/util_test.go
@@ -121,7 +121,6 @@ func skipBetweenVersions(c arangodb.Client, ctx context.Context, minVersion, max
 	return x
 }
 
-
 // skipVersionNotInRange skips the test if the current server version is less than
 // the min version or higher/equal max version
 func skipVersionNotInRange(c arangodb.Client, ctx context.Context, minVersion, maxVersion arangodb.Version, t testing.TB) arangodb.VersionInfo {

--- a/v2/tests/utils_retry_test.go
+++ b/v2/tests/utils_retry_test.go
@@ -31,7 +31,7 @@ import (
 
 // defaultTestTimeout is the default timeout for context use in tests
 // less than 2 minutes is causing problems on CI
-const defaultTestTimeout = 5 * time.Minute
+const defaultTestTimeout = 15 * time.Minute
 
 type Timeout func() error
 


### PR DESCRIPTION
- add deffer cleanup methods to drop databases created during the respective tests
- add deffer cleanup methods to delete users created during the respective tests
- increase the timeout to hot backup restore waiting
- limit the license test to the versions pre-disk-usage.