### PR TITLE
ensure tests clean up the resources they create in the test flow

### DIFF
--- a/test/arangosearch_analyzers_test.go
+++ b/test/arangosearch_analyzers_test.go
@@ -83,6 +83,12 @@ func TestArangoSearchAnalyzerEnsureAnalyzer(t *testing.T) {
 
 	dbname := "analyzer_test_ensure"
 	db := ensureDatabase(ctx, c, dbname, nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	testCases := []struct {
 		Name               string
@@ -444,6 +450,12 @@ func TestArangoSearchAnalyzerGet(t *testing.T) {
 
 	dbname := "analyzer_test_get"
 	db := ensureDatabase(ctx, c, dbname, nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	aname := "my-ngram"
 	def := driver.ArangoSearchAnalyzerDefinition{
 		Name: aname,
@@ -478,6 +490,12 @@ func TestArangoSearchAnalyzerGetAll(t *testing.T) {
 
 	dbname := "analyzer_test_get_all"
 	db := ensureDatabase(ctx, c, dbname, nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	aname := "my-ngram"
 	def := driver.ArangoSearchAnalyzerDefinition{
 		Name: aname,
@@ -518,6 +536,12 @@ func TestArangoSearchAnalyzerRemove(t *testing.T) {
 
 	dbname := "analyzer_test_get_all"
 	db := ensureDatabase(ctx, c, dbname, nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	aname := "my-ngram"
 	def := driver.ArangoSearchAnalyzerDefinition{
 		Name: aname,

--- a/test/asyncjob_test.go
+++ b/test/asyncjob_test.go
@@ -102,7 +102,12 @@ func TestAsyncJobListPending(t *testing.T) {
 	skipResilientSingle(t)
 
 	db := ensureDatabase(ctx, c, databaseName("db", "async"), nil, t)
-	defer db.Remove(ctx)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "frontend", nil, t)
 
 	idTransaction := runLongRequest(t, ctxAsync, db, 2, col.Name())
@@ -145,7 +150,12 @@ func TestAsyncJobCancel(t *testing.T) {
 	skipResilientSingle(t)
 
 	db := ensureDatabase(ctx, c, databaseName("db", "async", "cancel"), nil, t)
-	defer db.Remove(ctx)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	aqlQuery := "FOR i IN 1..10 FOR j IN 1..10 LET x = sleep(1.0) FILTER i == 5 && j == 5 RETURN 42"
 	_, err := db.Query(ctxAsync, aqlQuery, nil)
@@ -192,7 +202,12 @@ func TestAsyncJobDelete(t *testing.T) {
 	skipResilientSingle(t)
 
 	db := ensureDatabase(ctx, c, databaseName("db", "async", "cancel"), nil, t)
-	defer db.Remove(ctx)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "backend", nil, t)
 
 	t.Run("delete all jobs", func(t *testing.T) {

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -314,7 +314,7 @@ func waitForServerRestart(ctx context.Context, c driver.Client, t *testing.T) dr
 		}
 
 		return nil
-	}).RetryT(t, 100*time.Millisecond, 15*time.Second)
+	}).RetryT(t, 100*time.Millisecond, 30*time.Second)
 
 	// Wait for secret to start
 	newRetryFunc(func() error {
@@ -327,7 +327,7 @@ func waitForServerRestart(ctx context.Context, c driver.Client, t *testing.T) dr
 		}
 
 		return nil
-	}).RetryT(t, 100*time.Millisecond, 15*time.Second)
+	}).RetryT(t, 100*time.Millisecond, 30*time.Second)
 
 	return c
 }
@@ -354,6 +354,13 @@ func TestBackupRestore(t *testing.T) {
 	colname := "col"
 
 	db := ensureDatabase(ctx, c, dbname, nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", dbname, err)
+		}
+	}()
+
 	col := ensureCollection(ctx, db, colname, nil, t)
 
 	// Write a document
@@ -576,6 +583,12 @@ func TestBackupCompleteCycle(t *testing.T) {
 	colname := "col"
 
 	db := ensureDatabase(ctx, c, dbname, nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", dbname, err)
+		}
+	}()
 	col := ensureCollection(ctx, db, colname, nil, t)
 
 	isSingle := false
@@ -750,6 +763,12 @@ func TestBackupRestoreWithViews(t *testing.T) {
 	trueVar := true
 
 	db := ensureDatabase(ctx, c, dbname, nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", dbname, err)
+		}
+	}()
 	col := ensureCollection(ctx, db, colname, nil, t)
 	ensureArangoSearchView(ctx, db, viewname, &driver.ArangoSearchViewProperties{
 		Links: driver.ArangoSearchLinks{
@@ -795,7 +814,7 @@ func TestBackupRestoreWithViews(t *testing.T) {
 	defer waitForHealthyClusterAfterBackup(t, c)
 
 	if isSingle {
-		waitctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		waitctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 		defer cancel()
 		c = waitForServerRestart(waitctx, c, t)
 	}

--- a/test/benchmark_collection_test.go
+++ b/test/benchmark_collection_test.go
@@ -29,6 +29,12 @@ import (
 func BenchmarkCollectionExists(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, b)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "collection_exist_test", nil, b)
 
 	b.ResetTimer()
@@ -43,6 +49,12 @@ func BenchmarkCollectionExists(b *testing.B) {
 func BenchmarkCollection(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, b)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "collection_test", nil, b)
 
 	b.ResetTimer()
@@ -57,6 +69,12 @@ func BenchmarkCollection(b *testing.B) {
 func BenchmarkCollections(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, b)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	for i := 0; i < 10; i++ {
 		ensureCollection(nil, db, fmt.Sprintf("col%d", i), nil, b)
 	}

--- a/test/benchmark_document_test.go
+++ b/test/benchmark_document_test.go
@@ -26,6 +26,12 @@ import "testing"
 func BenchmarkCreateDocument(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, b)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, b)
 
 	b.ResetTimer()
@@ -44,6 +50,12 @@ func BenchmarkCreateDocument(b *testing.B) {
 func BenchmarkCreateDocumentParallel(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, b)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, b)
 
 	b.SetParallelism(100)
@@ -64,6 +76,12 @@ func BenchmarkCreateDocumentParallel(b *testing.B) {
 func BenchmarkReadDocument(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, b)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, b)
 	doc := UserDoc{
 		"Jan",
@@ -87,6 +105,12 @@ func BenchmarkReadDocument(b *testing.B) {
 func BenchmarkReadDocumentParallel(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, b)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, b)
 	doc := UserDoc{
 		"Jan",
@@ -112,6 +136,12 @@ func BenchmarkReadDocumentParallel(b *testing.B) {
 func BenchmarkRemoveDocument(b *testing.B) {
 	c := createClient(b, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, b)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			b.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, b)
 
 	b.ResetTimer()

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -496,6 +496,12 @@ func TestResponseHeader(t *testing.T) {
 	} else {
 		var resp driver.Response
 		db := ensureDatabase(ctx, c, "_system", nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 		col := ensureCollection(ctx, db, "response_header_test", nil, t)
 		defer clean(t, ctx, col)
 
@@ -579,6 +585,21 @@ func TestClientConnectionReuse(t *testing.T) {
 			Options: driver.CreateDatabaseDefaultOptions{},
 		}, t)
 	}
+	defer func() {
+		for dbName, user := range dbUsers {
+			t.Logf("Dropping DB %s ...", dbName)
+			db := ensureDatabase(ctx, c, dbName, nil, t)
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", dbName, err)
+			}
+			u := ensureUser(ctx, c, user.UserName, nil, t)
+			err = u.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to delete user %s: %s ...", user.UserName, err)
+			}
+		}
+	}()
 
 	var wg sync.WaitGroup
 	const clientsPerDB = 20

--- a/test/collection_schema_test.go
+++ b/test/collection_schema_test.go
@@ -51,6 +51,12 @@ func TestCollectionSchema(t *testing.T) {
 
 	name := "document_schema_validation_test"
 	db := ensureDatabase(nil, c, name, nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	t.Run("Create collection with schema validation", func(t *testing.T) {
 		opts := driver.CreateCollectionOptions{
 			Schema: &driver.CollectionSchemaOptions{

--- a/test/collection_test.go
+++ b/test/collection_test.go
@@ -63,6 +63,12 @@ func assertCollection(ctx context.Context, db driver.Database, name string, t *t
 func TestGetCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_get_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	name := "test_wrong_collection"
 
@@ -80,6 +86,12 @@ func TestGetCollection(t *testing.T) {
 func TestCreateCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_collection"
 	if _, err := db.CreateCollection(nil, name, nil); err != nil {
 		t.Fatalf("Failed to create collection '%s': %s", name, describe(err))
@@ -96,6 +108,12 @@ func TestCreateCollection(t *testing.T) {
 func TestCollection_CacheEnabled(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test_cache_enabled", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	t.Run("Default value", func(t *testing.T) {
 		name := "test_create_collection_cache_default"
@@ -179,6 +197,12 @@ func TestCollection_ComputedValues(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.10", t)
 	db := ensureDatabase(nil, c, "collection_test_computed_values", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	t.Run("Create with ComputedValues", func(t *testing.T) {
 		name := "test_users_computed_values"
@@ -322,6 +346,12 @@ func TestCreateSatelliteCollection(t *testing.T) {
 	c := createClient(t, nil)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_collection_satellite"
 	options := driver.CreateCollectionOptions{
 		ReplicationFactor: driver.ReplicationFactorSatellite,
@@ -356,6 +386,12 @@ func TestCreateSmartJoinCollection(t *testing.T) {
 	skipBelowVersion(c, "3.4.5", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	name := "test_create_collection_smart_join"
 	nameParent := "test_create_collection_smart_join_parent"
@@ -397,6 +433,12 @@ func TestCreateCollectionWithShardingStrategy(t *testing.T) {
 	skipBelowVersion(c, "3.4", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_collection_sharding_strategy"
 	options := driver.CreateCollectionOptions{
 		ShardingStrategy: driver.ShardingStrategyCommunityCompat,
@@ -445,6 +487,12 @@ func parseInt64FromInterface(value interface{}) (int64, error) {
 func TestRemoveCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_remove_collection"
 	col, err := db.CreateCollection(nil, name, nil)
 	if err != nil {
@@ -472,6 +520,12 @@ func TestRemoveCollection(t *testing.T) {
 func TestLoadUnloadCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	// we are not able to unload RocksDB
 	skipIfEngineTypeRocksDB(t, db)
 	name := "test_load_collection"
@@ -535,6 +589,12 @@ func TestLoadUnloadCollection(t *testing.T) {
 func TestCollectionName(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_collection_name"
 	col, err := db.CreateCollection(nil, name, nil)
 	if err != nil {
@@ -550,6 +610,12 @@ func TestCollectionTruncate(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_collection_truncate"
 	col, err := db.CreateCollection(nil, name, nil)
 	if err != nil {
@@ -588,6 +654,12 @@ func TestCollectionTruncate(t *testing.T) {
 func TestCollectionProperties(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_collection_properties"
 	col, err := db.CreateCollection(nil, name, nil)
 	if err != nil {
@@ -622,6 +694,12 @@ func TestCollectionProperties(t *testing.T) {
 func TestCollectionSetProperties(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_collection_set_properties"
 	col, err := db.CreateCollection(nil, name, nil)
 	if err != nil {
@@ -733,6 +811,12 @@ func TestCollectionSetPropertiesSatellite(t *testing.T) {
 	if _, err := c.Cluster(nil); err == nil {
 
 		db := ensureDatabase(nil, c, "collection_test_satellite", nil, t)
+		defer func() {
+			err := db.Remove(nil)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 		name := "test_collection_set_properties_sat"
 		col, err := db.CreateCollection(nil, name, &driver.CreateCollectionOptions{ReplicationFactor: driver.ReplicationFactorSatellite})
 		if err != nil {
@@ -764,6 +848,12 @@ func TestCollectionRevision(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
 	name := "test_collection_revision"
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col, err := db.CreateCollection(nil, name, nil)
 	if err != nil {
 		t.Fatalf("Failed to create collection '%s': %s", name, describe(err))
@@ -793,6 +883,12 @@ func TestCollectionRevision(t *testing.T) {
 func TestCollectionChecksum(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_checksum", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_collection_checksum"
 	col, err := db.CreateCollection(nil, name, nil)
 	require.NoError(t, err)
@@ -827,6 +923,12 @@ func TestCollectionChecksum(t *testing.T) {
 func TestCollectionStatistics(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_collection_statistics"
 	col, err := db.CreateCollection(nil, name, nil)
 	if err != nil {
@@ -862,6 +964,12 @@ func TestCollectionMinReplFactDeprecatedCreate(t *testing.T) {
 	version := skipBelowVersion(c, "3.5", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_min_repl_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_min_repl_create"
 	minRepl := 2
 	options := driver.CreateCollectionOptions{
@@ -905,6 +1013,12 @@ func TestCollectionMinReplFactDeprecatedInvalid(t *testing.T) {
 	skipBelowVersion(c, "3.5", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_min_repl_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_min_repl_create_invalid"
 	minRepl := 2
 	options := driver.CreateCollectionOptions{
@@ -928,6 +1042,12 @@ func TestCollectionMinReplFactDeprecatedClusterInv(t *testing.T) {
 	version := skipBelowVersion(c, "3.5", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_min_repl_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_min_repl_cluster_invent"
 	minRepl := 2
 	ensureCollection(nil, db, name, &driver.CreateCollectionOptions{
@@ -968,6 +1088,12 @@ func TestCollectionMinReplFactDeprecatedSetProp(t *testing.T) {
 	version := skipBelowVersion(c, "3.5", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_min_repl_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_min_repl_set_prop"
 	minRepl := 2
 	minReplChanged := 1
@@ -1004,6 +1130,12 @@ func TestCollectionMinReplFactDeprecatedSetPropInvalid(t *testing.T) {
 	version := skipBelowVersion(c, "3.5", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_min_repl_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_min_repl_set_prop_inv"
 	minRepl := 2
 	col := ensureCollection(nil, db, name, &driver.CreateCollectionOptions{
@@ -1038,6 +1170,12 @@ func TestCollectionWriteConcernCreate(t *testing.T) {
 	skipBelowVersion(c, "3.6", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_write_concern_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_write_concern_create"
 	minRepl := 2
 	options := driver.CreateCollectionOptions{
@@ -1076,6 +1214,12 @@ func TestCollectionWriteConcernInvalid(t *testing.T) {
 	skipNoCluster(c, t)
 
 	db := ensureDatabase(nil, c, "collection_write_concern_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_write_concern_invalid"
 	minRepl := 2
 	options := driver.CreateCollectionOptions{
@@ -1098,6 +1242,12 @@ func TestCollectionWriteConcernClusterInv(t *testing.T) {
 	skipBelowVersion(c, "3.6", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_write_concern_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_write_concern_cluster_invent"
 	minRepl := 2
 	ensureCollection(nil, db, name, &driver.CreateCollectionOptions{
@@ -1125,6 +1275,12 @@ func TestCollectionWriteConcernSetProp(t *testing.T) {
 	skipBelowVersion(c, "3.6", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_write_concern_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_write_concern_set_prop"
 	minRepl := 2
 	writeConcernChanged := 1
@@ -1150,6 +1306,12 @@ func TestCollectionWriteConcernSetPropInvalid(t *testing.T) {
 	skipBelowVersion(c, "3.6", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(nil, c, "collection_write_concern_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_write_concern_set_prop_inv"
 	minRepl := 2
 	defaultWriteConcern := 1
@@ -1181,6 +1343,12 @@ func Test_CollectionShards(t *testing.T) {
 	databaseName := getCallerFunctionName()
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, databaseName, nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_collection_set_properties"
 	col, err := db.CreateCollection(nil, name, &driver.CreateCollectionOptions{
 		ReplicationFactor: 2,

--- a/test/concurrency_test.go
+++ b/test/concurrency_test.go
@@ -56,6 +56,12 @@ func TestConcurrentCreateSmallDocuments(t *testing.T) {
 		t.Skip("Skipping VST load test on 3.2")
 	} else {
 		db := ensureDatabase(nil, c, "document_test", nil, t)
+		defer func() {
+			err := db.Remove(nil)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 		col := ensureCollection(nil, db, "TestConcurrentCreateSmallDocuments", nil, t)
 
 		docChan := make(chan driver.DocumentMeta, 128*1024)
@@ -147,6 +153,12 @@ func TestConcurrentCreateBigDocuments(t *testing.T) {
 		t.Skip("Skipping VST load test on 3.2")
 	} else {
 		db := ensureDatabase(nil, c, "document_test", nil, t)
+		defer func() {
+			err := db.Remove(nil)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 		col := ensureCollection(nil, db, "TestConcurrentCreateBigDocuments", nil, t)
 
 		docChan := make(chan driver.DocumentMeta, 16*1024)

--- a/test/cursor_test.go
+++ b/test/cursor_test.go
@@ -38,7 +38,14 @@ func TestCreateCursorWithMaxRuntime(t *testing.T) {
 	collectionName := "cursor_max_retry_test"
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.6", t)
-	db := ensureDatabase(context.Background(), c, "cursor_test", nil, t)
+	ctx := context.Background()
+	db := ensureDatabase(ctx, c, "cursor_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	ensureCollection(context.Background(), db, collectionName, nil, t)
 
 	tests := []struct {
@@ -87,7 +94,14 @@ func TestWithQueryOptimizerRules(t *testing.T) {
 	collectionName := "col_query_optimizer_rules"
 	fieldName := "value"
 	c := createClient(t, nil)
-	db := ensureDatabase(context.Background(), c, "query_optimizer_rules", nil, t)
+	ctx := context.Background()
+	db := ensureDatabase(ctx, c, "query_optimizer_rules", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(context.Background(), db, collectionName, nil, t)
 
 	tests := map[string]struct {
@@ -176,6 +190,12 @@ func TestCreateCursor(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "cursor_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	// Create data set
 	collectionData := map[string][]interface{}{
@@ -399,6 +419,12 @@ func TestCreateCursorReturnNull(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "cursor_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	var result interface{}
 	query := "return null"
@@ -433,6 +459,12 @@ func TestCreateStreamCursor(t *testing.T) {
 	}
 
 	db := ensureDatabase(ctx, c, "cursor_stream_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "cursor_stream_test", nil, t)
 
 	// Query engine info (on rocksdb, JournalSize is always 0)

--- a/test/database_collection_defaults_test.go
+++ b/test/database_collection_defaults_test.go
@@ -70,6 +70,12 @@ func TestDatabaseSharding(t *testing.T) {
 
 			db, err := c.CreateDatabase(nil, name, &opt)
 			require.NoError(t, err)
+			defer func() {
+				err := db.Remove(nil)
+				if err != nil {
+					t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+				}
+			}()
 
 			info, err := db.Info(nil)
 			require.NoError(t, err)
@@ -169,6 +175,12 @@ func TestDatabaseDefaults(t *testing.T) {
 
 			db, err := c.CreateDatabase(nil, name, &opt)
 			require.NoError(t, err)
+			defer func() {
+				err := db.Remove(nil)
+				if err != nil {
+					t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+				}
+			}()
 
 			col, err := db.CreateCollection(nil, "test", &scenario.col)
 			require.NoError(t, err)

--- a/test/database_transaction_test.go
+++ b/test/database_transaction_test.go
@@ -35,6 +35,12 @@ func TestDatabaseTransaction(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.2", t)
 	db := ensureDatabase(nil, c, "transaction_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	const colName = "books"
 	ensureCollection(context.Background(), db, colName, nil, t)
@@ -100,6 +106,12 @@ func TestTransactionCommit(t *testing.T) {
 	colname := "trx_test_col"
 	ctx := context.Background()
 	db := ensureDatabase(ctx, c, "trx_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, colname, nil, t)
 
 	trxid, err := db.BeginTransaction(ctx, driver.TransactionCollections{Exclusive: []string{colname}}, nil)
@@ -135,6 +147,12 @@ func TestTransactionAbort(t *testing.T) {
 	colname := "trx_test_col_abort"
 	ctx := context.Background()
 	db := ensureDatabase(ctx, c, "trx_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, colname, nil, t)
 
 	trxid, err := db.BeginTransaction(ctx, driver.TransactionCollections{Exclusive: []string{colname}}, nil)

--- a/test/document_create_test.go
+++ b/test/document_create_test.go
@@ -44,6 +44,12 @@ func TestCreateDocument(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Jan",
@@ -74,6 +80,12 @@ func TestCreateDocumentWithKey(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_withKey_test", nil, t)
 	doc := UserDocWithKey{
 		"jan",
@@ -109,6 +121,12 @@ func TestCreateDocumentReturnNew(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"JanNew",
@@ -149,6 +167,12 @@ func TestCreateDocumentSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Sjjjj",
@@ -165,6 +189,12 @@ func TestCreateDocumentSilent(t *testing.T) {
 func TestCreateDocumentNil(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	if _, err := col.CreateDocument(nil, nil); !driver.IsInvalidArgument(err) {
 		t.Fatalf("Expected InvalidArgumentError, got %s", describe(err))
@@ -177,6 +207,12 @@ func TestCreateDocumentInWaitForSyncCollection(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "TestCreateDocumentInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)

--- a/test/document_read_test.go
+++ b/test/document_read_test.go
@@ -69,4 +69,8 @@ func TestReadDocumentWithIfMatch(t *testing.T) {
 	if resp.StatusCode() != 412 {
 		t.Errorf("Expected status code 412, found %d", resp.StatusCode())
 	}
+	err = db.Remove(ctx)
+	if err != nil {
+		t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+	}
 }

--- a/test/document_remove_test.go
+++ b/test/document_remove_test.go
@@ -33,6 +33,12 @@ func TestRemoveDocument(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Piere",
@@ -64,6 +70,12 @@ func TestRemoveDocumentReturnOld(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Tim",
@@ -94,6 +106,12 @@ func TestRemoveDocumentSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Angela",
@@ -121,6 +139,12 @@ func TestRemoveDocumentRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"DryLake",
@@ -163,6 +187,12 @@ func TestRemoveDocumentRevision(t *testing.T) {
 func TestRemoveDocumentKeyEmpty(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	if _, err := col.RemoveDocument(nil, ""); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
@@ -176,6 +206,12 @@ func TestRemoveDocumentInWaitForSyncCollection(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "TestRemoveDocumentInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)

--- a/test/document_replace_test.go
+++ b/test/document_replace_test.go
@@ -34,6 +34,12 @@ func TestReplaceDocument(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Piere",
@@ -67,6 +73,12 @@ func TestReplaceDocumentReturnOld(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Tim",
@@ -97,6 +109,12 @@ func TestReplaceDocumentReturnNew(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Tim",
@@ -127,6 +145,12 @@ func TestReplaceDocumentSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Angela",
@@ -154,6 +178,12 @@ func TestReplaceDocumentRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Revision",
@@ -196,6 +226,12 @@ func TestReplaceDocumentRevision(t *testing.T) {
 func TestReplaceDocumentKeyEmpty(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	// Update document
 	replacement := map[string]interface{}{
@@ -210,6 +246,12 @@ func TestReplaceDocumentKeyEmpty(t *testing.T) {
 func TestReplaceDocumentUpdateNil(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	if _, err := col.ReplaceDocument(nil, "validKey", nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
@@ -223,6 +265,12 @@ func TestReplaceDocumentInWaitForSyncCollection(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "TestReplaceDocumentInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)

--- a/test/document_update_test.go
+++ b/test/document_update_test.go
@@ -34,6 +34,12 @@ func TestUpdateDocument1(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Piere",
@@ -67,6 +73,12 @@ func TestUpdateDocumentReturnOld(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Tim",
@@ -97,6 +109,12 @@ func TestUpdateDocumentReturnNew(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Tim",
@@ -129,6 +147,12 @@ func TestUpdateDocumentWithMergeObjectsTrue(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	type account struct {
 		ID   string                 `json:"id"`
@@ -174,6 +198,12 @@ func TestUpdateDocumentWithMergeObjectsFalse(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	type account struct {
 		ID   string                 `json:"id"`
@@ -221,6 +251,12 @@ func TestUpdateDocumentKeepNullTrue(t *testing.T) {
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	conn := c.Connection()
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := Account{
 		ID: "1234",
@@ -267,6 +303,12 @@ func TestUpdateDocumentKeepNullFalse(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := Account{
 		ID: "1234",
@@ -302,6 +344,12 @@ func TestUpdateDocumentSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Angela",
@@ -329,6 +377,12 @@ func TestUpdateDocumentRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "document_test", nil, t)
 	doc := UserDoc{
 		"Revision",
@@ -371,6 +425,12 @@ func TestUpdateDocumentRevision(t *testing.T) {
 func TestUpdateDocumentKeyEmpty(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	// Update document
 	update := map[string]interface{}{
@@ -385,6 +445,12 @@ func TestUpdateDocumentKeyEmpty(t *testing.T) {
 func TestUpdateDocumentUpdateNil(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 	if _, err := col.UpdateDocument(nil, "validKey", nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
@@ -398,6 +464,12 @@ func TestUpdateDocumentInWaitForSyncCollection(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "TestUpdateDocumentInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)

--- a/test/documents_create_overwrite_test.go
+++ b/test/documents_create_overwrite_test.go
@@ -48,6 +48,12 @@ func TestCreateOverwriteDocument(t *testing.T) {
 	defer cancel()
 
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_overwrite_test", nil, t)
 
 	t.Run("Single Doc - replace", func(t *testing.T) {
@@ -102,6 +108,12 @@ func TestCreateOverwriteModeDocument(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.7.0"))
 
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "document_test", nil, t)
 
 	t.Run("Single Doc - ignore", func(t *testing.T) {

--- a/test/documents_create_test.go
+++ b/test/documents_create_test.go
@@ -33,6 +33,12 @@ func TestCreateDocuments(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -92,6 +98,12 @@ func TestCreateDocumentsReturnNew(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -135,6 +147,12 @@ func TestCreateDocumentsSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -162,6 +180,12 @@ func TestCreateDocumentsSilent(t *testing.T) {
 func TestCreateDocumentsNil(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	if _, _, err := col.CreateDocuments(nil, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
@@ -172,6 +196,12 @@ func TestCreateDocumentsNil(t *testing.T) {
 func TestCreateDocumentsNonSlice(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	var obj UserDoc
 	if _, _, err := col.CreateDocuments(nil, &obj); !driver.IsInvalidArgument(err) {
@@ -188,6 +218,12 @@ func TestCreateDocumentsInWaitForSyncCollection(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "TestCreateDocumentsInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)

--- a/test/documents_import_test.go
+++ b/test/documents_import_test.go
@@ -30,6 +30,12 @@ import (
 func TestImportDocumentsWithKeys(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_withKeys_test", nil, t)
 	docs := []UserDocWithKey{
 		{
@@ -71,6 +77,12 @@ func TestImportDocumentsWithKeys(t *testing.T) {
 func TestImportDocumentsWithoutKeys(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_withoutKeys_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -113,6 +125,12 @@ func TestImportDocumentsEmptyEntries(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_emptyEntries_test", nil, t)
 	docs := []*UserDocWithKey{
 		{
@@ -158,6 +176,12 @@ func TestImportDocumentsInvalidEntries(t *testing.T) {
 	}
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_invalidEntries_test", nil, t)
 	docs := []interface{}{
 		&UserDocWithKey{
@@ -202,6 +226,12 @@ func TestImportDocumentsInvalidEntries(t *testing.T) {
 func TestImportDocumentsDuplicateEntries(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_duplicateEntries_test", nil, t)
 	docs := []interface{}{
 		&UserDocWithKey{
@@ -244,6 +274,12 @@ func TestImportDocumentsDuplicateEntries(t *testing.T) {
 func TestImportDocumentsDuplicateEntriesComplete(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_duplicateEntriesComplete_test", nil, t)
 	docs := []interface{}{
 		&UserDocWithKey{
@@ -272,6 +308,12 @@ func TestImportDocumentsDuplicateEntriesUpdate(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_duplicateEntriesUpdate_test", nil, t)
 	docs := []interface{}{
 		&UserDocWithKey{
@@ -328,6 +370,12 @@ func TestImportDocumentsDuplicateEntriesReplace(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_duplicateEntriesReplace_test", nil, t)
 	docs := []interface{}{
 		&UserDocWithKey{
@@ -384,6 +432,12 @@ func TestImportDocumentsDuplicateEntriesIgnore(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_duplicateEntriesIgnore_test", nil, t)
 	docs := []interface{}{
 		&UserDocWithKey{
@@ -440,6 +494,12 @@ func TestImportDocumentsDetails(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_details_test", nil, t)
 	docs := []interface{}{
 		&UserDocWithKey{
@@ -490,6 +550,12 @@ func TestImportDocumentsOverwriteYes(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_overwriteYes_test", nil, t)
 	docs := []interface{}{
 		&UserDoc{
@@ -530,6 +596,12 @@ func TestImportDocumentsOverwriteNo(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "import_overwriteNo_test", nil, t)
 	docs := []interface{}{
 		&UserDoc{
@@ -570,6 +642,12 @@ func TestImportDocumentsOverwriteNo(t *testing.T) {
 func TestImportDocumentsWithKeysInWaitForSyncCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "TestImportDocumentsWithKeysInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)

--- a/test/documents_remove_test.go
+++ b/test/documents_remove_test.go
@@ -33,6 +33,12 @@ func TestRemoveDocuments(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -63,6 +69,12 @@ func TestRemoveDocumentsReturnOld(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -111,6 +123,12 @@ func TestRemoveDocumentsSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -153,6 +171,12 @@ func TestRemoveDocumentsRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -220,6 +244,12 @@ func TestRemoveDocumentsRevision(t *testing.T) {
 func TestRemoveDocumentsKeyEmpty(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	if _, _, err := col.RemoveDocuments(nil, []string{""}); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
@@ -232,6 +262,12 @@ func TestRemoveDocumentsInWaitForSyncCollection(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "TestRemoveDocumentsInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)

--- a/test/documents_replace_test.go
+++ b/test/documents_replace_test.go
@@ -35,6 +35,12 @@ func TestReplaceDocuments(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -83,6 +89,12 @@ func TestReplaceDocumentsReturnOld(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -127,6 +139,12 @@ func TestReplaceDocumentsReturnNew(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -172,6 +190,12 @@ func TestReplaceDocumentsSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -224,6 +248,12 @@ func TestReplaceDocumentsRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -291,6 +321,12 @@ func TestReplaceDocumentsRevision(t *testing.T) {
 func TestReplaceDocumentsKeyEmpty(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	// Replacement document
 	replacement := map[string]interface{}{
@@ -315,6 +351,12 @@ func TestReplaceDocumentsUpdateNil(t *testing.T) {
 func TestReplaceDocumentsUpdateLenDiff(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	replacements := []map[string]interface{}{
 		{
@@ -336,6 +378,12 @@ func TestReplaceDocumentsInWaitForSyncCollection(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "TestReplaceDocumentsInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)

--- a/test/documents_update_test.go
+++ b/test/documents_update_test.go
@@ -38,6 +38,12 @@ func TestUpdateDocuments1(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -86,6 +92,12 @@ func TestUpdateDocumentsReturnOld(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -147,6 +159,12 @@ func TestUpdateDocumentsReturnNew(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -202,6 +220,12 @@ func TestUpdateDocumentsKeepNullTrue(t *testing.T) {
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	conn := c.Connection()
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []Account{
 		{
@@ -268,6 +292,12 @@ func TestUpdateDocumentsKeepNullFalse(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []Account{
 		{
@@ -322,6 +352,12 @@ func TestUpdateDocumentsSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -362,6 +398,12 @@ func TestUpdateDocumentsRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "documents_test", nil, t)
 	docs := []UserDoc{
 		{
@@ -426,6 +468,12 @@ func TestUpdateDocumentsRevision(t *testing.T) {
 func TestUpdateDocumentsKeyEmpty(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	// Update document
 	updates := []map[string]interface{}{
@@ -442,6 +490,12 @@ func TestUpdateDocumentsKeyEmpty(t *testing.T) {
 func TestUpdateDocumentsUpdateNil(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	if _, _, err := col.UpdateDocuments(nil, []string{"validKey"}, nil); !driver.IsInvalidArgument(err) {
 		t.Errorf("Expected InvalidArgumentError, got %s", describe(err))
@@ -452,6 +506,12 @@ func TestUpdateDocumentsUpdateNil(t *testing.T) {
 func TestUpdateDocumentsUpdateLenDiff(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "documents_test", nil, t)
 	updates := []map[string]interface{}{
 		{
@@ -473,6 +533,12 @@ func TestUpdateDocumentsInWaitForSyncCollection(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "document_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "TestUpdateDocumentsInWaitForSyncCollection", &driver.CreateCollectionOptions{
 		WaitForSync: true,
 	}, t)

--- a/test/edge_collection_test.go
+++ b/test/edge_collection_test.go
@@ -47,6 +47,12 @@ func ensureEdgeCollection(ctx context.Context, g driver.Graph, collection string
 func TestCreateEdgeCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "edge_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_edge_collection"
 	g, err := db.CreateGraphV2(nil, name, nil)
 	if err != nil {
@@ -115,6 +121,12 @@ func TestCreateSatelliteEdgeCollection(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.9.0")).Cluster().Enterprise()
 
 	db := ensureDatabase(nil, c, "edge_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	name := "test_create_sat_edge_collection"
 	options := driver.CreateGraphOptions{
@@ -125,6 +137,8 @@ func TestCreateSatelliteEdgeCollection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create graph '%s': %s", name, describe(err))
 	}
+	// revert
+	defer g.Remove(ctx)
 
 	// List edge collections, must be empty
 	if list, _, err := g.EdgeCollections(nil); err != nil {
@@ -177,14 +191,18 @@ func TestCreateSatelliteEdgeCollection(t *testing.T) {
 		}
 	}
 
-	// revert
-	g.Remove(ctx)
 }
 
 // TestRemoveEdgeCollection creates a graph and then adds an edge collection in it and then removes the edge collection.
 func TestRemoveEdgeCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "edge_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_remove_edge_collection"
 	g, err := db.CreateGraphV2(nil, name, nil)
 	if err != nil {
@@ -227,6 +245,12 @@ func TestRemoveEdgeCollection(t *testing.T) {
 func TestSetVertexConstraints(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "edge_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "set_vertex_constraints"
 	g, err := db.CreateGraphV2(nil, name, nil)
 	if err != nil {
@@ -287,6 +311,12 @@ func TestRenameEdgeCollection(t *testing.T) {
 	skipNoSingle(c, t)
 
 	db := ensureDatabase(nil, c, "edge_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_rename_edge_collection"
 	g, err := db.CreateGraphV2(nil, name, nil)
 	if err != nil {

--- a/test/edge_create_test.go
+++ b/test/edge_create_test.go
@@ -33,6 +33,12 @@ func TestCreateEdge(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edge_test_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -70,6 +76,12 @@ func TestCreateCustomEdge(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_custom_edge_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -102,6 +114,12 @@ func TestCreateEdgeReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edge_return_new_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -139,6 +157,12 @@ func TestCreateEdgeSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edge_silent_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -164,6 +188,12 @@ func TestCreateEdgeNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edge_nil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)

--- a/test/edge_remove_test.go
+++ b/test/edge_remove_test.go
@@ -34,6 +34,12 @@ func TestRemoveEdge(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edge_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -67,6 +73,12 @@ func TestRemoveEdgeReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edge_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -98,6 +110,12 @@ func TestRemoveEdgeSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edge_silent_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -133,6 +151,12 @@ func TestRemoveEdgeRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edge_revision_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -193,6 +217,12 @@ func TestRemoveEdgeKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edge_nil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)

--- a/test/edge_replace_test.go
+++ b/test/edge_replace_test.go
@@ -33,6 +33,12 @@ func TestReplaceEdge(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edge_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -75,6 +81,12 @@ func TestReplaceEdgeReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edge_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -115,6 +127,12 @@ func TestReplaceEdgeReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edge_returnNew_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -155,6 +173,12 @@ func TestReplaceEdgeSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edge_returnNew_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -192,6 +216,12 @@ func TestReplaceEdgeRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edge_revision_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -245,6 +275,12 @@ func TestReplaceEdgeKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edge_keyEmpty_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -263,6 +299,12 @@ func TestReplaceEdgeUpdateNil(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edge_updateNil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)

--- a/test/edge_update_test.go
+++ b/test/edge_update_test.go
@@ -33,6 +33,12 @@ func TestUpdateEdge(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -74,6 +80,12 @@ func TestUpdateEdgeReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -112,6 +124,12 @@ func TestUpdateEdgeReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_returnNew_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -152,6 +170,12 @@ func TestUpdateEdgeKeepNullTrue(t *testing.T) {
 	c := createClient(t, nil)
 	conn := c.Connection()
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_keepNullTrue_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -214,6 +238,12 @@ func TestUpdateEdgeKeepNullFalse(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_keepNullFalse_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -257,6 +287,12 @@ func TestUpdateEdgeSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_silent_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -292,6 +328,12 @@ func TestUpdateEdgeRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_revision_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -343,6 +385,12 @@ func TestUpdateEdgeKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_keyEmpty_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -361,6 +409,12 @@ func TestUpdateEdgeUpdateNil(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edge_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edge_updateNil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)

--- a/test/edges_create_test.go
+++ b/test/edges_create_test.go
@@ -33,6 +33,12 @@ func TestCreateEdges(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edges_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -103,6 +109,12 @@ func TestCreateEdgesReturnNew(t *testing.T) {
 	// TODO refactor ME
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edges_returnNew_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -160,6 +172,12 @@ func TestCreateEdgesSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edges_silent_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -202,6 +220,12 @@ func TestCreateEdgesNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edges_nil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -215,6 +239,12 @@ func TestCreateEdgesNonSlice(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "create_edges_nonSlice_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)

--- a/test/edges_import_test.go
+++ b/test/edges_import_test.go
@@ -33,6 +33,12 @@ func TestImportEdgesWithKeys(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -85,6 +91,12 @@ func TestImportEdgesWithoutKeys(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_withhoutKeys_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -140,6 +152,12 @@ func TestImportEdgesEmptyEntries(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_emptyEntries_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -196,6 +214,12 @@ func TestImportEdgesInvalidEntries(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_invalidEntries_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -251,6 +275,12 @@ func TestImportEdgesDuplicateEntries(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_duplicateEntries_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -306,6 +336,12 @@ func TestImportEdgesDuplicateEntriesComplete(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_duplicateEntriesComplete_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -344,6 +380,12 @@ func TestImportEdgesDuplicateEntriesUpdate(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_duplicateEntriesUpdate_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -409,6 +451,12 @@ func TestImportEdgesDuplicateEntriesReplace(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_duplicateEntriesReplace_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -474,6 +522,12 @@ func TestImportEdgesDuplicateEntriesIgnore(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_duplicateEntriesIgnore_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -539,6 +593,12 @@ func TestImportEdgesDetails(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_details_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -599,6 +659,12 @@ func TestImportEdgesOverwriteYes(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_overwriteYes_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -649,6 +715,12 @@ func TestImportEdgesOverwriteNo(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_overwriteNo_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -699,6 +771,12 @@ func TestImportEdgesPrefix(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "import_edges_prefix_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	col := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)

--- a/test/edges_remove_test.go
+++ b/test/edges_remove_test.go
@@ -34,6 +34,12 @@ func TestRemoveEdges(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edges_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -82,6 +88,12 @@ func TestRemoveEdgesReturnOld(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	prefix := "remove_edges_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
@@ -131,6 +143,12 @@ func TestRemoveEdgesSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edges_silent_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -182,6 +200,12 @@ func TestRemoveEdgesRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edges_revision_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)
@@ -263,6 +287,12 @@ func TestRemoveEdgesKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "remove_edges_keyEmpty_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"citiesPerState", []string{prefix + "city"}, []string{prefix + "state"}, t)

--- a/test/edges_replace_test.go
+++ b/test/edges_replace_test.go
@@ -34,6 +34,12 @@ func TestReplaceEdges(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -92,6 +98,12 @@ func TestReplaceEdgesReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -148,6 +160,12 @@ func TestReplaceEdgesReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_returnNew_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -204,6 +222,12 @@ func TestReplaceEdgesSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_silent_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -260,6 +284,12 @@ func TestReplaceEdgesRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_revision_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -341,6 +371,12 @@ func TestReplaceEdgesKeyEmpty(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_updateNil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -358,6 +394,12 @@ func TestReplaceEdgesUpdateNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_updateNil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -372,6 +414,12 @@ func TestReplaceEdgesUpdateLenDiff(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "replace_edges_updateNil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)

--- a/test/edges_update_test.go
+++ b/test/edges_update_test.go
@@ -35,6 +35,12 @@ func TestUpdateEdges(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -93,6 +99,12 @@ func TestUpdateEdgesReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -147,6 +159,12 @@ func TestUpdateEdgesReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2363
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_returnOld_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -203,6 +221,12 @@ func TestUpdateEdgesKeepNullTrue(t *testing.T) {
 	c := createClient(t, nil)
 	conn := c.Connection()
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_keepNullTrue_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -287,6 +311,12 @@ func TestUpdateEdgesKeepNullFalse(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_keepNullFalse_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -351,6 +381,12 @@ func TestUpdateEdgesSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_silent_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -400,6 +436,12 @@ func TestUpdateEdgesRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_revision_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -474,6 +516,12 @@ func TestUpdateEdgesKeyEmpty(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_keyEmpty_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -494,6 +542,12 @@ func TestUpdateEdgesUpdateNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_updateNil_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)
@@ -508,6 +562,12 @@ func TestUpdateEdgesUpdateLenDiff(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "edges_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	prefix := "update_edges_updateLenDiff_"
 	g := ensureGraph(ctx, db, prefix+"graph", nil, t)
 	ec := ensureEdgeCollection(ctx, g, prefix+"relation", []string{prefix + "male", prefix + "female"}, []string{prefix + "male", prefix + "female"}, t)

--- a/test/graph_creation_test.go
+++ b/test/graph_creation_test.go
@@ -105,6 +105,12 @@ func Test_Graph_AdvancedCreate(t *testing.T) {
 	skipNoCluster(c, t)
 
 	db := ensureDatabase(ctx, c, databaseName("graph", "create", "replication"), nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	// Create
 	graphID := db.Name() + "_graph"
@@ -149,7 +155,13 @@ func Test_Graph_AdvancedCreate_Defaults(t *testing.T) {
 
 	skipNoCluster(c, t)
 
-	db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+	db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults1"), nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	// Create
 	graphID := db.Name() + "_graph"
@@ -187,6 +199,12 @@ func TestGraphCreation(t *testing.T) {
 
 	t.Run("Satellite", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -208,6 +226,12 @@ func TestGraphCreation(t *testing.T) {
 
 	t.Run("Satellite - list", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -234,6 +258,12 @@ func TestGraphCreation(t *testing.T) {
 
 	t.Run("Standard", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -251,6 +281,12 @@ func TestGraphCreation(t *testing.T) {
 
 	t.Run("Standard - list", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -273,6 +309,12 @@ func TestGraphCreation(t *testing.T) {
 
 	t.Run("Disjoint", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -292,6 +334,12 @@ func TestGraphCreation(t *testing.T) {
 
 	t.Run("Disjoint - list", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -322,6 +370,12 @@ func TestHybridSmartGraphCreation(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.9.0")).Cluster().Enterprise()
 
 	db := ensureDatabase(ctx, c, databaseName("graph", "create", "hybrid"), nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	name := db.Name() + "_test_create_hybrid_graph"
 	colName := db.Name() + "_create_hybrid_edge_col"

--- a/test/graph_creation_v2_test.go
+++ b/test/graph_creation_v2_test.go
@@ -41,6 +41,12 @@ func Test_Graph_AdvancedCreateV2(t *testing.T) {
 	skipNoCluster(c, t)
 
 	db := ensureDatabase(ctx, c, databaseName("graph", "create", "replication"), nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	// Create
 	graphID := db.Name() + "_graph"
@@ -85,6 +91,12 @@ func Test_Graph_AdvancedCreateV2_Defaults(t *testing.T) {
 	skipNoCluster(c, t)
 
 	db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	// Create
 	graphID := db.Name() + "_graph"
@@ -122,6 +134,12 @@ func TestGraphCreationV2(t *testing.T) {
 
 	t.Run("Satellite", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -144,6 +162,12 @@ func TestGraphCreationV2(t *testing.T) {
 
 	t.Run("Satellite - list", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -171,6 +195,12 @@ func TestGraphCreationV2(t *testing.T) {
 
 	t.Run("Standard", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -188,6 +218,12 @@ func TestGraphCreationV2(t *testing.T) {
 
 	t.Run("Standard - list", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -210,6 +246,12 @@ func TestGraphCreationV2(t *testing.T) {
 
 	t.Run("Disjoint", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -229,6 +271,12 @@ func TestGraphCreationV2(t *testing.T) {
 
 	t.Run("Disjoint - list", func(t *testing.T) {
 		db := ensureDatabase(ctx, c, databaseName("graph", "create", "defaults"), nil, t)
+		defer func() {
+			err := db.Remove(ctx)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		// Create
 		graphID := db.Name() + "_graph"
@@ -259,6 +307,12 @@ func TestHybridSmartGraphCreationV2(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.9.0")).Cluster().Enterprise()
 
 	db := ensureDatabase(ctx, c, databaseName("graph", "create", "hybrid"), nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	name := db.Name() + "_test_create_hybrid_graph"
 	colName := db.Name() + "_create_hybrid_edge_col"
@@ -312,6 +366,12 @@ func TestHybridSmartGraphCreationConditions(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.10.0")).Cluster().Enterprise()
 
 	db := ensureDatabase(ctx, c, databaseName("graph", "create", "hybrid", "options"), nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	t.Run("General Graph - isSmart is False and no smartGraphAttribute", func(t *testing.T) {
 		graphID := db.Name() + "_graph_smart_no_conditions"

--- a/test/graph_test.go
+++ b/test/graph_test.go
@@ -49,6 +49,12 @@ func TestCreateGraph(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "graph_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_graph"
 
 	if _, err := db.CreateGraphV2(ctx, name, nil); err != nil {
@@ -91,6 +97,12 @@ func TestCreateGraphWithOptions(t *testing.T) {
 	skipNoCluster(c, t)
 
 	db := ensureDatabase(ctx, c, "graph_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_graph_2"
 
 	options := &driver.CreateGraphOptions{
@@ -169,6 +181,12 @@ func TestRemoveGraph(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "graph_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_remove_graph"
 	g, err := db.CreateGraphV2(ctx, name, nil)
 	if err != nil {
@@ -197,6 +215,12 @@ func TestRemoveGraphWithOpts(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "graph_test_remove", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_remove_graph_opts"
 	colName := "remove_graph_col"
 

--- a/test/index_ensure_test.go
+++ b/test/index_ensure_test.go
@@ -36,6 +36,12 @@ import (
 func TestEnsureFullTextIndex(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	testOptions := []*driver.EnsureFullTextIndexOptions{
 		nil,
@@ -94,6 +100,12 @@ func TestEnsureFullTextIndex(t *testing.T) {
 func TestEnsureGeoIndex(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	testOptions := []*driver.EnsureGeoIndexOptions{
 		nil,
@@ -155,6 +167,12 @@ func TestEnsureGeoIndexLegacyPolygons(t *testing.T) {
 	skipBelowVersion(c, "3.10", t)
 
 	db := ensureDatabase(ctx, c, "index_geo_LegacyPolygons_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, fmt.Sprintf("persistent_index_options_test_"), nil, t)
 
 	options := &driver.EnsureGeoIndexOptions{
@@ -181,6 +199,12 @@ func TestEnsureGeoIndexLegacyPolygons(t *testing.T) {
 func TestEnsureHashIndex(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	testOptions := []*driver.EnsureHashIndexOptions{
 		nil,
@@ -244,6 +268,12 @@ func TestEnsureHashIndex(t *testing.T) {
 func TestEnsurePersistentIndex(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	testOptions := []*driver.EnsurePersistentIndexOptions{
 		nil,
@@ -310,6 +340,12 @@ func TestEnsurePersistentIndexOptions(t *testing.T) {
 	skipBelowVersion(c, "3.10", t)
 
 	db := ensureDatabase(ctx, c, "index_persistent_options_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, fmt.Sprintf("persistent_index_options_test_"), nil, t)
 
 	options := &driver.EnsurePersistentIndexOptions{
@@ -336,6 +372,12 @@ func TestEnsurePersistentIndexOptions(t *testing.T) {
 func TestEnsureSkipListIndex(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	testOptions := []*driver.EnsureSkipListIndexOptions{
 		nil,
@@ -402,6 +444,12 @@ func TestEnsureSkipListIndex(t *testing.T) {
 func TestEnsureTTLIndex(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	skipBelowVersion(c, "3.5", t)
 
 	col := ensureCollection(nil, db, "ttl_index_test", nil, t)
@@ -471,6 +519,12 @@ func TestEnsureZKDIndex(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.9.0"))
 
 	db := ensureDatabase(ctx, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, fmt.Sprintf("zkd_index_test"), nil, t)
 
 	f1 := "field-zkd-index_1"
@@ -495,6 +549,12 @@ func TestEnsureZKDIndexWithOptions(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.9.0"))
 
 	db := ensureDatabase(ctx, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, fmt.Sprintf("zkd_index_opt_test"), nil, t)
 
 	f1 := "field-zkd-index1-opt"
@@ -524,6 +584,12 @@ func TestEnsureInvertedIndex(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.10.0"))
 
 	db := ensureDatabase(ctx, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, fmt.Sprintf("inverted_index_opt_test"), nil, t)
 
 	type testCase struct {

--- a/test/indexes_test.go
+++ b/test/indexes_test.go
@@ -35,6 +35,12 @@ import (
 func TestDefaultIndexes(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "def_indexes_test", nil, t)
 
 	// Get list of indexes
@@ -52,6 +58,12 @@ func TestDefaultIndexes(t *testing.T) {
 func TestDefaultEdgeIndexes(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "def_indexes_edge_test", &driver.CreateCollectionOptions{Type: driver.CollectionTypeEdge}, t)
 
 	// Get list of indexes
@@ -82,6 +94,12 @@ func TestDefaultEdgeIndexes(t *testing.T) {
 func TestIndexes(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "indexes_test", nil, t)
 
 	// Create some indexes
@@ -133,6 +151,12 @@ func TestIndexes(t *testing.T) {
 func TestMultipleIndexes(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "multiple_indexes_test", nil, t)
 
 	// Create some indexes of same type & fields, but different options
@@ -183,6 +207,12 @@ func TestIndexesDeduplicateHash(t *testing.T) {
 		t.Skip("Test requires 3.2")
 	} else {
 		db := ensureDatabase(nil, c, "index_test", nil, t)
+		defer func() {
+			err := db.Remove(nil)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		{
 			// Create some indexes with de-duplication off
@@ -240,6 +270,12 @@ func TestIndexesDeduplicateSkipList(t *testing.T) {
 		t.Skip("Test requires 3.2")
 	} else {
 		db := ensureDatabase(nil, c, "index_test", nil, t)
+		defer func() {
+			err := db.Remove(nil)
+			if err != nil {
+				t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+			}
+		}()
 
 		{
 			// Create some indexes with de-duplication off
@@ -291,6 +327,12 @@ func TestIndexesTTL(t *testing.T) {
 	skipBelowVersion(c, "3.5", t)
 
 	db := ensureDatabase(nil, c, "index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	// Create some indexes with de-duplication off
 	col := ensureCollection(nil, db, "indexes_ttl_test", nil, t)
@@ -438,6 +480,12 @@ func TestNamedIndexes(t *testing.T) {
 	skipBelowVersion(c, "3.5", t)
 
 	db := ensureDatabase(nil, c, "named_index_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "named_index_test_col", nil, t)
 
 	for _, testCase := range namedIndexTestCases {
@@ -496,6 +544,12 @@ func TestNamedIndexesClusterInventory(t *testing.T) {
 	skipNoCluster(c, t)
 	colname := "named_index_test_col_inv"
 	db := ensureDatabase(nil, c, "named_index_test_inv", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, colname, nil, t)
 
 	cc, err := c.Cluster(nil)
@@ -549,6 +603,12 @@ func TestTTLIndexesClusterInventory(t *testing.T) {
 	ttl := 3600
 	colname := "ttl_index_test_col_inv"
 	db := ensureDatabase(nil, c, "index_test_inv", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, colname, nil, t)
 
 	cc, err := c.Cluster(nil)
@@ -600,7 +660,6 @@ func TestTTLIndexesClusterInventory(t *testing.T) {
 			t.Fatalf("Index not created: %s", describe(ctx.Err()))
 		}
 	}
-
 }
 
 func TestPersistentIndexCreation(t *testing.T) {
@@ -608,6 +667,12 @@ func TestPersistentIndexCreation(t *testing.T) {
 	skipBelowVersion(c, "3.7", t)
 
 	db := ensureDatabase(nil, c, "index_test_creation", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	coll := ensureCollection(nil, db, "index_creation_test_col", nil, t)
 
 	for i := 0; i < 16; i++ {

--- a/test/pregel_test.go
+++ b/test/pregel_test.go
@@ -37,6 +37,12 @@ func TestCreatePregelJob(t *testing.T) {
 	skipNoCluster(c, t)
 
 	db := ensureDatabase(ctx, c, "pregel_job_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "pregel_graph_test", nil, t)
 
 	nameVertex := "test_pregel_vertex"

--- a/test/query_test.go
+++ b/test/query_test.go
@@ -91,8 +91,6 @@ func prepareQueryDatabase(t *testing.T, ctx context.Context, c driver.Client, na
 func TestValidateQuery(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "validate_query_test", nil, t)
-
 	db, clean := prepareQueryDatabase(t, ctx, c, "validate_query_test")
 	defer clean(t)
 
@@ -139,8 +137,6 @@ func TestValidateQuery(t *testing.T) {
 func TestExplainQuery(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "explain_query_test", nil, t)
-
 	db, clean := prepareQueryDatabase(t, ctx, c, "explain_query_test")
 	defer clean(t)
 
@@ -207,11 +203,9 @@ func TestValidateQueryOptionShardIds(t *testing.T) {
 	if driver.IsPreconditionFailed(err) {
 		t.Skip("Not a cluster")
 	} else {
-		db := ensureDatabase(ctx, c, "validate_query_options_test", nil, t)
-		col := ensureCollection(ctx, db, "c", nil, t)
-
 		db, clean := prepareQueryDatabase(t, ctx, c, "validate_query_options_test")
 		defer clean(t)
+		col := ensureCollection(ctx, db, "c", nil, t)
 
 		t.Run(fmt.Sprintf("Real shards"), func(t *testing.T) {
 			shards, err := col.Shards(ctx, true)
@@ -237,8 +231,6 @@ func TestValidateQueryOptionShardIds(t *testing.T) {
 func TestProfileQuery(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "validate_query_test", nil, t)
-
 	db, clean := prepareQueryDatabase(t, ctx, c, "validate_query_test")
 	defer clean(t)
 
@@ -336,8 +328,6 @@ func TestForceOneShardAttributeValue(t *testing.T) {
 
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.9.0")).Cluster().Enterprise()
 
-	db := ensureDatabase(ctx, c, "force_one_shard_attribute_value", nil, t)
-
 	db, clean := prepareQueryDatabase(t, ctx, c, "force_one_shard_attribute_value")
 	defer clean(t)
 
@@ -373,8 +363,6 @@ func TestFillBlockCache(t *testing.T) {
 	c := createClient(t, nil)
 
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.8.1")).Cluster().Enterprise()
-
-	db := ensureDatabase(ctx, c, "fill_block_cache", nil, t)
 
 	db, clean := prepareQueryDatabase(t, ctx, c, "fill_block_cache")
 	defer clean(t)
@@ -419,7 +407,12 @@ func TestOptimizerRulesForQueries(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.10", t)
 	db := ensureDatabase(ctx, c, "optimizer_rules_test", nil, t)
-
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	t.Run(fmt.Sprintf("Fake shards"), func(t *testing.T) {
 		rules, err := db.OptimizerRulesForQueries(ctx)
 		require.Nil(t, err)
@@ -447,7 +440,6 @@ func TestRetryReadDocument(t *testing.T) {
 
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.11.0"))
 
-	db := ensureDatabase(ctx, c, "query_retry_test", nil, t)
 	db, clean := prepareQueryDatabase(t, ctx, c, "query_retry_test")
 	defer clean(t)
 

--- a/test/revisions_test.go
+++ b/test/revisions_test.go
@@ -41,6 +41,12 @@ func TestRevisionTree(t *testing.T) {
 	skipBelowVersion(c, "3.8", t)
 
 	db := ensureDatabase(nil, c, "revision_tree", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(nil, db, "revision_tree", nil, t)
 
 	var noOfDocuments int = 80000

--- a/test/server_license_test.go
+++ b/test/server_license_test.go
@@ -34,7 +34,7 @@ import (
 func Test_License(t *testing.T) {
 	c := createClient(t, nil)
 	ctx := context.Background()
-	skipBelowVersion(c, "3.10.0", t)
+	skipVersionNotInRange(c, "3.10.0", "3.12.4", t)
 
 	version, err := c.Version(ctx)
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func Test_License(t *testing.T) {
 
 	if version.IsEnterprise() {
 		assert.Equalf(t, driver.LicenseStatusExpiring, license.Status, "by default status should be expiring")
-		assert.Equalf(t, 1, license.Version, "excpected version should be 1")
+		assert.EqualValuesf(t, 1, license.Version, "excpected version should be 1")
 	} else {
 		assert.Equalf(t, driver.LicenseStatus(""), license.Status, "license status should be empty")
 		assert.Equalf(t, 0, license.Version, "license version should be empty")

--- a/test/server_mode_auth_test.go
+++ b/test/server_mode_auth_test.go
@@ -156,5 +156,9 @@ func TestServerModeAndGrants(t *testing.T) {
 		} else if grant != defaultDBAccess {
 			t.Errorf("Collection access using WithConfigured differs, got '%s', expected '%s'", grant, defaultColAccess)
 		}
+		err = db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
 	}
 }

--- a/test/server_mode_test.go
+++ b/test/server_mode_test.go
@@ -83,5 +83,9 @@ func TestServerMode(t *testing.T) {
 		if err := col.Remove(ctx); err != nil {
 			t.Fatalf("Collection remove failed: %s", describe(err))
 		}
+		err = db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
 	}
 }

--- a/test/server_statistics_test.go
+++ b/test/server_statistics_test.go
@@ -177,6 +177,13 @@ func TestServerStatisticsTraffic(t *testing.T) {
 	}
 
 	doSomeWrites(t, nil, c)
+	defer func() {
+		db := ensureDatabase(ctx, c, "statistics_test", nil, t)
+		err = db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	time.Sleep(time.Second) // Wait until statistics updated
 
@@ -257,6 +264,13 @@ func TestServerStatisticsForwarding(t *testing.T) {
 
 	// At least 5000 documents in the collection:
 	doSomeWrites(t, ctx1, c)
+	defer func() {
+		db := ensureDatabase(ctx, c, "statistics_test", nil, t)
+		err = db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	doSomeWrites(t, ctx1, c)
 	doSomeWrites(t, ctx1, c)
 	doSomeWrites(t, ctx1, c)

--- a/test/user_test.go
+++ b/test/user_test.go
@@ -157,7 +157,12 @@ func TestCreateUser(t *testing.T) {
 func TestUpdateUser(t *testing.T) {
 	c := createClient(t, nil)
 	u := ensureUser(nil, c, "update_user", nil, t)
-
+	defer func() {
+		err := u.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to delete user %s: %s ...", u.Name(), err)
+		}
+	}()
 	if err := u.Update(context.TODO(), driver.UserOptions{}); err != nil {
 		t.Errorf("Cannot update user with empty options: %s", describe(err))
 	}
@@ -201,6 +206,12 @@ func TestUpdateUser(t *testing.T) {
 func TestReplaceUser(t *testing.T) {
 	c := createClient(t, nil)
 	u := ensureUser(nil, c, "replace_user", nil, t)
+	defer func() {
+		err := u.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to delete user %s: %s ...", u.Name(), err)
+		}
+	}()
 
 	if err := u.Replace(context.TODO(), driver.UserOptions{}); err != nil {
 		t.Errorf("Cannot replace user with empty options: %s", describe(err))

--- a/test/vertex_collection_test.go
+++ b/test/vertex_collection_test.go
@@ -48,6 +48,12 @@ func ensureVertexCollection(ctx context.Context, g driver.Graph, collection stri
 func TestCreateVertexCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "vertex_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_vertex_collection"
 	g, err := db.CreateGraphV2(nil, name, nil)
 	if err != nil {
@@ -100,6 +106,12 @@ func TestCreateSatelliteVertexCollection(t *testing.T) {
 	EnsureVersion(t, ctx, c).CheckVersion(MinimumVersion("3.9.0")).Cluster().Enterprise()
 
 	db := ensureDatabase(ctx, c, "vertex_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	name := "test_create_satellite_vertex_collection"
 	options := driver.CreateGraphOptions{
@@ -154,6 +166,12 @@ func TestCreateSatelliteVertexCollection(t *testing.T) {
 func TestRemoveVertexCollection(t *testing.T) {
 	c := createClient(t, nil)
 	db := ensureDatabase(nil, c, "vertex_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_remove_vertex_collection"
 	g, err := db.CreateGraphV2(nil, name, nil)
 	if err != nil {
@@ -189,7 +207,6 @@ func TestRemoveVertexCollection(t *testing.T) {
 
 	// Collection must still exist in database
 	assertCollection(nil, db, "friends", t)
-
 }
 
 // TestRenameVertexCollection creates a graph and then adds an vertex collection in it and then renames the vertex collection.
@@ -200,6 +217,12 @@ func TestRenameVertexCollection(t *testing.T) {
 	skipNoSingle(c, t)
 
 	db := ensureDatabase(nil, c, "vertex_collection_test", nil, t)
+	defer func() {
+		err := db.Remove(nil)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_rename_vertex_collection"
 	g, err := db.CreateGraphV2(nil, name, nil)
 	if err != nil {
@@ -237,5 +260,4 @@ func TestRenameVertexCollection(t *testing.T) {
 
 	// Collection must still exist in database
 	assertCollection(nil, db, newName, t)
-
 }

--- a/test/vertex_create_test.go
+++ b/test/vertex_create_test.go
@@ -33,6 +33,12 @@ func TestCreateVertex(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertex_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -65,6 +71,12 @@ func TestCreateVertexReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertex_return_new_est", nil, t)
 	vc := ensureVertexCollection(ctx, g, "users", t)
 
@@ -96,6 +108,12 @@ func TestCreateVertexSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertex_silent_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "users", t)
 
@@ -115,6 +133,12 @@ func TestCreateVertexNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertex_nil_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "users", t)
 

--- a/test/vertex_remove_test.go
+++ b/test/vertex_remove_test.go
@@ -34,6 +34,12 @@ func TestRemoveVertex(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertex_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "users", t)
 
@@ -68,6 +74,12 @@ func TestRemoveVertexReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertex_returnOld_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -91,6 +103,12 @@ func TestRemoveVertexSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertex_silent_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -119,6 +137,12 @@ func TestRemoveVertexRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertex_revision_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "persons", t)
 
@@ -164,6 +188,12 @@ func TestRemoveVertexKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertex_nil_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "hobby", t)
 

--- a/test/vertex_replace_test.go
+++ b/test/vertex_replace_test.go
@@ -33,6 +33,12 @@ func TestReplaceVertex(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertex_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "friend", t)
 
@@ -67,6 +73,12 @@ func TestReplaceVertexReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertex_returnOld_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -99,6 +111,12 @@ func TestReplaceVertexReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertex_returnNew_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "users", t)
 
@@ -131,6 +149,12 @@ func TestReplaceVertexSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertex_returnNew_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "person", t)
 
@@ -159,6 +183,12 @@ func TestReplaceVertexRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertex_revision_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -203,6 +233,12 @@ func TestReplaceVertexKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertex_keyEmpty_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "names", t)
 
@@ -220,6 +256,12 @@ func TestReplaceVertexUpdateNil(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertex_updateNil_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "names", t)
 

--- a/test/vertex_update_test.go
+++ b/test/vertex_update_test.go
@@ -33,6 +33,12 @@ func TestUpdateVertex(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "user", t)
 
@@ -68,6 +74,12 @@ func TestUpdateVertexReturnOld(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_returnOld_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -99,6 +111,12 @@ func TestUpdateVertexReturnNew(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_returnNew_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "person", t)
 
@@ -133,6 +151,12 @@ func TestUpdateVertexKeepNullTrue(t *testing.T) {
 	c := createClient(t, nil)
 	conn := c.Connection()
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_keepNullTrue_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "accounts", t)
 
@@ -189,6 +213,12 @@ func TestUpdateVertexKeepNullFalse(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_keepNullFalse_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "accounts", t)
 
@@ -226,6 +256,12 @@ func TestUpdateVertexSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_silent_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "moments", t)
 
@@ -254,6 +290,12 @@ func TestUpdateVertexRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_revision_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -298,6 +340,12 @@ func TestUpdateVertexKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_keyEmpty_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "tests", t)
 
@@ -315,6 +363,12 @@ func TestUpdateVertexUpdateNil(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertex_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertex_updateNil_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "errors", t)
 

--- a/test/vertices_create_test.go
+++ b/test/vertices_create_test.go
@@ -32,7 +32,13 @@ import (
 func TestCreateVertices(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_create_test1", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertices_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -90,7 +96,13 @@ func TestCreateVerticesReturnNew(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_create_test2", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertices_returnNew_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -136,7 +148,13 @@ func TestCreateVerticesReturnNew(t *testing.T) {
 func TestCreateVerticesSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_create_test3", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertices_silent_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "users", t)
 
@@ -166,7 +184,13 @@ func TestCreateVerticesSilent(t *testing.T) {
 func TestCreateVerticesNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_create_test4", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertices_nil_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "rivers", t)
 	if _, _, err := vc.CreateDocuments(nil, nil); !driver.IsInvalidArgument(err) {
@@ -178,7 +202,13 @@ func TestCreateVerticesNil(t *testing.T) {
 func TestCreateVerticesNonSlice(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_create_test5", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "create_vertices_nonSlice_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "failures", t)
 

--- a/test/vertices_import_test.go
+++ b/test/vertices_import_test.go
@@ -32,6 +32,12 @@ func TestImportVerticesWithKeys(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_withKeys_test", t)
 	docs := []UserDocWithKey{
@@ -75,6 +81,12 @@ func TestImportVerticesWithoutKeys(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_withoutKeys_test", t)
 	docs := []UserDoc{
@@ -118,6 +130,12 @@ func TestImportVerticesEmptyEntries(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_emptyEntries_test", t)
 	docs := []*UserDocWithKey{
@@ -165,6 +183,12 @@ func TestImportVerticesInvalidEntries(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_invalidEntries_test", t)
 	docs := []interface{}{
@@ -211,6 +235,12 @@ func TestImportVerticesDuplicateEntries(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_duplicateEntries_test", t)
 	docs := []interface{}{
@@ -255,6 +285,12 @@ func TestImportVerticesDuplicateEntriesComplete(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_duplicateEntriesComplete_test", t)
 	docs := []interface{}{
@@ -284,6 +320,12 @@ func TestImportVerticesDuplicateEntriesUpdate(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_duplicateEntriesUpdate_test", t)
 	docs := []interface{}{
@@ -341,6 +383,12 @@ func TestImportVerticesDuplicateEntriesReplace(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_duplicateEntriesReplace_test", t)
 	docs := []interface{}{
@@ -398,6 +446,12 @@ func TestImportVerticesDuplicateEntriesIgnore(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_duplicateEntriesIgnore_test", t)
 	docs := []interface{}{
@@ -455,6 +509,12 @@ func TestImportVerticesDetails(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_details_test", t)
 	docs := []interface{}{
@@ -507,6 +567,12 @@ func TestImportVerticesOverwriteYes(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_overwriteYes_test", t)
 	docs := []interface{}{
@@ -549,6 +615,12 @@ func TestImportVerticesOverwriteNo(t *testing.T) {
 	// don't use disallowUnknownFields in this test - we have here custom structs defined
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "import_vertices_test", nil, t)
 	col := ensureVertexCollection(nil, g, "import_overwriteNo_test", t)
 	docs := []interface{}{

--- a/test/vertices_remove_test.go
+++ b/test/vertices_remove_test.go
@@ -33,7 +33,13 @@ import (
 func TestRemoveVertices(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_remove_test1", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertices_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "places", t)
 
@@ -70,7 +76,13 @@ func TestRemoveVertices(t *testing.T) {
 func TestRemoveVerticesReturnOld(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_remove_test2", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
 	g := ensureGraph(ctx, db, "remove_vertices_returnOld_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
@@ -106,7 +118,13 @@ func TestRemoveVerticesReturnOld(t *testing.T) {
 func TestRemoveVerticesSilent(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_remove_test3", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertices_silent_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "silence", t)
 
@@ -148,7 +166,13 @@ func TestRemoveVerticesSilent(t *testing.T) {
 func TestRemoveVerticesRevision(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_remove_test4", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertices_revision_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -216,7 +240,13 @@ func TestRemoveVerticesRevision(t *testing.T) {
 func TestRemoveVerticesKeyEmpty(t *testing.T) {
 	var ctx context.Context
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_remove_test5", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "remove_vertices_keyEmpty_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "failures", t)
 

--- a/test/vertices_replace_test.go
+++ b/test/vertices_replace_test.go
@@ -33,7 +33,13 @@ import (
 func TestReplaceVertices(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_replace_test1", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "male", t)
 
@@ -80,7 +86,13 @@ func TestReplaceVerticesReturnOld(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_test2", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_returnOld_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "pensions", t)
 
@@ -125,7 +137,13 @@ func TestReplaceVerticesReturnNew(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_replace_test3", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_returnNew_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "books", t)
 
@@ -170,7 +188,13 @@ func TestReplaceVerticesReturnNew(t *testing.T) {
 func TestReplaceVerticesSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_replace_test4", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_silent_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "moments", t)
 
@@ -215,7 +239,13 @@ func TestReplaceVerticesSilent(t *testing.T) {
 func TestReplaceVerticesRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_replace_test5", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_revision_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "planets", t)
 
@@ -283,7 +313,13 @@ func TestReplaceVerticesRevision(t *testing.T) {
 func TestReplaceVerticesKeyEmpty(t *testing.T) {
 	ctx := context.TODO()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_replace_test6", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_keyEmpty_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "planets", t)
 
@@ -300,7 +336,13 @@ func TestReplaceVerticesKeyEmpty(t *testing.T) {
 func TestReplaceVerticesUpdateNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_replace_test7", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_updateNil_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "relations", t)
 
@@ -313,7 +355,13 @@ func TestReplaceVerticesUpdateNil(t *testing.T) {
 func TestReplaceVerticesUpdateLenDiff(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_replace_test8", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "replace_vertices_updateNil_test", nil, t)
 	vc := ensureVertexCollection(ctx, g, "failures", t)
 

--- a/test/vertices_update_test.go
+++ b/test/vertices_update_test.go
@@ -34,7 +34,13 @@ import (
 func TestUpdateVertices(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test1", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "relations", t)
 
@@ -83,7 +89,13 @@ func TestUpdateVerticesReturnOld(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test2", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_returnOld_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "books", t)
 
@@ -128,7 +140,13 @@ func TestUpdateVerticesReturnNew(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t) // See https://github.com/arangodb/arangodb/issues/2365
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test3", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_returnOld_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "users", t)
 
@@ -175,7 +193,13 @@ func TestUpdateVerticesKeepNullTrue(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
 	conn := c.Connection()
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test4", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_keepNullTrue_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "keepers", t)
 
@@ -252,7 +276,13 @@ func TestUpdateVerticesKeepNullTrue(t *testing.T) {
 func TestUpdateVerticesKeepNullFalse(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test5", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_keepNullFalse_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "accounts", t)
 
@@ -309,7 +339,13 @@ func TestUpdateVerticesKeepNullFalse(t *testing.T) {
 func TestUpdateVerticesSilent(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test6", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_silent_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "moments", t)
 
@@ -349,7 +385,13 @@ func TestUpdateVerticesSilent(t *testing.T) {
 func TestUpdateVerticesRevision(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test7", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_revision_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "revisions", t)
 
@@ -414,7 +456,13 @@ func TestUpdateVerticesRevision(t *testing.T) {
 func TestUpdateVerticesKeyEmpty(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test8", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_keyEmpty_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "lonely", t)
 
@@ -433,7 +481,13 @@ func TestUpdateVerticesKeyEmpty(t *testing.T) {
 func TestUpdateVerticesUpdateNil(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test9", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_updateNil_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "nilAndSome", t)
 
@@ -446,7 +500,13 @@ func TestUpdateVerticesUpdateNil(t *testing.T) {
 func TestUpdateVerticesUpdateLenDiff(t *testing.T) {
 	ctx := context.Background()
 	c := createClient(t, nil)
-	db := ensureDatabase(ctx, c, "vertices_test", nil, t)
+	db := ensureDatabase(ctx, c, "vertices_update_test10", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	g := ensureGraph(ctx, db, "update_vertices_updateLenDiff_test", nil, t)
 	ec := ensureVertexCollection(ctx, g, "diffs", t)
 

--- a/test/view_alias_test.go
+++ b/test/view_alias_test.go
@@ -56,6 +56,12 @@ func TestSearchViewsAlias(t *testing.T) {
 	skipBelowVersion(c, "3.10", t)
 	skipBelowVersion(c, "3.10", t)
 	db := ensureDatabase(ctx, c, "search_view_test_basic", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	nameAlias := "test_add_collection_view_alias"
 	nameCol := "col_in_alias_view"

--- a/test/view_test.go
+++ b/test/view_test.go
@@ -85,6 +85,12 @@ func TestCreateArangoSearchView(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	ensureCollection(ctx, db, "someCol", nil, t)
 	name := "test_create_asview"
 	opts := &driver.ArangoSearchViewProperties{
@@ -122,6 +128,12 @@ func TestCreateArangoSearchViewInvalidLinks(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_inv_view"
 	opts := &driver.ArangoSearchViewProperties{
 		Links: driver.ArangoSearchLinks{
@@ -150,6 +162,12 @@ func TestCreateEmptyArangoSearchView(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_empty_asview"
 	v, err := db.CreateArangoSearchView(ctx, name, nil)
 	if err != nil {
@@ -177,6 +195,12 @@ func TestCreateDuplicateArangoSearchView(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_create_dup_asview"
 	if _, err := db.CreateArangoSearchView(ctx, name, nil); err != nil {
 		t.Fatalf("Failed to create view '%s': %s", name, describe(err))
@@ -200,6 +224,12 @@ func TestCreateArangoSearchViewThenRemoveCollection(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "someViewTmpCol", nil, t)
 	name := "test_create_view_then_rem_col"
 	opts := &driver.ArangoSearchViewProperties{
@@ -253,6 +283,12 @@ func TestAddCollectionMultipleViews(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "col_in_multi_view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	ensureCollection(ctx, db, "col_in_multi_view", nil, t)
 	v1 := ensureArangoSearchView(ctx, db, "col_in_multi_view_view1", nil, t)
 	if !tryAddArangoSearchLink(ctx, db, v1, "col_in_multi_view", t) {
@@ -271,6 +307,12 @@ func TestAddCollectionMultipleViewsViaCreate(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "col_in_multi_view_create_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	ensureCollection(ctx, db, "col_in_multi_view_create", nil, t)
 	opts := &driver.ArangoSearchViewProperties{
 		Links: driver.ArangoSearchLinks{
@@ -294,6 +336,12 @@ func TestGetArangoSearchOptimizeTopK(t *testing.T) {
 	skipBelowVersion(c, "3.12.0", t)
 	skipNoEnterprise(t)
 	db := ensureDatabase(ctx, c, "view_test_optimize_top_k", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_get_asview"
 	optimizeTopK := []string{"BM25(@doc) DESC", "TFIDF(@doc) DESC"}
 	opts := &driver.ArangoSearchViewProperties{
@@ -329,6 +377,12 @@ func TestGetArangoSearchView(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "someCol", nil, t)
 	name := "test_get_asview"
 	opts := &driver.ArangoSearchViewProperties{
@@ -377,6 +431,12 @@ func TestGetArangoSearchViews(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	// Get views before adding some
 	before, err := db.Views(ctx)
 	if err != nil {
@@ -421,6 +481,12 @@ func TestRenameAndRemoveArangoSearchView(t *testing.T) {
 	skipBelowVersion(c, "3.4", t)
 
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	name := "test_rename_view"
 	renamedView := "test_rename_view_new"
 	v, err := db.CreateArangoSearchView(ctx, name, nil)
@@ -461,7 +527,6 @@ func TestRenameAndRemoveArangoSearchView(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, found)
 	})
-
 }
 
 // TestUseArangoSearchView tries to create a view and actually use it in
@@ -472,6 +537,12 @@ func TestUseArangoSearchView(t *testing.T) {
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	skipBelowVersion(c, "3.4", t)
 	db := ensureDatabase(nil, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "some_collection", nil, t)
 
 	ensureArangoSearchView(ctx, db, "some_view", &driver.ArangoSearchViewProperties{
@@ -555,6 +626,12 @@ func TestUseArangoSearchViewWithNested(t *testing.T) {
 	skipBelowVersion(c, "3.10", t)
 	skipNoEnterprise(t)
 	db := ensureDatabase(nil, c, "view_nested_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "some_collection", nil, t)
 
 	ensureArangoSearchView(ctx, db, "some_nested_view", &driver.ArangoSearchViewProperties{
@@ -622,6 +699,12 @@ func TestUseArangoSearchViewWithPipelineAnalyzer(t *testing.T) {
 	c := createClient(t, &testsClientConfig{skipDisallowUnknownFields: true})
 	skipBelowVersion(c, "3.8", t)
 	db := ensureDatabase(nil, c, "view_with_pipeline_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	col := ensureCollection(ctx, db, "some_collection_with_analyzer", nil, t)
 
 	analyzer := driver.ArangoSearchAnalyzerDefinition{
@@ -719,6 +802,12 @@ func TestArangoSearchViewProperties35(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.7.1", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	ensureCollection(ctx, db, "someCol", nil, t)
 	commitInterval := int64(100)
 	sortDir := driver.ArangoSearchSortDirectionDesc
@@ -787,6 +876,12 @@ func TestArangoSearchPrimarySort(t *testing.T) {
 	c := createClient(t, nil)
 	skipBelowVersion(c, "3.5", t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	ensureCollection(ctx, db, "primary_col_sort", nil, t)
 
 	boolTrue := true
@@ -931,6 +1026,12 @@ func TestArangoSearchViewProperties353(t *testing.T) {
 	skipBelowVersion(c, "3.5.3", t)
 	skipNoCluster(c, t)
 	db := ensureDatabase(ctx, c, "view_test", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	colname := "someCol"
 	ensureCollection(ctx, db, colname, nil, t)
 	name := "test_get_asview_353"
@@ -999,6 +1100,12 @@ func TestArangoSearchViewLinkAndStoredValueCache(t *testing.T) {
 	skipBetweenVersions(c, "3.10.0", "3.10.1", t)
 	skipNoEnterprise(t)
 	db := ensureDatabase(ctx, c, "view_test_links_stored_value_cache", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 	linkedColName := "linkedColumn"
 	ensureCollection(ctx, db, linkedColName, nil, t)
 	name := "test_create_asview"
@@ -1045,6 +1152,12 @@ func TestArangoSearchViewInMemoryCache(t *testing.T) {
 
 	skipNoEnterprise(t)
 	db := ensureDatabase(ctx, c, "view_test_in_memory_cache", nil, t)
+	defer func() {
+		err := db.Remove(ctx)
+		if err != nil {
+			t.Logf("Failed to drop database %s: %s ...", db.Name(), err)
+		}
+	}()
 
 	t.Run("primarySortCache", func(t *testing.T) {
 		// feature was introduced in 3.9.5 and in 3.10.2:

--- a/v2/tests/admin_cluster_test.go
+++ b/v2/tests/admin_cluster_test.go
@@ -36,7 +36,7 @@ func Test_ClusterHealth(t *testing.T) {
 
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
-
+			requireClusterMode(t)
 			health, err := client.Health(ctx)
 			require.NoError(t, err, "Health failed")
 			require.NotNil(t, health, "Health did not return a health")
@@ -74,6 +74,7 @@ func Test_ClusterDatabaseInventory(t *testing.T) {
 	requireClusterMode(t)
 
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
+		requireClusterMode(t)
 		t.Run("DatabaseInventory simple checks", func(t *testing.T) {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
 

--- a/v2/tests/admin_license_test.go
+++ b/v2/tests/admin_license_test.go
@@ -33,10 +33,7 @@ import (
 func Test_License(t *testing.T) {
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {
-			skipBelowVersion(client, ctx, "3.10.0", t)
-
-			version, err := client.Version(ctx)
-			require.NoError(t, err)
+			version := skipVersionNotInRange(client, ctx, "3.10.0", "3.12.4", t)
 
 			license, err := client.GetLicense(ctx)
 			require.NoError(t, err)

--- a/v2/tests/asyncjob_test.go
+++ b/v2/tests/asyncjob_test.go
@@ -122,8 +122,8 @@ func TestAsyncJobListPending(t *testing.T) {
 						require.Len(t, jobs, 1)
 					})
 
-					t.Run("wait fot the async jobs to be done", func(t *testing.T) {
-						time.Sleep(4 * time.Second)
+					t.Run("wait for the async jobs to be done", func(t *testing.T) {
+						time.Sleep(12 * time.Second)
 
 						jobs, err := client.AsyncJobList(ctx, arangodb.JobPending, nil)
 						require.NoError(t, err)
@@ -179,7 +179,7 @@ func TestAsyncJobCancel(t *testing.T) {
 					})
 
 					t.Run("cancelled job should move from pending to done state", func(t *testing.T) {
-						time.Sleep(5 * time.Second)
+						time.Sleep(10 * time.Second)
 
 						jobs, err := client.AsyncJobList(ctx, arangodb.JobPending, nil)
 						require.NoError(t, err)

--- a/v2/tests/database_collection_indexes_test.go
+++ b/v2/tests/database_collection_indexes_test.go
@@ -219,6 +219,10 @@ func Test_TTLIndex(t *testing.T) {
 					t.Run("Removing documents at a fixed period after creation", func(t *testing.T) {
 						idx, created, err := col.EnsureTTLIndex(ctx, []string{"createdAt"}, 5, nil)
 						require.NoError(t, err)
+						defer func() {
+							err := col.DeleteIndexByID(ctx, idx.ID)
+							require.NoError(t, err)
+						}()
 						require.True(t, created)
 						require.Equal(t, *idx.RegularIndex.ExpireAfter, 5)
 						require.Equal(t, arangodb.TTLIndexType, idx.Type)
@@ -248,13 +252,15 @@ func Test_TTLIndex(t *testing.T) {
 							}
 						})
 
-						err = col.DeleteIndexByID(ctx, idx.ID)
-						require.NoError(t, err)
 					})
 
 					t.Run("Removing documents at certain points in time", func(t *testing.T) {
 						idx, created, err := col.EnsureTTLIndex(ctx, []string{"expireDate"}, 0, nil)
 						require.NoError(t, err)
+						defer func() {
+							err := col.DeleteIndexByID(ctx, idx.ID)
+							require.NoError(t, err)
+						}()
 						require.True(t, created)
 						require.Equal(t, *idx.RegularIndex.ExpireAfter, 0)
 						require.Equal(t, arangodb.TTLIndexType, idx.Type)
@@ -283,9 +289,6 @@ func Test_TTLIndex(t *testing.T) {
 								time.Sleep(1 * time.Second)
 							}
 						})
-
-						err = col.DeleteIndexByID(ctx, idx.ID)
-						require.NoError(t, err)
 					})
 				})
 			})

--- a/v2/tests/database_transactions_test.go
+++ b/v2/tests/database_transactions_test.go
@@ -225,7 +225,7 @@ func Test_DatabaseTransactions_DocumentLock(t *testing.T) {
 						LockTimeoutDuration: 1 * time.Second,
 					})
 					require.NoError(t, err)
-					defer abortTransaction(t, t1)
+					defer abortTransaction(t, t2)
 
 					col2, err := t2.GetCollection(ctx, col.Name(), nil)
 					require.NoError(t, err)
@@ -251,10 +251,13 @@ func Test_DatabaseTransactions_List(t *testing.T) {
 				t.Run("List all transactions", func(t *testing.T) {
 					t1, err := db.BeginTransaction(ctx, arangodb.TransactionCollections{}, nil)
 					require.NoError(t, err)
+					defer abortTransaction(t, t1)
 					t2, err := db.BeginTransaction(ctx, arangodb.TransactionCollections{}, nil)
 					require.NoError(t, err)
+					defer abortTransaction(t, t2)
 					t3, err := db.BeginTransaction(ctx, arangodb.TransactionCollections{}, nil)
 					require.NoError(t, err)
+					defer abortTransaction(t, t3)
 
 					transactions, err := db.ListTransactions(ctx)
 					require.NoError(t, err)
@@ -282,6 +285,13 @@ func ensureTransactionStatus(t testing.TB, db arangodb.Database, tid arangodb.Tr
 	withContextT(t, 30*time.Second, func(ctx context.Context, t testing.TB) {
 		transaction, err := db.Transaction(ctx, tid)
 		require.NoError(t, err)
+		defer func() {
+			status, err := transaction.Status(ctx)
+			require.NoError(t, err)
+			if status.Status != arangodb.TransactionCommitted {
+				abortTransaction(t, transaction)
+			}
+		}()
 
 		s, err := transaction.Status(ctx)
 		require.NoError(t, err)

--- a/v2/tests/run_wrap_test.go
+++ b/v2/tests/run_wrap_test.go
@@ -261,10 +261,10 @@ func waitForConnection(t testing.TB, client arangodb.Client) arangodb.Client {
 					return nil
 				}
 			}
-
+			current := time.Now()
 			resp, err := client.Get(ctx, nil, "_admin", "server", "availability")
 			if err != nil {
-				log.Warn().Err(err).Msgf("Unable to get cluster health")
+				log.Warn().Err(err).Msgf("Unable to get SUT health, deadline: %s", time.Since(current))
 				return nil
 			}
 

--- a/v2/tests/users_permissions_test.go
+++ b/v2/tests/users_permissions_test.go
@@ -65,6 +65,13 @@ func Test_UserPermission(t *testing.T) {
 				t.Run("Test custom user", func(t *testing.T) {
 					WithCollectionV2(t, db, nil, func(col arangodb.Collection) {
 						userCustom, err := client.CreateUser(ctx, "custom"+GenerateUUID("user-db"), nil)
+						defer func() {
+							err := client.RemoveUser(ctx, userCustom.Name())
+							if err != nil {
+								t.Logf("Failed to delete user %s: %s ...", userCustom.Name(), err)
+							}
+						}()
+
 						require.NoError(t, err)
 						require.NotNil(t, userCustom)
 

--- a/v2/tests/users_test.go
+++ b/v2/tests/users_test.go
@@ -48,6 +48,12 @@ func Test_Users(t *testing.T) {
 				require.GreaterOrEqual(t, len(users), 1)
 			})
 
+			defer func() {
+				err := client.RemoveUser(ctx, user1Name)
+				if err != nil {
+					t.Logf("Failed to delete user %s: %s ...", user1Name, err)
+				}
+			}()
 			t.Run("Test created user", func(t *testing.T) {
 				u, err := client.CreateUser(ctx, user1Name, nil)
 				require.NoError(t, err)
@@ -61,6 +67,12 @@ func Test_Users(t *testing.T) {
 				require.Equal(t, user1Name, ur.Name())
 			})
 
+			defer func() {
+				err := client.RemoveUser(ctx, user2Name)
+				if err != nil {
+					t.Logf("Failed to delete user %s: %s ...", user2Name, err)
+				}
+			}()
 			t.Run("Test created user with options", func(t *testing.T) {
 				opts := &arangodb.UserOptions{
 					Extra: doc,

--- a/v2/tests/util_test.go
+++ b/v2/tests/util_test.go
@@ -120,3 +120,19 @@ func skipBetweenVersions(c arangodb.Client, ctx context.Context, minVersion, max
 	}
 	return x
 }
+
+// skipVersionNotInRange skips the test if the current server version is less than
+// the min version or higher/equal max version
+func skipVersionNotInRange(c arangodb.Client, ctx context.Context, minVersion, maxVersion arangodb.Version, t testing.TB) arangodb.VersionInfo {
+	x, err := c.Version(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get version info: %s", err)
+	}
+	if x.Version.CompareTo(minVersion) < 0 {
+		t.Skipf("Skipping below version '%s', got version '%s'", minVersion, x.Version)
+	}
+	if x.Version.CompareTo(maxVersion) >= 0 {
+		t.Skipf("Skipping above version '%s', got version '%s'", maxVersion, x.Version)
+	}
+	return x
+}

--- a/v2/tests/utils_retry_test.go
+++ b/v2/tests/utils_retry_test.go
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Copyright holder is ArangoDB GmbH, Cologne, Germany
+//  Copyright holder is ArangoDB GmbH, Cologne, Germany
 //
 
 package tests

--- a/v2/tests/utils_retry_test.go
+++ b/v2/tests/utils_retry_test.go
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-//  Copyright holder is ArangoDB GmbH, Cologne, Germany
+//    Copyright holder is ArangoDB GmbH, Cologne, Germany
 //
 
 package tests

--- a/v2/tests/utils_retry_test.go
+++ b/v2/tests/utils_retry_test.go
@@ -31,7 +31,7 @@ import (
 
 // defaultTestTimeout is the default timeout for context use in tests
 // less than 2 minutes is causing problems on CI
-const defaultTestTimeout = 5 * time.Minute
+const defaultTestTimeout = 15 * time.Minute
 
 type Timeout func() error
 


### PR DESCRIPTION
 - increase timeouts for various actions
 - add defferred database cleanup
 - have more informative error messages
 - increase the timeout to hot backup restore waiting
 - disable replication 2 tests
 - disable license tests, for post 3.12.4 versions, it works different now.