### PR TITLE
Add V2 endpoints for Foxx Service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,6 @@ workflows:
           requires:
             - download-demo-data
           test-to-run: run-v2-tests-cluster
-          resources-path: "${HOME}/resources/"
 
       - run-integration-tests:
           name: Test V2 cluster - DB extra features (compression)
@@ -137,7 +136,6 @@ workflows:
             - download-demo-data
           test-to-run: run-v2-tests-cluster
           enable-extra-db-features: true
-          resources-path: "${HOME}/resources/"
 
       - run-integration-tests:
           name: Test V1 single
@@ -150,7 +148,6 @@ workflows:
           requires:
             - download-demo-data
           test-to-run: run-v2-tests-single
-          resources-path: "${HOME}/resources/"
   # Weekly vulnerability check
   weekly_vulncheck:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,26 +49,6 @@ jobs:
     environment:
       GOIMAGE: << pipeline.parameters.goImage >>
 
-  download-demo-data:
-    executor: machine-executor
-    steps:
-      - run: mkdir -p $HOME/resources
-      - run:
-          name: Download itzpapalotl demo foxx service
-          command: |
-            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-              echo "This is not a pull request. Skipping..."
-              exit 0
-            fi
-            if ! [ -f "$HOME/resources/itzpapalotl-v1.2.0.zip" ]; then
-              curl -L0 -o $HOME/resources/itzpapalotl-v1.2.0.zip "https://github.com/arangodb-foxx/demo-itzpapalotl/archive/v1.2.0.zip"
-            fi
-      - run: ls -l $HOME/resources
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - resources
-
   run-integration-tests:
     executor: machine-executor
     parameters:
@@ -82,6 +62,14 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/
+      - run:
+          name: Create resources symlink
+          command: |
+            if [ -d "${HOME}/resources" ]; then
+              sudo mkdir -p /tmp/resources
+              sudo cp -r ${HOME}/resources/* /tmp/resources/
+              ls -la /tmp/resources/
+            fi
       - run: echo "TEST_RESOURCES=$TEST_RESOURCES"
       - run: ls -l $TEST_RESOURCES
       - run:
@@ -101,6 +89,26 @@ jobs:
       ENABLE_DATABASE_EXTRA_FEATURES: << parameters.enable-extra-db-features >>
       TEST_DISALLOW_UNKNOWN_FIELDS: false
       VERBOSE: 1
+
+  download-demo-data:
+    executor: machine-executor
+    steps:
+      - run: mkdir -p $HOME/resources
+      - run:
+          name: Download itzpapalotl demo foxx service
+          command: |
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+              echo "This is not a pull request. Skipping..."
+              exit 0
+            fi
+            if ! [ -f "$HOME/resources/itzpapalotl-v1.2.0.zip" ]; then
+              curl -L0 -o $HOME/resources/itzpapalotl-v1.2.0.zip "https://github.com/arangodb-foxx/demo-itzpapalotl/archive/v1.2.0.zip"
+            fi
+      - run: ls -l $HOME/resources 
+      - persist_to_workspace:      
+          root: ~/
+          paths:
+            - resources
 
   vulncheck:
     executor: golang-executor
@@ -131,13 +139,11 @@ workflows:
           requires:
             - download-demo-data
           test-to-run: run-tests-cluster
-
       - run-integration-tests:
           name: Test V2 cluster
           requires:
             - download-demo-data
           test-to-run: run-v2-tests-cluster
-
       - run-integration-tests:
           name: Test V2 cluster - DB extra features (compression)
           requires:
@@ -150,12 +156,12 @@ workflows:
           requires:
             - download-demo-data
           test-to-run: run-tests-single
-
       - run-integration-tests:
           name: Test V2 single
           requires:
             - download-demo-data
           test-to-run: run-v2-tests-single
+
   # Weekly vulnerability check
   weekly_vulncheck:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,18 +60,40 @@ jobs:
         default: false
     steps:
       - checkout
+      - run:
+          name: Debug - Check if this is a PR
+          command: |
+            echo "CIRCLE_PULL_REQUEST: $CIRCLE_PULL_REQUEST"
+            echo "CIRCLE_PR_NUMBER: $CIRCLE_PR_NUMBER"
       - attach_workspace:
           at: ~/
+      - run:
+          name: Debug - Check workspace contents
+          command: |
+            echo "Contents of HOME directory:"
+            ls -la $HOME/
+            echo "Looking for resources directory:"
+            find $HOME -name "resources" -type d 2>/dev/null || echo "No resources directory found"
       - run:
           name: Create resources symlink
           command: |
             if [ -d "${HOME}/resources" ]; then
+              echo "Found ${HOME}/resources, copying to /tmp/resources"
               sudo mkdir -p /tmp/resources
               sudo cp -r ${HOME}/resources/* /tmp/resources/
               ls -la /tmp/resources/
+            else
+              echo "Directory ${HOME}/resources does not exist"
+              echo "Creating empty /tmp/resources for fallback"
+              sudo mkdir -p /tmp/resources
             fi
       - run: echo "TEST_RESOURCES=$TEST_RESOURCES"
-      - run: ls -l $TEST_RESOURCES
+      - run: |
+          if [ -d "$TEST_RESOURCES" ]; then
+            ls -l $TEST_RESOURCES
+          else
+            echo "TEST_RESOURCES directory $TEST_RESOURCES does not exist"
+          fi
       - run:
           name: make << parameters.test-to-run >>
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-        at: ~/
+          at: ~/
       - run: echo "TEST_RESOURCES=$TEST_RESOURCES"
       - run: ls -l $TEST_RESOURCES
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,10 @@ jobs:
         default: false
     steps:
       - checkout
+      - attach_workspace:
+        at: ~/
+      - run: echo "TEST_RESOURCES=$TEST_RESOURCES"
+      - run: ls -l $TEST_RESOURCES
       - run:
           name: make << parameters.test-to-run >>
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,11 @@ jobs:
     steps:
       - checkout
       - run:
+        name: "Check resources before tests"
+        command: |
+          echo "HOME is $HOME"
+          ls -l $HOME/resources || echo "No resources in $HOME/resources"
+      - run:
           name: make << parameters.test-to-run >>
           command: |
             if [ -z "$CIRCLE_PULL_REQUEST" ]; then
@@ -68,6 +73,10 @@ jobs:
               exit 0
             fi
             make << parameters.test-to-run >>
+      - run:
+        name: "Check resources inside container"
+        command: |
+          docker run --rm -v $HOME/resources:/tmp/resources alpine ls -l /tmp/resources
     environment:
       TEST_RESOURCES: "${HOME}/resources/"
       ARANGODB: << pipeline.parameters.arangodbImage >>
@@ -92,6 +101,7 @@ jobs:
             if ! [ -f "$HOME/resources/itzpapalotl-v1.2.0.zip" ]; then
               curl -L0 -o $HOME/resources/itzpapalotl-v1.2.0.zip "https://github.com/arangodb-foxx/demo-itzpapalotl/archive/v1.2.0.zip"
             fi
+      - run: ls -l $HOME/resources
 
   vulncheck:
     executor: golang-executor
@@ -127,13 +137,16 @@ workflows:
           requires:
             - download-demo-data
           test-to-run: run-v2-tests-cluster
+          environment:
+            TEST_RESOURCES: "${HOME}/resources/"
       - run-integration-tests:
           name: Test V2 cluster - DB extra features (compression)
           requires:
             - download-demo-data
           test-to-run: run-v2-tests-cluster
           enable-extra-db-features: true
-
+        environment:
+            TEST_RESOURCES: "${HOME}/resources/"
       - run-integration-tests:
           name: Test V1 single
           requires:
@@ -144,7 +157,8 @@ workflows:
           requires:
             - download-demo-data
           test-to-run: run-v2-tests-single
-
+          environment:
+            TEST_RESOURCES: "${HOME}/resources/"
   # Weekly vulnerability check
   weekly_vulncheck:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,40 +61,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Debug - Check if this is a PR
-          command: |
-            echo "CIRCLE_PULL_REQUEST: $CIRCLE_PULL_REQUEST"
-            echo "CIRCLE_PR_NUMBER: $CIRCLE_PR_NUMBER"
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Debug - Check workspace contents
-          command: |
-            echo "Contents of HOME directory:"
-            ls -la $HOME/
-            echo "Looking for resources directory:"
-            find $HOME -name "resources" -type d 2>/dev/null || echo "No resources directory found"
-      - run:
-          name: Create resources symlink
-          command: |
-            if [ -d "${HOME}/resources" ]; then
-              echo "Found ${HOME}/resources, copying to /tmp/resources"
-              sudo mkdir -p /tmp/resources
-              sudo cp -r ${HOME}/resources/* /tmp/resources/
-              ls -la /tmp/resources/
-            else
-              echo "Directory ${HOME}/resources does not exist"
-              echo "Creating empty /tmp/resources for fallback"
-              sudo mkdir -p /tmp/resources
-            fi
-      - run: echo "TEST_RESOURCES=$TEST_RESOURCES"
-      - run: |
-          if [ -d "$TEST_RESOURCES" ]; then
-            ls -l $TEST_RESOURCES
-          else
-            echo "TEST_RESOURCES directory $TEST_RESOURCES does not exist"
-          fi
-      - run:
           name: make << parameters.test-to-run >>
           command: |
             if [ -z "$CIRCLE_PULL_REQUEST" ]; then
@@ -126,11 +92,6 @@ jobs:
             if ! [ -f "$HOME/resources/itzpapalotl-v1.2.0.zip" ]; then
               curl -L0 -o $HOME/resources/itzpapalotl-v1.2.0.zip "https://github.com/arangodb-foxx/demo-itzpapalotl/archive/v1.2.0.zip"
             fi
-      - run: ls -l $HOME/resources 
-      - persist_to_workspace:      
-          root: ~/
-          paths:
-            - resources
 
   vulncheck:
     executor: golang-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,7 @@ workflows:
           requires:
             - download-demo-data
           test-to-run: run-tests-cluster
+
       - run-integration-tests:
           name: Test V2 cluster
           requires:
@@ -130,19 +131,22 @@ workflows:
           test-to-run: run-v2-tests-cluster
           environment:
             TEST_RESOURCES: "${HOME}/resources/"
+
       - run-integration-tests:
           name: Test V2 cluster - DB extra features (compression)
           requires:
             - download-demo-data
           test-to-run: run-v2-tests-cluster
           enable-extra-db-features: true
-        environment:
+          environment:
             TEST_RESOURCES: "${HOME}/resources/"
+
       - run-integration-tests:
           name: Test V1 single
           requires:
             - download-demo-data
           test-to-run: run-tests-single
+
       - run-integration-tests:
           name: Test V2 single
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,11 +61,6 @@ jobs:
     steps:
       - checkout
       - run:
-        name: "Check resources before tests"
-        command: |
-          echo "HOME is $HOME"
-          ls -l $HOME/resources || echo "No resources in $HOME/resources"
-      - run:
           name: make << parameters.test-to-run >>
           command: |
             if [ -z "$CIRCLE_PULL_REQUEST" ]; then
@@ -73,10 +68,6 @@ jobs:
               exit 0
             fi
             make << parameters.test-to-run >>
-      - run:
-        name: "Check resources inside container"
-        command: |
-          docker run --rm -v $HOME/resources:/tmp/resources alpine ls -l /tmp/resources
     environment:
       TEST_RESOURCES: "${HOME}/resources/"
       ARANGODB: << pipeline.parameters.arangodbImage >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,7 @@ workflows:
           requires:
             - download-demo-data
           test-to-run: run-v2-tests-cluster
-          environment:
-            TEST_RESOURCES: "${HOME}/resources/"
+          resources-path: "${HOME}/resources/"
 
       - run-integration-tests:
           name: Test V2 cluster - DB extra features (compression)
@@ -138,8 +137,7 @@ workflows:
             - download-demo-data
           test-to-run: run-v2-tests-cluster
           enable-extra-db-features: true
-          environment:
-            TEST_RESOURCES: "${HOME}/resources/"
+          resources-path: "${HOME}/resources/"
 
       - run-integration-tests:
           name: Test V1 single
@@ -152,8 +150,7 @@ workflows:
           requires:
             - download-demo-data
           test-to-run: run-v2-tests-single
-          environment:
-            TEST_RESOURCES: "${HOME}/resources/"
+          resources-path: "${HOME}/resources/"
   # Weekly vulnerability check
   weekly_vulncheck:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,26 @@ jobs:
     environment:
       GOIMAGE: << pipeline.parameters.goImage >>
 
+  download-demo-data:
+    executor: machine-executor
+    steps:
+      - run: mkdir -p $HOME/resources
+      - run:
+          name: Download itzpapalotl demo foxx service
+          command: |
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+              echo "This is not a pull request. Skipping..."
+              exit 0
+            fi
+            if ! [ -f "$HOME/resources/itzpapalotl-v1.2.0.zip" ]; then
+              curl -L0 -o $HOME/resources/itzpapalotl-v1.2.0.zip "https://github.com/arangodb-foxx/demo-itzpapalotl/archive/v1.2.0.zip"
+            fi
+      - run: ls -l $HOME/resources
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - resources
+
   run-integration-tests:
     executor: machine-executor
     parameters:
@@ -77,22 +97,6 @@ jobs:
       ENABLE_DATABASE_EXTRA_FEATURES: << parameters.enable-extra-db-features >>
       TEST_DISALLOW_UNKNOWN_FIELDS: false
       VERBOSE: 1
-
-  download-demo-data:
-    executor: machine-executor
-    steps:
-      - run: mkdir -p $HOME/resources
-      - run:
-          name: Download itzpapalotl demo foxx service
-          command: |
-            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-              echo "This is not a pull request. Skipping..."
-              exit 0
-            fi
-            if ! [ -f "$HOME/resources/itzpapalotl-v1.2.0.zip" ]; then
-              curl -L0 -o $HOME/resources/itzpapalotl-v1.2.0.zip "https://github.com/arangodb-foxx/demo-itzpapalotl/archive/v1.2.0.zip"
-            fi
-      - run: ls -l $HOME/resources
 
   vulncheck:
     executor: golang-executor

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add missing endpoints from collections to v2
 - Add missing endpoints from query to v2
 - Add SSO auth token implementation
+- Add missing endpoints from foxx to v2
 
 ## [2.1.3](https://github.com/arangodb/go-driver/tree/v2.1.3) (2025-02-21)
 - Switch to Go 1.22.11

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -77,6 +77,11 @@ type ClientFoxxService interface {
 	//  * mount: Current mount path of the dependency service (if set)
 	// An error if the request fails or the mount is missing.
 	GetFoxxServiceDependencies(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error)
+	// UpdateFoxxServiceDependencies updates the configured dependencies of a specific Foxx service.
+	// If the Foxx service does not allow a particular dependency key, it will appear
+	// in the "warnings" field of the response.
+	// The caller is responsible for ensuring that only allowed dependency keys are provided.
+	UpdateFoxxServiceDependencies(ctx context.Context, dbName string, mount *string, opt map[string]interface{}) (map[string]interface{}, error)
 }
 
 type FoxxDeploymentOptions struct {

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -54,7 +54,10 @@ type ClientFoxxService interface {
 	// at the specified mount path, retaining the existing service’s configuration and dependencies.
 	// This should be used only when upgrading to a newer or equivalent version of the same service.
 	UpgradeFoxxService(ctx context.Context, dbName string, zipFile string, opts *FoxxDeploymentOptions) error
-
+	// GetFoxxServiceConfiguration retrieves the configuration values for the Foxx service
+	// mounted at the specified path in the given database.
+	// The mount parameter must not be nil or empty.
+	// Returns a map containing the current configuration key-value pairs.
 	GetFoxxServiceConfiguration(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error)
 }
 

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -64,6 +64,11 @@ type ClientFoxxService interface {
 	// in the response warnings.
 	// The caller is responsible for validating allowed keys before calling this method.
 	UpdateFoxxServiceConfiguration(ctx context.Context, dbName string, mount *string, opt map[string]interface{}) (map[string]interface{}, error)
+	// ReplaceFoxxServiceConfiguration replaces the given Foxx service's dependencies entirely.
+	// If the Foxx service does not allow a particular configuration key, it will appear
+	// in the response warnings.
+	// The caller is responsible for validating allowed keys before calling this method.
+	ReplaceFoxxServiceConfiguration(ctx context.Context, dbName string, mount *string, opt map[string]interface{}) (map[string]interface{}, error)
 }
 
 type FoxxDeploymentOptions struct {

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -73,8 +73,10 @@ func (c *InstallFoxxServiceRequest) modifyRequest(r connection.Request) error {
 	}
 
 	r.AddHeader(connection.ContentType, "application/zip")
-	r.AddQuery("mount", *c.Mount)
-
+	if c.Mount != nil && *c.Mount != "" {
+		mount := *c.Mount
+		r.AddQuery("mount", mount)
+	}
 	return nil
 }
 
@@ -83,10 +85,16 @@ func (c *UninstallFoxxServiceRequest) modifyRequest(r connection.Request) error 
 		return nil
 	}
 
-	r.AddQuery("mount", *c.Mount)
-	r.AddQuery("teardown", strconv.FormatBool(*c.Teardown))
-	return nil
+	if c.Mount != nil && *c.Mount != "" {
+		mount := *c.Mount
+		r.AddQuery("mount", mount)
+	}
 
+	if c.Teardown != nil {
+		r.AddQuery("teardown", strconv.FormatBool(*c.Teardown))
+	}
+
+	return nil
 }
 
 type CommonFoxxServiceFields struct {

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -87,6 +87,10 @@ type ClientFoxxService interface {
 	// in the "warnings" field of the response.
 	// The caller is responsible for validating allowed keys before calling this method.
 	ReplaceFoxxServiceDependencies(ctx context.Context, dbName string, mount *string, opt map[string]interface{}) (map[string]interface{}, error)
+	// GetFoxxServiceScripts retrieves the scripts associated with a specific Foxx service.
+	GetFoxxServiceScripts(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error)
+	// RunFoxxServiceScript executes a specific script associated with a Foxx service.
+	RunFoxxServiceScript(ctx context.Context, dbName string, name string, mount *string, body map[string]interface{}) (map[string]interface{}, error)
 }
 
 type FoxxDeploymentOptions struct {

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -69,6 +69,14 @@ type ClientFoxxService interface {
 	// in the response warnings.
 	// The caller is responsible for validating allowed keys before calling this method.
 	ReplaceFoxxServiceConfiguration(ctx context.Context, dbName string, mount *string, opt map[string]interface{}) (map[string]interface{}, error)
+
+	// GetFoxxServiceDependencies retrieves the configured dependencies for a specific Foxx service.
+	// Returns:
+	// A map where each key is a dependency name and the value is an object containing:
+	// 	* title: Human-readable title of the dependency
+	//  * mount: Current mount path of the dependency service (if set)
+	// An error if the request fails or the mount is missing.
+	GetFoxxServiceDependencies(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error)
 }
 
 type FoxxDeploymentOptions struct {

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -59,6 +59,11 @@ type ClientFoxxService interface {
 	// The mount parameter must not be nil or empty.
 	// Returns a map containing the current configuration key-value pairs.
 	GetFoxxServiceConfiguration(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error)
+	// UpdateFoxxServiceConfiguration updates the configuration of a specific Foxx service.
+	// If the Foxx service does not allow a particular configuration key, it will appear
+	// in the response warnings.
+	// The caller is responsible for validating allowed keys before calling this method.
+	UpdateFoxxServiceConfiguration(ctx context.Context, dbName string, mount *string, opt map[string]interface{}) (map[string]interface{}, error)
 }
 
 type FoxxDeploymentOptions struct {

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -102,6 +102,9 @@ type ClientFoxxService interface {
 	DisableDevelopmentMode(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error)
 	// GetFoxxServiceReadme retrieves the README file for a specific Foxx service.
 	GetFoxxServiceReadme(ctx context.Context, dbName string, mount *string) ([]byte, error)
+	// GetFoxxServiceSwagger retrieves the Swagger specification
+	// for a specific Foxx service mounted in the given database.
+	GetFoxxServiceSwagger(ctx context.Context, dbName string, mount *string) (SwaggerResponse, error)
 }
 
 type FoxxDeploymentOptions struct {
@@ -273,4 +276,30 @@ type FoxxTestOptions struct {
 	Reporter  *string `json:"reporter,omitempty"`
 	Idiomatic *bool   `json:"idiomatic,omitempty"`
 	Filter    *string `json:"filter,omitempty"`
+}
+
+// SwaggerInfo contains general metadata about the API, typically displayed
+// in tools like Swagger UI.
+type SwaggerInfo struct {
+	// Title is the title of the API.
+	Title *string `json:"title,omitempty"`
+	// Description provides a short description of the API.
+	Description *string `json:"description,omitempty"`
+	// Version specifies the version of the API.
+	Version *string `json:"version,omitempty"`
+	// License provides licensing information for the API.
+	License map[string]interface{} `json:"license,omitempty"`
+}
+
+// SwaggerResponse represents the root object of a Swagger (OpenAPI 2.0) specification.
+// It contains metadata, versioning information, available API paths, and additional details.
+type SwaggerResponse struct {
+	// Swagger specifies the Swagger specification version (e.g., "2.0").
+	Swagger *string `json:"swagger,omitempty"`
+	// BasePath defines the base path on which the API is served, relative to the host.
+	BasePath *string `json:"basePath,omitempty"`
+	// Paths holds the available endpoints and their supported operations.
+	Paths map[string]interface{} `json:"paths,omitempty"`
+	// Info provides metadata about the API, such as title, version, and license.
+	Info *SwaggerInfo `json:"info,omitempty"`
 }

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -54,6 +54,8 @@ type ClientFoxxService interface {
 	// at the specified mount path, retaining the existing service’s configuration and dependencies.
 	// This should be used only when upgrading to a newer or equivalent version of the same service.
 	UpgradeFoxxService(ctx context.Context, dbName string, zipFile string, opts *FoxxDeploymentOptions) error
+
+	GetFoxxServiceConfiguration(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error)
 }
 
 type FoxxDeploymentOptions struct {

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -108,6 +108,10 @@ type ClientFoxxService interface {
 	// CommitFoxxService commits the local Foxx service state of the Coordinator
 	// to the database. This can resolve service conflicts between Coordinators.
 	CommitFoxxService(ctx context.Context, dbName string, replace *bool) error
+	// DownloadFoxxServiceBundle downloads a zip bundle of the Foxx service directory
+	// from the specified database and mount point.
+	// Note: The response is the raw zip data (binary).
+	DownloadFoxxServiceBundle(ctx context.Context, dbName string, mount *string) ([]byte, error)
 }
 
 type FoxxDeploymentOptions struct {

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -91,6 +91,15 @@ type ClientFoxxService interface {
 	GetFoxxServiceScripts(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error)
 	// RunFoxxServiceScript executes a specific script associated with a Foxx service.
 	RunFoxxServiceScript(ctx context.Context, dbName string, name string, mount *string, body map[string]interface{}) (map[string]interface{}, error)
+	// RunFoxxServiceTests executes the test suite of a specific Foxx service
+	// deployed in an ArangoDB database.
+	RunFoxxServiceTests(ctx context.Context, dbName string, opt FoxxTestOptions) (map[string]interface{}, error)
+	// EnableDevelopmentMode enables the development mode for a specific Foxx service.
+	// Development mode causes the Foxx service to be reloaded from the filesystem and its setup
+	// script (if present) to be re-executed every time the service handles a request.
+	EnableDevelopmentMode(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error)
+	// DisableDevelopmentMode disables the development mode for a specific Foxx service.
+	DisableDevelopmentMode(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error)
 }
 
 type FoxxDeploymentOptions struct {
@@ -255,4 +264,11 @@ type FoxxServiceObject struct {
 
 	// Options contains optional runtime options defined for the service.
 	Options map[string]interface{} `json:"options,omitempty"`
+}
+
+type FoxxTestOptions struct {
+	FoxxDeploymentOptions
+	Reporter  *string `json:"reporter,omitempty"`
+	Idiomatic *bool   `json:"idiomatic,omitempty"`
+	Filter    *string `json:"filter,omitempty"`
 }

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -82,6 +82,11 @@ type ClientFoxxService interface {
 	// in the "warnings" field of the response.
 	// The caller is responsible for ensuring that only allowed dependency keys are provided.
 	UpdateFoxxServiceDependencies(ctx context.Context, dbName string, mount *string, opt map[string]interface{}) (map[string]interface{}, error)
+	// ReplaceFoxxServiceDependencies replaces the given Foxx service's dependencies entirely.
+	// If the Foxx service does not allow a particular dependency key, it will appear
+	// in the "warnings" field of the response.
+	// The caller is responsible for validating allowed keys before calling this method.
+	ReplaceFoxxServiceDependencies(ctx context.Context, dbName string, mount *string, opt map[string]interface{}) (map[string]interface{}, error)
 }
 
 type FoxxDeploymentOptions struct {

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -47,9 +47,13 @@ type ClientFoxxService interface {
 	// The returned FoxxServiceObject contains the full metadata and configuration details
 	// for the specified service.
 	GetInstalledFoxxService(ctx context.Context, dbName string, mount *string) (FoxxServiceObject, error)
-	//ReplaceAFoxxService removes the service at the given mount path from the database and file system
-	//installs the given new service at the same mount path.
-	ReplaceAFoxxService(ctx context.Context, dbName string, zipFile string, opts *FoxxDeploymentOptions) error
+	// ReplaceFoxxService removes the service at the given mount path from the database and file system
+	// and installs the given new service at the same mount path.
+	ReplaceFoxxService(ctx context.Context, dbName string, zipFile string, opts *FoxxDeploymentOptions) error
+	// UpgradeFoxxService installs the given new service on top of the service currently installed
+	// at the specified mount path, retaining the existing service’s configuration and dependencies.
+	// This should be used only when upgrading to a newer or equivalent version of the same service.
+	UpgradeFoxxService(ctx context.Context, dbName string, zipFile string, opts *FoxxDeploymentOptions) error
 }
 
 type FoxxDeploymentOptions struct {

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -105,6 +105,9 @@ type ClientFoxxService interface {
 	// GetFoxxServiceSwagger retrieves the Swagger specification
 	// for a specific Foxx service mounted in the given database.
 	GetFoxxServiceSwagger(ctx context.Context, dbName string, mount *string) (SwaggerResponse, error)
+	// CommitFoxxService commits the local Foxx service state of the Coordinator
+	// to the database. This can resolve service conflicts between Coordinators.
+	CommitFoxxService(ctx context.Context, dbName string, replace *bool) error
 }
 
 type FoxxDeploymentOptions struct {

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -33,7 +33,7 @@ type ClientFoxx interface {
 
 type ClientFoxxService interface {
 	// InstallFoxxService installs a new service at a given mount path.
-	InstallFoxxService(ctx context.Context, dbName string, zipFile string, options *FoxxCreateOptions) error
+	InstallFoxxService(ctx context.Context, dbName string, zipFile string, options *FoxxDeploymentOptions) error
 	// UninstallFoxxService uninstalls service at a given mount path.
 	UninstallFoxxService(ctx context.Context, dbName string, options *FoxxDeleteOptions) error
 	// ListInstalledFoxxServices retrieves the list of Foxx services installed in the specified database.
@@ -47,9 +47,12 @@ type ClientFoxxService interface {
 	// The returned FoxxServiceObject contains the full metadata and configuration details
 	// for the specified service.
 	GetInstalledFoxxService(ctx context.Context, dbName string, mount *string) (FoxxServiceObject, error)
+	//ReplaceAFoxxService removes the service at the given mount path from the database and file system
+	//installs the given new service at the same mount path.
+	ReplaceAFoxxService(ctx context.Context, dbName string, zipFile string, opts *FoxxDeploymentOptions) error
 }
 
-type FoxxCreateOptions struct {
+type FoxxDeploymentOptions struct {
 	Mount *string
 }
 
@@ -59,15 +62,15 @@ type FoxxDeleteOptions struct {
 }
 
 // ImportDocumentRequest holds Query parameters for /import.
-type InstallFoxxServiceRequest struct {
-	FoxxCreateOptions `json:",inline"`
+type DeployFoxxServiceRequest struct {
+	FoxxDeploymentOptions `json:",inline"`
 }
 
 type UninstallFoxxServiceRequest struct {
 	FoxxDeleteOptions `json:",inline"`
 }
 
-func (c *InstallFoxxServiceRequest) modifyRequest(r connection.Request) error {
+func (c *DeployFoxxServiceRequest) modifyRequest(r connection.Request) error {
 	if c == nil {
 		return nil
 	}

--- a/v2/arangodb/client_foxx.go
+++ b/v2/arangodb/client_foxx.go
@@ -100,6 +100,8 @@ type ClientFoxxService interface {
 	EnableDevelopmentMode(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error)
 	// DisableDevelopmentMode disables the development mode for a specific Foxx service.
 	DisableDevelopmentMode(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error)
+	// GetFoxxServiceReadme retrieves the README file for a specific Foxx service.
+	GetFoxxServiceReadme(ctx context.Context, dbName string, mount *string) ([]byte, error)
 }
 
 type FoxxDeploymentOptions struct {

--- a/v2/arangodb/client_foxx_impl.go
+++ b/v2/arangodb/client_foxx_impl.go
@@ -83,6 +83,10 @@ func (c *clientFoxx) InstallFoxxService(ctx context.Context, dbName string, zipF
 		request.FoxxDeploymentOptions = *opts
 	}
 
+	if _, err := os.Stat(zipFile); os.IsNotExist(err) {
+		return errors.WithStack(err)
+	}
+
 	bytes, err := os.ReadFile(zipFile)
 	if err != nil {
 		return errors.WithStack(err)
@@ -216,6 +220,10 @@ func (c *clientFoxx) ReplaceFoxxService(ctx context.Context, dbName string, zipF
 		request.FoxxDeploymentOptions = *opts
 	}
 
+	if _, err := os.Stat(zipFile); os.IsNotExist(err) {
+		return errors.WithStack(err)
+	}
+
 	bytes, err := os.ReadFile(zipFile)
 	if err != nil {
 		return errors.WithStack(err)
@@ -245,6 +253,10 @@ func (c *clientFoxx) UpgradeFoxxService(ctx context.Context, dbName string, zipF
 	request := &DeployFoxxServiceRequest{}
 	if opts != nil {
 		request.FoxxDeploymentOptions = *opts
+	}
+
+	if _, err := os.Stat(zipFile); os.IsNotExist(err) {
+		return errors.WithStack(err)
 	}
 
 	bytes, err := os.ReadFile(zipFile)

--- a/v2/arangodb/client_foxx_impl.go
+++ b/v2/arangodb/client_foxx_impl.go
@@ -64,7 +64,6 @@ func (c *clientFoxx) url(dbName string, pathSegments []string, queryParams map[s
 			default:
 				// skip unsupported types or handle as needed
 			}
-			fmt.Printf("Valueeeeeee of Q is %+v", q)
 		}
 		base = fmt.Sprintf("%s?%s", base, q.Encode())
 	}
@@ -263,5 +262,51 @@ func (c *clientFoxx) UpgradeFoxxService(ctx context.Context, dbName string, zipF
 		return nil
 	default:
 		return response.AsArangoErrorWithCode(code)
+	}
+}
+
+// GetFoxxServiceConfiguration retrieves the configuration for a specific Foxx service.
+func (c *clientFoxx) GetFoxxServiceConfiguration(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error) {
+	if mount == nil || *mount == "" {
+		return nil, RequiredFieldError("mount")
+	}
+
+	urlEndpoint := c.url(dbName, []string{"configuration"}, map[string]interface{}{
+		"mount": *mount,
+	})
+
+	var rawResult json.RawMessage
+
+	resp, err := connection.CallGet(ctx, c.client.connection, urlEndpoint, &rawResult)
+	if err != nil {
+		return nil, err
+	}
+
+	switch code := resp.Code(); code {
+	case http.StatusOK:
+		// Try to unmarshal as array first
+		var result map[string]interface{}
+		if err := json.Unmarshal(rawResult, &result); err == nil {
+			return result, nil
+		}
+
+		// If array unmarshaling fails, try as object with result field
+		var objResult struct {
+			Result map[string]interface{} `json:"result"`
+			Error  bool                   `json:"error"`
+			Code   int                    `json:"code"`
+		}
+
+		if err := json.Unmarshal(rawResult, &objResult); err == nil {
+			if objResult.Error {
+				return nil, fmt.Errorf("ArangoDB API error: code %d", objResult.Code)
+			}
+			return objResult.Result, nil
+		}
+
+		// If both fail, return the unmarshal error
+		return nil, fmt.Errorf("cannot unmarshal response into []FoxxServiceListItem or object with result field: %s", string(rawResult))
+	default:
+		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
 	}
 }

--- a/v2/arangodb/client_foxx_impl.go
+++ b/v2/arangodb/client_foxx_impl.go
@@ -547,3 +547,34 @@ func (c *clientFoxx) DisableDevelopmentMode(ctx context.Context, dbName string, 
 		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
 	}
 }
+
+func (c *clientFoxx) GetFoxxServiceReadme(ctx context.Context, dbName string, mount *string) ([]byte, error) {
+	if mount == nil || *mount == "" {
+		return nil, RequiredFieldError("mount")
+	}
+
+	urlEndpoint := c.url(dbName, []string{"readme"}, map[string]interface{}{
+		"mount": *mount,
+	})
+
+	// Create request
+	req, err := c.client.Connection().NewRequest(http.MethodGet, urlEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	var data []byte
+	// Call Do with nil result (we'll handle body manually)
+	resp, err := c.client.Connection().Do(ctx, req, &data, http.StatusOK, http.StatusNoContent)
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.Code() {
+	case http.StatusOK:
+		return data, nil
+	case http.StatusNoContent:
+		return nil, nil
+	default:
+		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(resp.Code())
+	}
+}

--- a/v2/arangodb/client_foxx_impl.go
+++ b/v2/arangodb/client_foxx_impl.go
@@ -347,3 +347,7 @@ func (c *clientFoxx) GetFoxxServiceDependencies(ctx context.Context, dbName stri
 func (c *clientFoxx) UpdateFoxxServiceDependencies(ctx context.Context, dbName string, mount *string, opt map[string]interface{}) (map[string]interface{}, error) {
 	return c.callFoxxServiceAPI(ctx, dbName, mount, "dependencies", http.MethodPatch, opt)
 }
+
+func (c *clientFoxx) ReplaceFoxxServiceDependencies(ctx context.Context, dbName string, mount *string, opt map[string]interface{}) (map[string]interface{}, error) {
+	return c.callFoxxServiceAPI(ctx, dbName, mount, "dependencies", http.MethodPut, opt)
+}

--- a/v2/arangodb/client_foxx_impl.go
+++ b/v2/arangodb/client_foxx_impl.go
@@ -400,3 +400,49 @@ func (c *clientFoxx) ReplaceFoxxServiceConfiguration(ctx context.Context, dbName
 		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
 	}
 }
+
+// GetFoxxServiceConfiguration retrieves the configuration for a specific Foxx service.
+func (c *clientFoxx) GetFoxxServiceDependencies(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error) {
+	if mount == nil || *mount == "" {
+		return nil, RequiredFieldError("mount")
+	}
+
+	urlEndpoint := c.url(dbName, []string{"dependencies"}, map[string]interface{}{
+		"mount": *mount,
+	})
+
+	var rawResult json.RawMessage
+
+	resp, err := connection.CallGet(ctx, c.client.connection, urlEndpoint, &rawResult)
+	if err != nil {
+		return nil, err
+	}
+
+	switch code := resp.Code(); code {
+	case http.StatusOK:
+		// Try to unmarshal as array first
+		var result map[string]interface{}
+		if err := json.Unmarshal(rawResult, &result); err == nil {
+			return result, nil
+		}
+
+		// If array unmarshaling fails, try as object with result field
+		var objResult struct {
+			Result map[string]interface{} `json:"result"`
+			Error  bool                   `json:"error"`
+			Code   int                    `json:"code"`
+		}
+
+		if err := json.Unmarshal(rawResult, &objResult); err == nil {
+			if objResult.Error {
+				return nil, fmt.Errorf("ArangoDB API error: code %d", objResult.Code)
+			}
+			return objResult.Result, nil
+		}
+
+		// If both fail, return the unmarshal error
+		return nil, fmt.Errorf("cannot unmarshal response into []FoxxServiceListItem or object with result field: %s", string(rawResult))
+	default:
+		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
+	}
+}

--- a/v2/arangodb/client_foxx_impl.go
+++ b/v2/arangodb/client_foxx_impl.go
@@ -400,3 +400,150 @@ func (c *clientFoxx) RunFoxxServiceScript(ctx context.Context, dbName string, na
 		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
 	}
 }
+
+func (c *clientFoxx) RunFoxxServiceTests(ctx context.Context, dbName string, opt FoxxTestOptions) (map[string]interface{}, error) {
+
+	if opt.Mount == nil || *opt.Mount == "" {
+		return nil, RequiredFieldError("mount")
+	}
+
+	queryParams := map[string]interface{}{
+		"mount": *opt.Mount,
+	}
+
+	if opt.Reporter != nil {
+		queryParams["reporter"] = *opt.Reporter
+	}
+	if opt.Idiomatic != nil {
+		queryParams["idiomatic"] = *opt.Idiomatic
+	}
+	if opt.Filter != nil {
+		queryParams["filter"] = *opt.Filter
+	}
+
+	urlEndpoint := c.url(dbName, []string{"tests"}, queryParams)
+
+	var rawResult json.RawMessage
+	resp, err := connection.CallPost(ctx, c.client.connection, urlEndpoint, &rawResult, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	switch code := resp.Code(); code {
+	case http.StatusOK:
+		var result map[string]interface{}
+		if err := json.Unmarshal(rawResult, &result); err == nil {
+			return result, nil
+		}
+
+		var objResult struct {
+			Result map[string]interface{} `json:"result"`
+			Error  bool                   `json:"error"`
+			Code   int                    `json:"code"`
+		}
+		if err := json.Unmarshal(rawResult, &objResult); err == nil {
+			if objResult.Error {
+				return nil, fmt.Errorf("ArangoDB API error: code %d", objResult.Code)
+			}
+			return objResult.Result, nil
+		}
+
+		return nil, fmt.Errorf(
+			"cannot unmarshal response into map or object with result field: %s",
+			string(rawResult),
+		)
+	default:
+		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
+	}
+}
+
+func (c *clientFoxx) EnableDevelopmentMode(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error) {
+
+	if mount == nil || *mount == "" {
+		return nil, RequiredFieldError("mount")
+	}
+
+	urlEndpoint := c.url(dbName, []string{"development"}, map[string]interface{}{
+		"mount": *mount,
+	})
+
+	var rawResult json.RawMessage
+	resp, err := connection.CallPost(ctx, c.client.connection, urlEndpoint, &rawResult, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	switch code := resp.Code(); code {
+	case http.StatusOK:
+		var result map[string]interface{}
+		if err := json.Unmarshal(rawResult, &result); err == nil {
+			return result, nil
+		}
+
+		var objResult struct {
+			Result map[string]interface{} `json:"result"`
+			Error  bool                   `json:"error"`
+			Code   int                    `json:"code"`
+		}
+		if err := json.Unmarshal(rawResult, &objResult); err == nil {
+			if objResult.Error {
+				return nil, fmt.Errorf("ArangoDB API error: code %d", objResult.Code)
+			}
+			return objResult.Result, nil
+		}
+
+		return nil, fmt.Errorf(
+			"cannot unmarshal response into map or object with result field: %s",
+			string(rawResult),
+		)
+	default:
+		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
+	}
+}
+
+func (c *clientFoxx) DisableDevelopmentMode(ctx context.Context, dbName string, mount *string) (map[string]interface{}, error) {
+
+	if mount == nil || *mount == "" {
+		return nil, RequiredFieldError("mount")
+	}
+
+	urlEndpoint := c.url(dbName, []string{"development"}, map[string]interface{}{
+		"mount": *mount,
+	})
+
+	var rawResult json.RawMessage
+	resp, err := connection.CallDelete(ctx, c.client.connection, urlEndpoint, &rawResult)
+
+	if err != nil {
+		return nil, err
+	}
+
+	switch code := resp.Code(); code {
+	case http.StatusOK:
+		var result map[string]interface{}
+		if err := json.Unmarshal(rawResult, &result); err == nil {
+			return result, nil
+		}
+
+		var objResult struct {
+			Result map[string]interface{} `json:"result"`
+			Error  bool                   `json:"error"`
+			Code   int                    `json:"code"`
+		}
+		if err := json.Unmarshal(rawResult, &objResult); err == nil {
+			if objResult.Error {
+				return nil, fmt.Errorf("ArangoDB API error: code %d", objResult.Code)
+			}
+			return objResult.Result, nil
+		}
+
+		return nil, fmt.Errorf(
+			"cannot unmarshal response into map or object with result field: %s",
+			string(rawResult),
+		)
+	default:
+		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
+	}
+}

--- a/v2/arangodb/client_foxx_impl.go
+++ b/v2/arangodb/client_foxx_impl.go
@@ -119,7 +119,7 @@ func (c *clientFoxx) UninstallFoxxService(ctx context.Context, dbName string, op
 	if opts != nil {
 		request.FoxxDeleteOptions = *opts
 	}
-	// UninstallFoxxService removes a Foxx service using DELETE as per ArangoDB API
+	// per ArangoDB docs (Foxx uninstall → DELETE /_db/{db}/_api/foxx/service).
 	resp, err := connection.CallDelete(ctx, c.client.connection, url, &response, request.modifyRequest)
 	if err != nil {
 		return errors.WithStack(err)

--- a/v2/arangodb/client_foxx_impl.go
+++ b/v2/arangodb/client_foxx_impl.go
@@ -98,7 +98,7 @@ func (c *clientFoxx) InstallFoxxService(ctx context.Context, dbName string, zipF
 	}
 
 	switch code := resp.Code(); code {
-	case http.StatusCreated:
+	case http.StatusCreated: // Foxx install returns 201 Created as per ArangoDB API
 		return nil
 	default:
 		return response.AsArangoErrorWithCode(code)
@@ -120,6 +120,7 @@ func (c *clientFoxx) UninstallFoxxService(ctx context.Context, dbName string, op
 		request.FoxxDeleteOptions = *opts
 	}
 
+	// UninstallFoxxService removes a Foxx service using DELETE as per ArangoDB API
 	resp, err := connection.CallDelete(ctx, c.client.connection, url, &response, request.modifyRequest)
 	if err != nil {
 		return errors.WithStack(err)

--- a/v2/arangodb/client_foxx_impl.go
+++ b/v2/arangodb/client_foxx_impl.go
@@ -578,3 +578,30 @@ func (c *clientFoxx) GetFoxxServiceReadme(ctx context.Context, dbName string, mo
 		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(resp.Code())
 	}
 }
+
+func (c *clientFoxx) GetFoxxServiceSwagger(ctx context.Context, dbName string, mount *string) (SwaggerResponse, error) {
+	if mount == nil || *mount == "" {
+		return SwaggerResponse{}, RequiredFieldError("mount")
+	}
+
+	urlEndpoint := c.url(dbName, []string{"swagger"}, map[string]interface{}{
+		"mount": *mount,
+	})
+
+	var result struct {
+		shared.ResponseStruct `json:",inline"`
+		SwaggerResponse       `json:",inline"`
+	}
+
+	resp, err := connection.CallGet(ctx, c.client.connection, urlEndpoint, &result)
+	if err != nil {
+		return SwaggerResponse{}, err
+	}
+
+	switch code := resp.Code(); code {
+	case http.StatusOK:
+		return result.SwaggerResponse, nil
+	default:
+		return SwaggerResponse{}, result.AsArangoErrorWithCode(code)
+	}
+}

--- a/v2/arangodb/client_foxx_impl.go
+++ b/v2/arangodb/client_foxx_impl.go
@@ -605,3 +605,28 @@ func (c *clientFoxx) GetFoxxServiceSwagger(ctx context.Context, dbName string, m
 		return SwaggerResponse{}, result.AsArangoErrorWithCode(code)
 	}
 }
+
+func (c *clientFoxx) CommitFoxxService(ctx context.Context, dbName string, replace *bool) error {
+	queryParams := make(map[string]interface{})
+	if replace != nil {
+		queryParams["replace"] = *replace
+	}
+
+	urlEndpoint := c.url(dbName, []string{"commit"}, queryParams)
+
+	var result struct {
+		shared.ResponseStruct `json:",inline"`
+	}
+
+	resp, err := connection.CallPost(ctx, c.client.connection, urlEndpoint, &result, nil)
+	if err != nil {
+		return err
+	}
+
+	switch code := resp.Code(); code {
+	case http.StatusNoContent: // 204 expected
+		return nil
+	default:
+		return result.AsArangoErrorWithCode(code)
+	}
+}

--- a/v2/arangodb/client_foxx_impl.go
+++ b/v2/arangodb/client_foxx_impl.go
@@ -119,7 +119,6 @@ func (c *clientFoxx) UninstallFoxxService(ctx context.Context, dbName string, op
 	if opts != nil {
 		request.FoxxDeleteOptions = *opts
 	}
-
 	// UninstallFoxxService removes a Foxx service using DELETE as per ArangoDB API
 	resp, err := connection.CallDelete(ctx, c.client.connection, url, &response, request.modifyRequest)
 	if err != nil {

--- a/v2/arangodb/client_foxx_impl.go
+++ b/v2/arangodb/client_foxx_impl.go
@@ -355,3 +355,48 @@ func (c *clientFoxx) UpdateFoxxServiceConfiguration(ctx context.Context, dbName 
 		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
 	}
 }
+
+func (c *clientFoxx) ReplaceFoxxServiceConfiguration(ctx context.Context, dbName string, mount *string, opt map[string]interface{}) (map[string]interface{}, error) {
+	if mount == nil || *mount == "" {
+		return nil, RequiredFieldError("mount")
+	}
+
+	urlEndpoint := c.url(dbName, []string{"configuration"}, map[string]interface{}{
+		"mount": *mount,
+	})
+
+	var rawResult json.RawMessage
+
+	resp, err := connection.CallPut(ctx, c.client.connection, urlEndpoint, &rawResult, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	switch code := resp.Code(); code {
+	case http.StatusOK:
+		// Try to unmarshal as array first
+		var result map[string]interface{}
+		if err := json.Unmarshal(rawResult, &result); err == nil {
+			return result, nil
+		}
+
+		// If array unmarshaling fails, try as object with result field
+		var objResult struct {
+			Result map[string]interface{} `json:"result"`
+			Error  bool                   `json:"error"`
+			Code   int                    `json:"code"`
+		}
+
+		if err := json.Unmarshal(rawResult, &objResult); err == nil {
+			if objResult.Error {
+				return nil, fmt.Errorf("ArangoDB API error: code %d", objResult.Code)
+			}
+			return objResult.Result, nil
+		}
+
+		// If both fail, return the unmarshal error
+		return nil, fmt.Errorf("cannot unmarshal response into []FoxxServiceListItem or object with result field: %s", string(rawResult))
+	default:
+		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
+	}
+}

--- a/v2/arangodb/client_foxx_impl.go
+++ b/v2/arangodb/client_foxx_impl.go
@@ -119,7 +119,7 @@ func (c *clientFoxx) UninstallFoxxService(ctx context.Context, dbName string, op
 	if opts != nil {
 		request.FoxxDeleteOptions = *opts
 	}
-	// per ArangoDB docs (Foxx uninstall → DELETE /_db/{db}/_api/foxx/service).
+	// As per ArangoDB docs (Foxx uninstall → DELETE /_db/{db}/_api/foxx/service).
 	resp, err := connection.CallDelete(ctx, c.client.connection, url, &response, request.modifyRequest)
 	if err != nil {
 		return errors.WithStack(err)

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -267,6 +267,20 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 				require.NotNil(t, resp)
 			})
 		})
+
+		// Commit Foxx Service
+		t.Run("Commit Foxx Service ", func(t *testing.T) {
+			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {
+				role, err := client.ServerRole(ctx)
+				require.NoError(t, err)
+				if role != "Single" {
+					timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
+					err := client.CommitFoxxService(timeoutCtx, db.Name(), utils.NewType(false))
+					cancel()
+					require.NoError(t, err)
+				}
+			})
+		})
 	})
 }
 

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -138,6 +138,17 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 			})
 		})
 
+		// Fetch Foxx Service Dependencies
+		t.Run("Fetch Foxx Service Dependencies", func(t *testing.T) {
+			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {
+				timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
+				resp, err := client.GetFoxxServiceDependencies(timeoutCtx, db.Name(), options.Mount)
+				cancel()
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+			})
+		})
+
 		// UninstallFoxxService
 		t.Run("Uninstall Foxx service", func(t *testing.T) {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -201,6 +201,48 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 				require.Error(t, err)
 			})
 		})
+		// Test Foxx Service
+		t.Run("Test Foxx Service", func(t *testing.T) {
+			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {
+				timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
+				resp, err := client.RunFoxxServiceTests(timeoutCtx, db.Name(), arangodb.FoxxTestOptions{
+					FoxxDeploymentOptions: arangodb.FoxxDeploymentOptions{
+						Mount: utils.NewType("/" + mountName),
+					},
+				})
+				cancel()
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+			})
+		})
+
+		// Enable Development Mode For Foxx Service
+		t.Run("Enable Development Mode For Foxx Service", func(t *testing.T) {
+			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {
+				timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
+				// if getTestMode() == string(testModeCluster) {
+				// 	t.Skipf("It's a cluster mode")
+				// }
+				resp, err := client.EnableDevelopmentMode(timeoutCtx, db.Name(), options.Mount)
+				cancel()
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+			})
+		})
+
+		// Disable Development Mode For Foxx Service
+		t.Run("Disable Development Mode For Foxx Service", func(t *testing.T) {
+			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {
+				timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
+				// if getTestMode() == string(testModeCluster) {
+				// 	t.Skipf("It's a cluster mode")
+				// }
+				resp, err := client.DisableDevelopmentMode(timeoutCtx, db.Name(), options.Mount)
+				cancel()
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+			})
+		})
 
 		// UninstallFoxxService
 		t.Run("Uninstall Foxx service", func(t *testing.T) {

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -44,7 +44,8 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 		}
 
 		// /tmp/resources/ directory is provided by .travis.yml
-		zipFilePath := "/tmp/resources/itzpapalotl-v1.2.0.zip"
+		// zipFilePath := "/tmp/resources/itzpapalotl-v1.2.0.zip"
+		zipFilePath := os.Getenv("HOME") + "/resources/itzpapalotl-v1.2.0.zip"
 		if _, err := os.Stat(zipFilePath); os.IsNotExist(err) {
 			// Test works only via travis pipeline unless the above file exists locally
 			t.Skipf("file %s does not exist", zipFilePath)

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -162,6 +162,21 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 			})
 		})
 
+		// Replace Foxx Service Dependencies
+		t.Run("Replace Foxx Service Dependencies", func(t *testing.T) {
+			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {
+				timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
+				resp, err := client.ReplaceFoxxServiceDependencies(timeoutCtx, db.Name(), options.Mount, map[string]interface{}{
+					"title":       "Auth Service",
+					"description": "Service that handles authentication",
+					"mount":       "/auth-v2",
+				})
+				cancel()
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+			})
+		})
+
 		// UninstallFoxxService
 		t.Run("Uninstall Foxx service", func(t *testing.T) {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -177,6 +177,31 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 			})
 		})
 
+		// Fetch Foxx Service Scripts
+		t.Run("Fetch Foxx Service Scripts", func(t *testing.T) {
+			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {
+				timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
+				resp, err := client.GetFoxxServiceScripts(timeoutCtx, db.Name(), options.Mount)
+				cancel()
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+			})
+		})
+
+		// Run Foxx Service Script
+		t.Run("Run Foxx Service Script", func(t *testing.T) {
+			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {
+				scriptName := "cleanupData"
+				timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
+				_, err := client.RunFoxxServiceScript(timeoutCtx, db.Name(), scriptName, options.Mount,
+					map[string]interface{}{
+						"cleanupData": "Cleanup Old Data",
+					})
+				cancel()
+				require.Error(t, err)
+			})
+		})
+
 		// UninstallFoxxService
 		t.Run("Uninstall Foxx service", func(t *testing.T) {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -256,6 +256,17 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 				require.NotNil(t, resp)
 			})
 		})
+
+		// Get Foxx Service Swagger
+		t.Run("Get Foxx Service Swagger ", func(t *testing.T) {
+			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {
+				timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
+				resp, err := client.GetFoxxServiceSwagger(timeoutCtx, db.Name(), options.Mount)
+				cancel()
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+			})
+		})
 	})
 }
 

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -124,6 +124,20 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 			})
 		})
 
+		// Replace Foxx service Configuration
+		t.Run("Replace Foxx service Configuration", func(t *testing.T) {
+			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {
+				timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
+				resp, err := client.ReplaceFoxxServiceConfiguration(timeoutCtx, db.Name(), options.Mount, map[string]interface{}{
+					"apiKey":   "xyz987",
+					"maxItems": 100,
+				})
+				cancel()
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+			})
+		})
+
 		// UninstallFoxxService
 		t.Run("Uninstall Foxx service", func(t *testing.T) {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -51,7 +51,7 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 
 				timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
 				mountName := "test"
-				options := &arangodb.FoxxCreateOptions{
+				options := &arangodb.FoxxDeploymentOptions{
 					Mount: utils.NewType[string]("/" + mountName),
 				}
 				err = client.InstallFoxxService(timeoutCtx, db.Name(), zipFilePath, options)
@@ -70,6 +70,11 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 				require.Equal(t, true, ok)
 				require.NotEmpty(t, value)
 				cancel()
+
+				timeoutCtx, cancel = context.WithTimeout(context.Background(), time.Minute*30)
+				err = client.ReplaceAFoxxService(timeoutCtx, db.Name(), zipFilePath, options)
+				cancel()
+				require.NoError(t, err)
 
 				timeoutCtx, cancel = context.WithTimeout(context.Background(), time.Second*30)
 				deleteOptions := &arangodb.FoxxDeleteOptions{

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -23,7 +23,6 @@ package tests
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -45,22 +44,9 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 		}
 
 		// /tmp/resources/ directory is provided by .travis.yml
-		zipFilePath1 := os.Getenv("TEST_RESOURCES")
-		if zipFilePath1 == "" {
-			zipFilePath1 = "/tmp/resources" // fallback for local testing
-		}
-
-		if info, err := os.Stat(zipFilePath1); err != nil {
-			if os.IsNotExist(err) {
-				t.Skipf("path %s does not exist", zipFilePath1)
-			}
-			t.Fatalf("error checking path %s: %v", zipFilePath1, err)
-		} else if !info.IsDir() {
-			t.Skipf("path %s is not directory", zipFilePath1)
-		}
-
-		zipFilePath := filepath.Join(zipFilePath1, "itzpapalotl-v1.2.0.zip")
+		zipFilePath := "/tmp/resources/itzpapalotl-v1.2.0.zip"
 		if _, err := os.Stat(zipFilePath); os.IsNotExist(err) {
+			// Test works only via travis pipeline unless the above file exists locally
 			t.Skipf("file %s does not exist", zipFilePath)
 		}
 		mountName := "test"

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -44,6 +44,16 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 		}
 
 		// /tmp/resources/ directory is provided by .travis.yml
+		zipFilePath1 := "/tmp/resources"
+		if info, err := os.Stat(zipFilePath1); err != nil {
+			if os.IsNotExist(err) {
+				t.Skipf("path %s does not exist", zipFilePath1)
+			}
+			t.Fatalf("error checking path %s: %v", zipFilePath1, err)
+		} else if !info.IsDir() {
+			t.Skipf("path %s is not a directory", zipFilePath1)
+		}
+
 		zipFilePath := "/tmp/resources/itzpapalotl-v1.2.0.zip"
 		if _, err := os.Stat(zipFilePath); os.IsNotExist(err) {
 			// Test works only via travis pipeline unless the above file exists locally

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -281,6 +281,17 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 				}
 			})
 		})
+
+		// Download Foxx Service Bundle
+		t.Run("Download Foxx Service Bundle ", func(t *testing.T) {
+			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {
+				timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
+				resp, err := client.DownloadFoxxServiceBundle(timeoutCtx, db.Name(), options.Mount)
+				cancel()
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+			})
+		})
 	})
 }
 

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -23,6 +23,7 @@ package tests
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -44,19 +45,22 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 		}
 
 		// /tmp/resources/ directory is provided by .travis.yml
-		zipFilePath1 := "/tmp/resources"
+		zipFilePath1 := os.Getenv("TEST_RESOURCES")
+		if zipFilePath1 == "" {
+			zipFilePath1 = "/tmp/resources" // fallback for local testing
+		}
+
 		if info, err := os.Stat(zipFilePath1); err != nil {
 			if os.IsNotExist(err) {
 				t.Skipf("path %s does not exist", zipFilePath1)
 			}
 			t.Fatalf("error checking path %s: %v", zipFilePath1, err)
 		} else if !info.IsDir() {
-			t.Skipf("path %s is not a directory", zipFilePath1)
+			t.Skipf("path %s is not directory", zipFilePath1)
 		}
 
-		zipFilePath := "/tmp/resources/itzpapalotl-v1.2.0.zip"
+		zipFilePath := filepath.Join(zipFilePath1, "itzpapalotl-v1.2.0.zip")
 		if _, err := os.Stat(zipFilePath); os.IsNotExist(err) {
-			// Test works only via travis pipeline unless the above file exists locally
 			t.Skipf("file %s does not exist", zipFilePath)
 		}
 		mountName := "test"

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -149,6 +149,19 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 			})
 		})
 
+		// Update Foxx Service Dependencies
+		t.Run("Update Foxx Service Dependencies", func(t *testing.T) {
+			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {
+				timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
+				resp, err := client.UpdateFoxxServiceDependencies(timeoutCtx, db.Name(), options.Mount, map[string]interface{}{
+					"title": "Auth Service",
+				})
+				cancel()
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+			})
+		})
+
 		// UninstallFoxxService
 		t.Run("Uninstall Foxx service", func(t *testing.T) {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -44,7 +44,7 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 		}
 
 		// /tmp/resources/ directory is provided by .travis.yml
-		zipFilePath := "tmp/resources/itzpapalotl-v1.2.0.zip"
+		zipFilePath := "/tmp/resources/itzpapalotl-v1.2.0.zip"
 		if _, err := os.Stat(zipFilePath); os.IsNotExist(err) {
 			// Test works only via travis pipeline unless the above file exists locally
 			t.Skipf("file %s does not exist", zipFilePath)

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -22,7 +22,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -127,8 +126,12 @@ func Test_GetInstalledFoxxService(t *testing.T) {
 		serviceDetails, err := client.GetInstalledFoxxService(ctx, db.Name(), &mount)
 		require.NoError(t, err)
 		require.NotEmpty(t, serviceDetails)
-		servicesJson, err := utils.ToJSONString(serviceDetails)
-		require.NoError(t, err)
-		fmt.Printf("serviceDetails after marshalling : %s", servicesJson)
+		require.NotNil(t, serviceDetails.Mount)
+		require.NotNil(t, serviceDetails.Name)
+		require.NotNil(t, serviceDetails.Version)
+		require.NotNil(t, serviceDetails.Development)
+		require.NotNil(t, serviceDetails.Path)
+		require.NotNil(t, serviceDetails.Legacy)
+		require.NotNil(t, serviceDetails.Manifest)
 	})
 }

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -22,6 +22,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -82,7 +83,7 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 	})
 }
 
-func Test_GetInstalledFoxxService(t *testing.T) {
+func Test_ListInstalledFoxxServices(t *testing.T) {
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		ctx := context.Background()
 		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -91,8 +92,8 @@ func Test_GetInstalledFoxxService(t *testing.T) {
 		db, err := client.GetDatabase(ctx, "_system", nil)
 		require.NoError(t, err)
 
-		excludeSystem := false
-		services, err := client.GetInstalledFoxxService(ctx, db.Name(), &excludeSystem)
+		// excludeSystem := false
+		services, err := client.ListInstalledFoxxServices(ctx, db.Name(), nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, services)
 		require.GreaterOrEqual(t, len(services), 0)
@@ -110,5 +111,24 @@ func Test_GetInstalledFoxxService(t *testing.T) {
 			require.NotNil(t, service.Provides)
 			require.NotNil(t, service.Legacy)
 		}
+	})
+}
+
+func Test_GetInstalledFoxxService(t *testing.T) {
+	Wrap(t, func(t *testing.T, client arangodb.Client) {
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		db, err := client.GetDatabase(ctx, "_system", nil)
+		require.NoError(t, err)
+
+		mount := "/_api/foxx"
+		serviceDetails, err := client.GetInstalledFoxxService(ctx, db.Name(), &mount)
+		require.NoError(t, err)
+		require.NotEmpty(t, serviceDetails)
+		servicesJson, err := utils.ToJSONString(serviceDetails)
+		require.NoError(t, err)
+		fmt.Printf("serviceDetails after marshalling : %s", servicesJson)
 	})
 }

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -81,3 +81,34 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 		})
 	})
 }
+
+func Test_GetInstalledFoxxService(t *testing.T) {
+	Wrap(t, func(t *testing.T, client arangodb.Client) {
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		db, err := client.GetDatabase(ctx, "_system", nil)
+		require.NoError(t, err)
+
+		excludeSystem := false
+		services, err := client.GetInstalledFoxxService(ctx, db.Name(), &excludeSystem)
+		require.NoError(t, err)
+		require.NotEmpty(t, services)
+		require.GreaterOrEqual(t, len(services), 0)
+
+		if len(services) == 0 {
+			t.Log("No Foxx services found.")
+			return
+		}
+
+		for _, service := range services {
+			require.NotEmpty(t, service.Mount)
+			require.NotEmpty(t, service.Name)
+			require.NotEmpty(t, service.Version)
+			require.NotNil(t, service.Development)
+			require.NotNil(t, service.Provides)
+			require.NotNil(t, service.Legacy)
+		}
+	})
+}

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -110,6 +110,20 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 			})
 		})
 
+		// Update Foxx service Configuration
+		t.Run("Update Foxx service Configuration", func(t *testing.T) {
+			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {
+				timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Minute*30)
+				resp, err := client.UpdateFoxxServiceConfiguration(timeoutCtx, db.Name(), options.Mount, map[string]interface{}{
+					"apiKey":   "abcdef",
+					"maxItems": 100,
+				})
+				cancel()
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+			})
+		})
+
 		// UninstallFoxxService
 		t.Run("Uninstall Foxx service", func(t *testing.T) {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, t testing.TB) {

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -67,7 +67,7 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 			Teardown: utils.NewType[bool](true),
 		})
 
-		// Try to fetch random name from installed foxx sercice
+		// Try to fetch random name from installed foxx service
 		timeoutCtx, cancel = context.WithTimeout(context.Background(), time.Second*30)
 		connection := client.Connection()
 		req, err := connection.NewRequest("GET", "_db/"+db.Name()+"/"+mountName+"/random")

--- a/v2/tests/foxx_test.go
+++ b/v2/tests/foxx_test.go
@@ -44,8 +44,7 @@ func Test_FoxxItzpapalotlService(t *testing.T) {
 		}
 
 		// /tmp/resources/ directory is provided by .travis.yml
-		// zipFilePath := "/tmp/resources/itzpapalotl-v1.2.0.zip"
-		zipFilePath := os.Getenv("HOME") + "/resources/itzpapalotl-v1.2.0.zip"
+		zipFilePath := "/tmp/resources/itzpapalotl-v1.2.0.zip"
 		if _, err := os.Stat(zipFilePath); os.IsNotExist(err) {
 			// Test works only via travis pipeline unless the above file exists locally
 			t.Skipf("file %s does not exist", zipFilePath)


### PR DESCRIPTION
This includes the following Foxx - related endpoints:
1.	GET - /_db/{database-name}/_api/foxx
2.	GET - /_db/{database-name}/_api/foxx/service
3.	DELETE - /_db/{database-name}/_api/foxx/service
4.	PUT - /_db/{database-name}/_api/foxx/service
5.	PATCH -	/_db/{database-name}/_api/foxx/service
6.	GET - /_db/{database-name}/_api/foxx/configuration
7.	PATCH -	/_db/{database-name}/_api/foxx/configuration
8.	PUT - /_db/{database-name}/_api/foxx/configuration
9.	GET - /_db/{database-name}/_api/foxx/dependencies
10.	PATCH -	/_db/{database-name}/_api/foxx/dependencies
11.	PUT - /_db/{database-name}/_api/foxx/dependencies
12.	GET - /_db/{database-name}/_api/foxx/scripts
13.	POST - /_db/{database-name}/_api/foxx/scripts/{name}
14.	POST - /_db/{database-name}/_api/foxx/tests
15.	POST - /_db/{database-name}/_api/foxx/development
16.	DELETE - /_db/{database-name}/_api/foxx/development
17.	GET - /_db/{database-name}/_api/foxx/readme
18.	GET - /_db/{database-name}/_api/foxx/swagger
19.	POST - /_db/{database-name}/_api/foxx/download
20.	POST - /_db/{database-name}/_api/foxx/commit