### PR TITLE
Feature/add mis endpoints in administration

### DIFF
--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
 - Add missing endpoints from replication to v2
 - Add missing endpoints from monitoring to v2
+- Add missing endpoints from administration to v2
 
 ## [2.1.5](https://github.com/arangodb/go-driver/tree/v2.1.5) (2025-08-31)
 - Add tasks endpoints to v2

--- a/v2/arangodb/client_admin.go
+++ b/v2/arangodb/client_admin.go
@@ -65,7 +65,7 @@ type ClientAdmin interface {
 
 	// ExecuteAdminScript executes JavaScript code on the server.
 	// Note: Requires ArangoDB to be started with --javascript.allow-admin-execute enabled.
-	ExecuteAdminScript(ctx context.Context, dbName string, script string) (interface{}, error)
+	ExecuteAdminScript(ctx context.Context, dbName string, script *string) (interface{}, error)
 
 	// CompactDatabases can be used to reclaim disk space after substantial data deletions have taken place,
 	// by compacting the entire database system data.
@@ -308,23 +308,23 @@ type ApiCallsResponse struct {
 
 type ServerStatusResponse struct {
 	// The server type (e.g., "arango")
-	Server string `json:"server"`
+	Server *string `json:"server,omitempty"`
 	// The server version string (e.g,. "3.12.*")
-	Version string `json:"version"`
+	Version *string `json:"version,omitempty"`
 	// Process ID of the server
-	Pid int `json:"pid"`
+	Pid *int `json:"pid,omitempty"`
 	// License type (e.g., "community" or "enterprise")
-	License string `json:"license"`
+	License *string `json:"license,omitempty"`
 	// Mode in which the server is running
-	Mode string `json:"mode"`
+	Mode *string `json:"mode,omitempty"`
 	// Operational mode (e.g., "server", "coordinator")
-	OperationMode string `json:"operationMode"`
+	OperationMode *string `json:"operationMode,omitempty"`
 	// Whether the Foxx API is enabled
-	FoxxApi bool `json:"foxxApi"`
+	FoxxApi *bool `json:"foxxApi,omitempty"`
 	// Host of the server
-	Host string `json:"host"`
+	Host *string `json:"host,omitempty"`
 	// System hostname of the server
-	Hostname string `json:"hostname"`
+	Hostname *string `json:"hostname,omitempty"`
 	// Nested server information details
 	ServerInfo ServerInformation `json:"serverInfo"`
 
@@ -339,13 +339,13 @@ type ServerInformation struct {
 	// Current progress of the server
 	Progress ServerProgress `json:"progress"`
 	// Whether the server is in maintenance mode
-	Maintenance bool `json:"maintenance"`
+	Maintenance *bool `json:"maintenance,omitempty"`
 	// Role of the server (e.g., "SINGLE", "COORDINATOR")
-	Role string `json:"role"`
+	Role *string `json:"role,omitempty"`
 	// Whether write operations are enabled
-	WriteOpsEnabled bool `json:"writeOpsEnabled"`
+	WriteOpsEnabled *bool `json:"writeOpsEnabled,omitempty"`
 	// Whether the server is in read-only mode
-	ReadOnly bool `json:"readOnly"`
+	ReadOnly *bool `json:"readOnly,omitempty"`
 
 	// Persisted server identifier (cluster only)
 	PersistedId *string `json:"persistedId,omitempty"`
@@ -362,11 +362,11 @@ type ServerInformation struct {
 // ServerProgress contains information about the startup or recovery phase.
 type ServerProgress struct {
 	// Current phase of the server (e.g., "in wait")
-	Phase string `json:"phase"`
+	Phase *string `json:"phase,omitempty"`
 	// Current feature being processed (if any)
-	Feature string `json:"feature"`
+	Feature *string `json:"feature,omitempty"`
 	// Recovery tick value
-	RecoveryTick int `json:"recoveryTick"`
+	RecoveryTick *int `json:"recoveryTick,omitempty"`
 }
 
 // CoordinatorInfo provides information specific to the coordinator role (cluster only).
@@ -393,28 +393,28 @@ type AgencyCommInfo struct {
 // (in single-server deployments) or individual servers (in cluster deployments).
 type ServerInfo struct {
 	// Role of the server (e.g., SINGLE, COORDINATOR, DBServer, etc.)
-	Role string `json:"role"`
+	Role *string `json:"role,omitempty"`
 
 	// Whether the server is in maintenance mode
-	Maintenance bool `json:"maintenance"`
+	Maintenance *bool `json:"maintenance,omitempty"`
 
 	// Whether the server is in read-only mode
-	ReadOnly bool `json:"readOnly"`
+	ReadOnly *bool `json:"readOnly,omitempty"`
 
 	// ArangoDB version running on the server
-	Version string `json:"version"`
+	Version *string `json:"version,omitempty"`
 
 	// Build identifier of the ArangoDB binary
-	Build string `json:"build"`
+	Build *string `json:"build,omitempty"`
 
 	// License type (e.g., community, enterprise)
-	License string `json:"license"`
+	License *string `json:"license,omitempty"`
 
 	// Operating system information string
-	Os string `json:"os"`
+	Os *string `json:"os,omitempty"`
 
 	// Platform (e.g., linux, windows, macos)
-	Platform string `json:"platform"`
+	Platform *string `json:"platform,omitempty"`
 
 	// Information about the physical memory of the host
 	PhysicalMemory PhysicalMemoryInfo `json:"physicalMemory"`
@@ -435,65 +435,65 @@ type ServerInfo struct {
 // PhysicalMemoryInfo represents a numeric system property and whether it was overridden.
 type PhysicalMemoryInfo struct {
 	// The value of the property (e.g., memory size, CPU cores)
-	Value int64 `json:"value"`
+	Value *int64 `json:"value,omitempty"`
 
 	// Whether this value was overridden by configuration
-	Overridden bool `json:"overridden"`
+	Overridden *bool `json:"overridden,omitempty"`
 }
 
 // ProcessStatsInfo contains runtime statistics of the ArangoDB process.
 type ProcessStatsInfo struct {
 	// Uptime of the process in seconds
-	ProcessUptime float64 `json:"processUptime"`
+	ProcessUptime *float64 `json:"processUptime,omitempty"`
 
 	// Number of active threads
-	NumberOfThreads int `json:"numberOfThreads"`
+	NumberOfThreads *int `json:"numberOfThreads,omitempty"`
 
 	// Virtual memory size in bytes
-	VirtualSize int64 `json:"virtualSize"`
+	VirtualSize *int64 `json:"virtualSize,omitempty"`
 
 	// Resident set size (RAM in use) in bytes
-	ResidentSetSize int64 `json:"residentSetSize"`
+	ResidentSetSize *int64 `json:"residentSetSize,omitempty"`
 
 	// Number of open file descriptors
-	FileDescriptors int `json:"fileDescriptors"`
+	FileDescriptors *int `json:"fileDescriptors,omitempty"`
 
 	// Limit on the number of file descriptors
-	FileDescriptorsLimit int64 `json:"fileDescriptorsLimit"`
+	FileDescriptorsLimit *int64 `json:"fileDescriptorsLimit,omitempty"`
 }
 
 // CpuStatsInfo contains CPU usage percentages.
 type CpuStatsInfo struct {
 	// Percentage of CPU time spent in user mode
-	UserPercent float64 `json:"userPercent"`
+	UserPercent *float64 `json:"userPercent,omitempty"`
 
 	// Percentage of CPU time spent in system/kernel mode
-	SystemPercent float64 `json:"systemPercent"`
+	SystemPercent *float64 `json:"systemPercent,omitempty"`
 
 	// Percentage of CPU time spent idle
-	IdlePercent float64 `json:"idlePercent"`
+	IdlePercent *float64 `json:"idlePercent,omitempty"`
 
 	// Percentage of CPU time spent waiting for I/O
-	IowaitPercent float64 `json:"iowaitPercent"`
+	IowaitPercent *float64 `json:"iowaitPercent,omitempty"`
 }
 
 // EngineStatsInfo contains metrics from the RocksDB storage engine and cache.
 type EngineStatsInfo struct {
-	CacheLimit                  *int64 `json:"cache.limit"`
-	CacheAllocated              *int64 `json:"cache.allocated"`
-	RocksdbEstimateNumKeys      *int   `json:"rocksdb.estimate-num-keys"`
-	RocksdbEstimateLiveDataSize *int   `json:"rocksdb.estimate-live-data-size"`
-	RocksdbLiveSstFilesSize     *int   `json:"rocksdb.live-sst-files-size"`
-	RocksdbBlockCacheCapacity   *int64 `json:"rocksdb.block-cache-capacity"`
-	RocksdbBlockCacheUsage      *int   `json:"rocksdb.block-cache-usage"`
-	RocksdbFreeDiskSpace        *int64 `json:"rocksdb.free-disk-space"`
-	RocksdbTotalDiskSpace       *int64 `json:"rocksdb.total-disk-space"`
+	CacheLimit                  *int64 `json:"cache.limit,omitempty"`
+	CacheAllocated              *int64 `json:"cache.allocated,omitempty"`
+	RocksdbEstimateNumKeys      *int   `json:"rocksdb.estimate-num-keys,omitempty"`
+	RocksdbEstimateLiveDataSize *int   `json:"rocksdb.estimate-live-data-size,omitempty"`
+	RocksdbLiveSstFilesSize     *int   `json:"rocksdb.live-sst-files-size,omitempty"`
+	RocksdbBlockCacheCapacity   *int64 `json:"rocksdb.block-cache-capacity,omitempty"`
+	RocksdbBlockCacheUsage      *int   `json:"rocksdb.block-cache-usage,omitempty"`
+	RocksdbFreeDiskSpace        *int64 `json:"rocksdb.free-disk-space,omitempty"`
+	RocksdbTotalDiskSpace       *int64 `json:"rocksdb.total-disk-space,omitempty"`
 }
 
 // DeploymentInfo contains information about the deployment type and cluster layout.
 type DeploymentInfo struct {
 	// Type of deployment ("single" or "cluster")
-	Type string `json:"type"`
+	Type *string `json:"type,omitempty"`
 
 	// Map of servers in the cluster, keyed by server ID (only present in cluster mode)
 	Servers *map[ServerID]ServerInfo `json:"servers,omitempty"`
@@ -532,12 +532,12 @@ type SupportInfoResponse struct {
 	Host *ServerInfo `json:"host,omitempty"`
 
 	// Timestamp when the data was collected
-	Date string `json:"date"`
+	Date *string `json:"date,omitempty"`
 }
 
 type CompactOpts struct {
 	//whether or not compacted data should be moved to the minimum possible level.
-	ChangeLevel bool `json:"changeLevel"`
+	ChangeLevel *bool `json:"changeLevel,omitempty"`
 	// Whether or not to compact the bottommost level of data.
-	CompactBottomMostLevel bool `json:"compactBottomMostLevel"`
+	CompactBottomMostLevel *bool `json:"compactBottomMostLevel,omitempty"`
 }

--- a/v2/arangodb/client_admin.go
+++ b/v2/arangodb/client_admin.go
@@ -66,6 +66,11 @@ type ClientAdmin interface {
 	// ExecuteAdminScript executes JavaScript code on the server.
 	// Note: Requires ArangoDB to be started with --javascript.allow-admin-execute enabled.
 	ExecuteAdminScript(ctx context.Context, dbName string, script string) (interface{}, error)
+
+	// CompactDatabases  can be used to reclaim disk space after substantial data deletions have taken place,
+	// by compacting the entire database system data.
+	// The endpoint requires superuser access.
+	CompactDatabases(ctx context.Context, opts *CompactOpts) (map[string]interface{}, error)
 }
 
 type ClientAdminLog interface {
@@ -528,4 +533,11 @@ type SupportInfoResponse struct {
 
 	// Timestamp when the data was collected
 	Date string `json:"date"`
+}
+
+type CompactOpts struct {
+	//whether or not compacted data should be moved to the minimum possible level.
+	ChangeLevel bool `json:"changeLevel"`
+	// Whether or not to compact the bottommost level of data.
+	CompactBottomMostLevel bool `json:"compactBottomMostLevel"`
 }

--- a/v2/arangodb/client_admin.go
+++ b/v2/arangodb/client_admin.go
@@ -44,10 +44,10 @@ type ClientAdmin interface {
 	// For ActiveFailover, it will return an error (503 code) if the server is not the leader.
 	CheckAvailability(ctx context.Context, serverEndpoint string) error
 
-	//GetSystemTime returns the current system time as a Unix timestamp with microsecond precision.
+	// GetSystemTime returns the current system time as a Unix timestamp with microsecond precision.
 	GetSystemTime(ctx context.Context, dbName string) (float64, error)
 
-	//GetServerStatus returns status information about the server.
+	// GetServerStatus returns status information about the server.
 	GetServerStatus(ctx context.Context, dbName string) (ServerStatusResponse, error)
 
 	// GetDeploymentSupportInfo retrieves deployment information for support purposes.

--- a/v2/arangodb/client_admin.go
+++ b/v2/arangodb/client_admin.go
@@ -67,7 +67,7 @@ type ClientAdmin interface {
 	// Note: Requires ArangoDB to be started with --javascript.allow-admin-execute enabled.
 	ExecuteAdminScript(ctx context.Context, dbName string, script string) (interface{}, error)
 
-	// CompactDatabases  can be used to reclaim disk space after substantial data deletions have taken place,
+	// CompactDatabases can be used to reclaim disk space after substantial data deletions have taken place,
 	// by compacting the entire database system data.
 	// The endpoint requires superuser access.
 	CompactDatabases(ctx context.Context, opts *CompactOpts) (map[string]interface{}, error)

--- a/v2/arangodb/client_admin.go
+++ b/v2/arangodb/client_admin.go
@@ -44,8 +44,11 @@ type ClientAdmin interface {
 	// For ActiveFailover, it will return an error (503 code) if the server is not the leader.
 	CheckAvailability(ctx context.Context, serverEndpoint string) error
 
-	//GetSystemTime returns the current system time as a Unix timestamp with microsecond precision
+	//GetSystemTime returns the current system time as a Unix timestamp with microsecond precision.
 	GetSystemTime(ctx context.Context, dbName string) (float64, error)
+
+	//GetServerStatus returns status information about the server.
+	GetServerStatus(ctx context.Context, dbName string) (ServerStatusResponse, error)
 }
 
 type ClientAdminLog interface {
@@ -279,4 +282,87 @@ type ApiCallsObject struct {
 
 type ApiCallsResponse struct {
 	Calls []ApiCallsObject `json:"calls"`
+}
+
+type ServerStatusResponse struct {
+	// The server type (e.g., "arango")
+	Server string `json:"server"`
+	// The server version string (e.g,. "3.12.*")
+	Version string `json:"version"`
+	// Process ID of the server
+	Pid int `json:"pid"`
+	// License type (e.g., "community" or "enterprise")
+	License string `json:"license"`
+	// Mode in which the server is running
+	Mode string `json:"mode"`
+	// Operational mode (e.g., "server", "coordinator")
+	OperationMode string `json:"operationMode"`
+	// Whether the Foxx API is enabled
+	FoxxApi bool `json:"foxxApi"`
+	// Host of the server
+	Host string `json:"host"`
+	// System hostname of the server
+	Hostname string `json:"hostname"`
+	// Nested server information details
+	ServerInfo ServerInformation `json:"serverInfo"`
+
+	// Present only in cluster mode
+	Coordinator *CoordinatorInfo `json:"coordinator,omitempty"`
+	Agency      *AgencyInfo      `json:"agency,omitempty"`
+}
+
+// ServerInformation provides detailed information about the server’s state.
+// Some fields are present only in cluster deployments.
+type ServerInformation struct {
+	// Current progress of the server
+	Progress ServerProgress `json:"progress"`
+	// Whether the server is in maintenance mode
+	Maintenance bool `json:"maintenance"`
+	// Role of the server (e.g., "SINGLE", "COORDINATOR")
+	Role string `json:"role"`
+	// Whether write operations are enabled
+	WriteOpsEnabled bool `json:"writeOpsEnabled"`
+	// Whether the server is in read-only mode
+	ReadOnly bool `json:"readOnly"`
+
+	// Persisted server identifier (cluster only)
+	PersistedId *string `json:"persistedId,omitempty"`
+	// Reboot ID
+	RebootId *int `json:"rebootId,omitempty"`
+	// Network address
+	Address *string `json:"address,omitempty"`
+	// Unique server identifier
+	ServerId *string `json:"serverId,omitempty"`
+	// Current server state
+	State *string `json:"state,omitempty"`
+}
+
+// ServerProgress contains information about the startup or recovery phase.
+type ServerProgress struct {
+	// Current phase of the server (e.g., "in wait")
+	Phase string `json:"phase"`
+	// Current feature being processed (if any)
+	Feature string `json:"feature"`
+	// Recovery tick value
+	RecoveryTick int `json:"recoveryTick"`
+}
+
+// CoordinatorInfo provides information specific to the coordinator role (cluster only).
+type CoordinatorInfo struct {
+	// ID of the Foxxmaster coordinator
+	Foxxmaster *string `json:"foxxmaster,omitempty"`
+	// Whether this server is the Foxxmaster
+	IsFoxxmaster *bool `json:"isFoxxmaster,omitempty"`
+}
+
+// AgencyInfo contains information about the agency configuration (cluster only).
+type AgencyInfo struct {
+	// Agency communication details
+	AgencyComm *AgencyCommInfo `json:"agencyComm,omitempty"`
+}
+
+// AgencyCommInfo contains communication endpoints for the agency.
+type AgencyCommInfo struct {
+	// List of agency endpoints
+	Endpoints *[]string `json:"endpoints,omitempty"`
 }

--- a/v2/arangodb/client_admin.go
+++ b/v2/arangodb/client_admin.go
@@ -59,6 +59,9 @@ type ClientAdmin interface {
 	// GetStartupConfigurationDescription fetches the available startup configuration
 	// options of the queried arangod instance.
 	GetStartupConfigurationDescription(ctx context.Context) (map[string]interface{}, error)
+
+	// ReloadRoutingTable reloads the routing information from the _routing system collection.
+	ReloadRoutingTable(ctx context.Context, dbName string) error
 }
 
 type ClientAdminLog interface {

--- a/v2/arangodb/client_admin.go
+++ b/v2/arangodb/client_admin.go
@@ -62,6 +62,10 @@ type ClientAdmin interface {
 
 	// ReloadRoutingTable reloads the routing information from the _routing system collection.
 	ReloadRoutingTable(ctx context.Context, dbName string) error
+
+	// ExecuteAdminScript executes JavaScript code on the server.
+	// Note: Requires ArangoDB to be started with --javascript.allow-admin-execute enabled.
+	ExecuteAdminScript(ctx context.Context, dbName string, script string) (interface{}, error)
 }
 
 type ClientAdminLog interface {

--- a/v2/arangodb/client_admin.go
+++ b/v2/arangodb/client_admin.go
@@ -43,6 +43,9 @@ type ClientAdmin interface {
 	// Use ClientAdminCluster.Health() to fetch the Endpoint list.
 	// For ActiveFailover, it will return an error (503 code) if the server is not the leader.
 	CheckAvailability(ctx context.Context, serverEndpoint string) error
+
+	//GetSystemTime returns the current system time as a Unix timestamp with microsecond precision
+	GetSystemTime(ctx context.Context, dbName string) (float64, error)
 }
 
 type ClientAdminLog interface {

--- a/v2/arangodb/client_admin.go
+++ b/v2/arangodb/client_admin.go
@@ -52,6 +52,9 @@ type ClientAdmin interface {
 
 	// GetDeploymentSupportInfo retrieves deployment information for support purposes.
 	GetDeploymentSupportInfo(ctx context.Context) (SupportInfoResponse, error)
+
+	// GetStartupConfiguration return the effective configuration of the queried arangod instance.
+	GetStartupConfiguration(ctx context.Context) (map[string]interface{}, error)
 }
 
 type ClientAdminLog interface {

--- a/v2/arangodb/client_admin.go
+++ b/v2/arangodb/client_admin.go
@@ -456,10 +456,10 @@ type ProcessStatsInfo struct {
 	ResidentSetSize int64 `json:"residentSetSize"`
 
 	// Number of open file descriptors
-	FileDescrtors int `json:"fileDescrtors"`
+	FileDescriptors int `json:"fileDescriptors"`
 
 	// Limit on the number of file descriptors
-	FileDescrtorsLimit int64 `json:"fileDescrtorsLimit"`
+	FileDescriptorsLimit int64 `json:"fileDescriptorsLimit"`
 }
 
 // CpuStatsInfo contains CPU usage percentages.

--- a/v2/arangodb/client_admin.go
+++ b/v2/arangodb/client_admin.go
@@ -55,6 +55,10 @@ type ClientAdmin interface {
 
 	// GetStartupConfiguration return the effective configuration of the queried arangod instance.
 	GetStartupConfiguration(ctx context.Context) (map[string]interface{}, error)
+
+	// GetStartupConfigurationDescription fetches the available startup configuration
+	// options of the queried arangod instance.
+	GetStartupConfigurationDescription(ctx context.Context) (map[string]interface{}, error)
 }
 
 type ClientAdminLog interface {

--- a/v2/arangodb/client_admin_impl.go
+++ b/v2/arangodb/client_admin_impl.go
@@ -332,7 +332,7 @@ func (c *clientAdmin) ExecuteAdminScript(ctx context.Context, dbName string, scr
 	}
 }
 
-// CompactDatabases  can be used to reclaim disk space after substantial data deletions have taken place,
+// CompactDatabases can be used to reclaim disk space after substantial data deletions have taken place,
 // by compacting the entire database system data.
 // The endpoint requires superuser access.
 func (c *clientAdmin) CompactDatabases(ctx context.Context, opts *CompactOpts) (map[string]interface{}, error) {

--- a/v2/arangodb/client_admin_impl.go
+++ b/v2/arangodb/client_admin_impl.go
@@ -332,7 +332,6 @@ func (c *clientAdmin) ExecuteAdminScript(ctx context.Context, dbName string, scr
 func (c *clientAdmin) CompactDatabases(ctx context.Context, opts *CompactOpts) (map[string]interface{}, error) {
 	url := connection.NewUrl("_admin", "compact")
 
-	// In client_admin_impl.go, consider this cleaner approach:
 	var modifyRequest []connection.RequestModifier
 
 	// Always add both parameters with appropriate defaults

--- a/v2/arangodb/client_admin_impl.go
+++ b/v2/arangodb/client_admin_impl.go
@@ -198,7 +198,6 @@ func (c *clientAdmin) GetSystemTime(ctx context.Context, dbName string) (float64
 
 // GetServerStatus returns status information about the server
 func (c *clientAdmin) GetServerStatus(ctx context.Context, dbName string) (ServerStatusResponse, error) {
-	// url := connection.NewUrl("_admin", "server", "mode")
 	url := connection.NewUrl("_db", url.PathEscape(dbName), "_admin", "status")
 
 	var response struct {
@@ -216,5 +215,27 @@ func (c *clientAdmin) GetServerStatus(ctx context.Context, dbName string) (Serve
 		return response.ServerStatusResponse, nil
 	default:
 		return ServerStatusResponse{}, response.AsArangoErrorWithCode(code)
+	}
+}
+
+// GetDeploymentSupportInfo retrieves deployment information for support purposes.
+func (c *clientAdmin) GetDeploymentSupportInfo(ctx context.Context) (SupportInfoResponse, error) {
+	url := connection.NewUrl("_db", "_system", "_admin", "support-info")
+
+	var response struct {
+		shared.ResponseStruct `json:",inline"`
+		SupportInfoResponse   `json:",inline"`
+	}
+
+	resp, err := connection.CallGet(ctx, c.client.connection, url, &response)
+	if err != nil {
+		return SupportInfoResponse{}, errors.WithStack(err)
+	}
+
+	switch code := resp.Code(); code {
+	case http.StatusOK:
+		return response.SupportInfoResponse, nil
+	default:
+		return SupportInfoResponse{}, response.AsArangoErrorWithCode(code)
 	}
 }

--- a/v2/arangodb/client_admin_impl.go
+++ b/v2/arangodb/client_admin_impl.go
@@ -195,3 +195,26 @@ func (c *clientAdmin) GetSystemTime(ctx context.Context, dbName string) (float64
 		return 0, response.AsArangoErrorWithCode(code)
 	}
 }
+
+// GetServerStatus returns status information about the server
+func (c *clientAdmin) GetServerStatus(ctx context.Context, dbName string) (ServerStatusResponse, error) {
+	// url := connection.NewUrl("_admin", "server", "mode")
+	url := connection.NewUrl("_db", url.PathEscape(dbName), "_admin", "status")
+
+	var response struct {
+		shared.ResponseStruct `json:",inline"`
+		ServerStatusResponse  `json:",inline"`
+	}
+
+	resp, err := connection.CallGet(ctx, c.client.connection, url, &response)
+	if err != nil {
+		return ServerStatusResponse{}, errors.WithStack(err)
+	}
+
+	switch code := resp.Code(); code {
+	case http.StatusOK:
+		return response.ServerStatusResponse, nil
+	default:
+		return ServerStatusResponse{}, response.AsArangoErrorWithCode(code)
+	}
+}

--- a/v2/arangodb/client_admin_impl.go
+++ b/v2/arangodb/client_admin_impl.go
@@ -282,3 +282,20 @@ func (c *clientAdmin) GetStartupConfigurationDescription(ctx context.Context) (m
 		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(resp.Code())
 	}
 }
+
+// ReloadRoutingTable reloads the routing information from the _routing system collection.
+func (c *clientAdmin) ReloadRoutingTable(ctx context.Context, dbName string) error {
+	urlEndpoint := connection.NewUrl("_db", url.PathEscape(dbName), "_admin", "routing", "reload")
+
+	resp, err := connection.CallPost(ctx, c.client.connection, urlEndpoint, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	switch code := resp.Code(); code {
+	case http.StatusOK, http.StatusNoContent:
+		return nil
+	default:
+		return (&shared.ResponseStruct{}).AsArangoErrorWithCode(resp.Code())
+	}
+}

--- a/v2/arangodb/client_admin_impl.go
+++ b/v2/arangodb/client_admin_impl.go
@@ -255,7 +255,10 @@ func (c *clientAdmin) GetStartupConfiguration(ctx context.Context) (map[string]i
 	case http.StatusOK:
 		return response, nil
 	case http.StatusForbidden:
-		return nil, errors.New("insufficient permissions to access server options")
+		return nil, (&shared.ArangoError{
+			Code:         resp.Code(),
+			ErrorMessage: "insufficient permissions to access server options",
+		})
 	default:
 		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
 	}
@@ -277,7 +280,10 @@ func (c *clientAdmin) GetStartupConfigurationDescription(ctx context.Context) (m
 	case http.StatusOK:
 		return response, nil
 	case http.StatusForbidden:
-		return nil, errors.New("insufficient permissions to access startup configuration description")
+		return nil, (&shared.ArangoError{
+			Code:         resp.Code(),
+			ErrorMessage: "insufficient permissions to access startup configuration description",
+		})
 	default:
 		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
 	}
@@ -348,7 +354,10 @@ func (c *clientAdmin) CompactDatabases(ctx context.Context, opts *CompactOpts) (
 	case http.StatusOK:
 		return response, nil
 	case http.StatusForbidden:
-		return nil, errors.New("This endpoint requires superuser access")
+		return nil, (&shared.ArangoError{
+			Code:         resp.Code(),
+			ErrorMessage: "This endpoint requires superuser access",
+		})
 	default:
 		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
 	}

--- a/v2/arangodb/client_admin_impl.go
+++ b/v2/arangodb/client_admin_impl.go
@@ -347,6 +347,8 @@ func (c *clientAdmin) CompactDatabases(ctx context.Context, opts *CompactOpts) (
 	switch code := resp.Code(); code {
 	case http.StatusOK:
 		return response, nil
+	case http.StatusForbidden:
+		return nil, errors.New("This endpoint requires superuser access")
 	default:
 		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
 	}

--- a/v2/arangodb/client_admin_impl.go
+++ b/v2/arangodb/client_admin_impl.go
@@ -331,3 +331,23 @@ func (c *clientAdmin) ExecuteAdminScript(ctx context.Context, dbName string, scr
 		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
 	}
 }
+
+// CompactDatabases  can be used to reclaim disk space after substantial data deletions have taken place,
+// by compacting the entire database system data.
+// The endpoint requires superuser access.
+func (c *clientAdmin) CompactDatabases(ctx context.Context, opts *CompactOpts) (map[string]interface{}, error) {
+	url := connection.NewUrl("_admin", "compact")
+
+	var response map[string]interface{}
+	resp, err := connection.CallPut(ctx, c.client.connection, url, &response, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	switch code := resp.Code(); code {
+	case http.StatusOK:
+		return response, nil
+	default:
+		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(code)
+	}
+}

--- a/v2/tests/admin_test.go
+++ b/v2/tests/admin_test.go
@@ -148,14 +148,19 @@ func Test_GetDeploymentSupportInfo(t *testing.T) {
 func Test_GetStartupConfiguration(t *testing.T) {
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		withContextT(t, time.Minute, func(ctx context.Context, t testing.TB) {
+
 			resp, err := client.GetStartupConfiguration(ctx)
 			t.Logf("Error type: %T,  Error:%v\n", err, err)
-
 			if err != nil {
-				var arangoErr *shared.ArangoError
-				if errors.As(err, &arangoErr) {
-					t.Logf("arangoErr code:%d", arangoErr.Code)
-					if arangoErr.Code == 403 || arangoErr.Code == 500 {
+				switch e := err.(type) {
+				case *shared.ArangoError:
+					t.Logf("arangoErr code:%d", e.Code)
+					if e.Code == 403 || e.Code == 500 {
+						t.Skip("startup configuration API not enabled on this server")
+					}
+				case shared.ArangoError:
+					t.Logf("arangoErr code:%d", e.Code)
+					if e.Code == 403 || e.Code == 500 {
 						t.Skip("startup configuration API not enabled on this server")
 					}
 				}
@@ -166,15 +171,20 @@ func Test_GetStartupConfiguration(t *testing.T) {
 			configDesc, err := client.GetStartupConfigurationDescription(ctx)
 			t.Logf("Error type: %T,  Error:%v\n", err, err)
 			if err != nil {
-				var arangoErr *shared.ArangoError
-				if errors.As(err, &arangoErr) {
-					t.Logf("arangoErr code:%d", arangoErr.Code)
-					if arangoErr.Code == 403 || arangoErr.Code == 500 {
+				switch e := err.(type) {
+				case *shared.ArangoError:
+					t.Logf("arangoErr code:%d", e.Code)
+					if e.Code == 403 || e.Code == 500 {
+						t.Skip("startup configuration description API not enabled on this server")
+					}
+				case shared.ArangoError:
+					t.Logf("arangoErr code:%d", e.Code)
+					if e.Code == 403 || e.Code == 500 {
 						t.Skip("startup configuration description API not enabled on this server")
 					}
 				}
-				require.NoError(t, err)
 			}
+			require.NoError(t, err)
 			require.NotEmpty(t, configDesc)
 
 			// Assert that certain well-known options exist

--- a/v2/tests/admin_test.go
+++ b/v2/tests/admin_test.go
@@ -244,7 +244,7 @@ func Test_ExecuteAdminScript(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				result, err := client.ExecuteAdminScript(ctx, db.Name(), tt.script)
-				var arangoErr *shared.ArangoError
+				var arangoErr shared.ArangoError
 				if errors.As(err, &arangoErr) {
 					t.Logf("arangoErr code:%d\n", arangoErr.Code)
 					if arangoErr.Code == http.StatusNotFound {
@@ -273,7 +273,7 @@ func Test_CompactDatabases(t *testing.T) {
 		withContextT(t, time.Minute, func(ctx context.Context, t testing.TB) {
 			resp, err := client.CompactDatabases(ctx, nil)
 			if err != nil {
-				var arangoErr *shared.ArangoError
+				var arangoErr shared.ArangoError
 				if errors.As(err, &arangoErr) {
 					t.Logf("arangoErr code:%d", arangoErr.Code)
 					if arangoErr.Code == 403 || arangoErr.Code == 500 {
@@ -290,7 +290,7 @@ func Test_CompactDatabases(t *testing.T) {
 			}
 			resp, err = client.CompactDatabases(ctx, opts)
 			if err != nil {
-				var arangoErr *shared.ArangoError
+				var arangoErr shared.ArangoError
 				if errors.As(err, &arangoErr) {
 					t.Logf("arangoErr code:%d", arangoErr.Code)
 					if arangoErr.Code == 403 || arangoErr.Code == 500 {

--- a/v2/tests/admin_test.go
+++ b/v2/tests/admin_test.go
@@ -152,9 +152,9 @@ func Test_GetStartupConfiguration(t *testing.T) {
 			t.Logf("Error type: %T,  Error:%v\n", err, err)
 
 			if err != nil {
-				var arangoErr shared.ArangoError
-				t.Logf("arangoErr code:%d", arangoErr.Code)
+				var arangoErr *shared.ArangoError
 				if errors.As(err, &arangoErr) {
+					t.Logf("arangoErr code:%d", arangoErr.Code)
 					if arangoErr.Code == 403 || arangoErr.Code == 500 {
 						t.Skip("startup configuration API not enabled on this server")
 					}
@@ -166,9 +166,9 @@ func Test_GetStartupConfiguration(t *testing.T) {
 			configDesc, err := client.GetStartupConfigurationDescription(ctx)
 			t.Logf("Error type: %T,  Error:%v\n", err, err)
 			if err != nil {
-				var arangoErr shared.ArangoError
-				t.Logf("arangoErr code:%d", arangoErr.Code)
+				var arangoErr *shared.ArangoError
 				if errors.As(err, &arangoErr) {
+					t.Logf("arangoErr code:%d", arangoErr.Code)
 					if arangoErr.Code == 403 || arangoErr.Code == 500 {
 						t.Skip("startup configuration description API not enabled on this server")
 					}
@@ -267,9 +267,9 @@ func Test_CompactDatabases(t *testing.T) {
 			t.Logf("Error type: %T,  Error:%v\n", err, err)
 
 			if err != nil {
-				var arangoErr shared.ArangoError
-				t.Logf("arangoErr code:%d", arangoErr.Code)
+				var arangoErr *shared.ArangoError
 				if errors.As(err, &arangoErr) {
+					t.Logf("arangoErr code:%d", arangoErr.Code)
 					if arangoErr.Code == 403 || arangoErr.Code == 500 {
 						t.Skip("The endpoint requires superuser access")
 					}
@@ -285,9 +285,9 @@ func Test_CompactDatabases(t *testing.T) {
 			}
 			resp, err = client.CompactDatabases(ctx, opts)
 			if err != nil {
-				var arangoErr shared.ArangoError
-				t.Logf("arangoErr code:%d", arangoErr.Code)
+				var arangoErr *shared.ArangoError
 				if errors.As(err, &arangoErr) {
+					t.Logf("arangoErr code:%d", arangoErr.Code)
 					if arangoErr.Code == 403 || arangoErr.Code == 500 {
 						t.Skip("The endpoint requires superuser access")
 					}

--- a/v2/tests/admin_test.go
+++ b/v2/tests/admin_test.go
@@ -153,7 +153,7 @@ func Test_GetStartupConfiguration(t *testing.T) {
 
 			configDesc, err := client.GetStartupConfigurationDescription(ctx)
 			if err != nil {
-				var arangoErr *shared.ArangoError
+				var arangoErr shared.ArangoError
 				t.Logf("arangoErr code:%d", arangoErr.Code)
 				if errors.As(err, &arangoErr) {
 					if arangoErr.Code == 403 || arangoErr.Code == 500 {
@@ -179,6 +179,17 @@ func Test_GetStartupConfiguration(t *testing.T) {
 				_, hasDesc := option["description"]
 				require.True(t, hasDesc, "expected option %s to have a description", key)
 			}
+		})
+	})
+}
+
+func Test_ReloadRoutingTable(t *testing.T) {
+	Wrap(t, func(t *testing.T, client arangodb.Client) {
+		withContextT(t, time.Minute, func(ctx context.Context, t testing.TB) {
+			db, err := client.GetDatabase(ctx, "_system", nil)
+			require.NoError(t, err)
+			err = client.ReloadRoutingTable(ctx, db.Name())
+			require.NoError(t, err)
 		})
 	})
 }

--- a/v2/tests/admin_test.go
+++ b/v2/tests/admin_test.go
@@ -89,3 +89,18 @@ func Test_Version(t *testing.T) {
 		})
 	})
 }
+
+func Test_GetSystemTime(t *testing.T) {
+	Wrap(t, func(t *testing.T, client arangodb.Client) {
+		withContextT(t, time.Minute, func(ctx context.Context, t testing.TB) {
+			db, err := client.GetDatabase(context.Background(), "_system", nil)
+			require.NoError(t, err)
+			require.NotEmpty(t, db)
+
+			time, err := client.GetSystemTime(context.Background(), db.Name())
+			require.NoError(t, err)
+			require.NotEmpty(t, time)
+			t.Logf("Current time in Unix timestamp with microsecond precision is:%f", time)
+		})
+	})
+}

--- a/v2/tests/admin_test.go
+++ b/v2/tests/admin_test.go
@@ -163,8 +163,8 @@ func Test_GetStartupConfiguration(t *testing.T) {
 						t.Skip("startup configuration API not enabled on this server")
 					}
 				}
+				require.NoError(t, err)
 			}
-			require.NoError(t, err)
 			require.NotEmpty(t, resp)
 
 			configDesc, err := client.GetStartupConfigurationDescription(ctx)
@@ -181,8 +181,8 @@ func Test_GetStartupConfiguration(t *testing.T) {
 						t.Skip("startup configuration description API not enabled on this server")
 					}
 				}
+				require.NoError(t, err)
 			}
-			require.NoError(t, err)
 			require.NotEmpty(t, configDesc)
 
 			// Assert that certain well-known options exist
@@ -280,8 +280,8 @@ func Test_CompactDatabases(t *testing.T) {
 						t.Skip("The endpoint requires superuser access")
 					}
 				}
+				require.NoError(t, err)
 			}
-			require.NoError(t, err)
 			require.Empty(t, resp)
 
 			opts := &arangodb.CompactOpts{
@@ -297,8 +297,8 @@ func Test_CompactDatabases(t *testing.T) {
 						t.Skip("The endpoint requires superuser access")
 					}
 				}
+				require.NoError(t, err)
 			}
-			require.NoError(t, err)
 			require.Empty(t, resp)
 		})
 	})

--- a/v2/tests/admin_test.go
+++ b/v2/tests/admin_test.go
@@ -104,3 +104,17 @@ func Test_GetSystemTime(t *testing.T) {
 		})
 	})
 }
+
+func Test_GetServerStatus(t *testing.T) {
+	Wrap(t, func(t *testing.T, client arangodb.Client) {
+		withContextT(t, time.Minute, func(ctx context.Context, t testing.TB) {
+			db, err := client.GetDatabase(context.Background(), "_system", nil)
+			require.NoError(t, err)
+			require.NotEmpty(t, db)
+
+			resp, err := client.GetServerStatus(context.Background(), db.Name())
+			require.NoError(t, err)
+			require.NotEmpty(t, resp)
+		})
+	})
+}

--- a/v2/tests/admin_test.go
+++ b/v2/tests/admin_test.go
@@ -149,6 +149,8 @@ func Test_GetStartupConfiguration(t *testing.T) {
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		withContextT(t, time.Minute, func(ctx context.Context, t testing.TB) {
 			resp, err := client.GetStartupConfiguration(ctx)
+			t.Logf("Error type: %T,  Error:%v\n", err, err)
+
 			if err != nil {
 				var arangoErr shared.ArangoError
 				t.Logf("arangoErr code:%d", arangoErr.Code)
@@ -157,12 +159,12 @@ func Test_GetStartupConfiguration(t *testing.T) {
 						t.Skip("startup configuration API not enabled on this server")
 					}
 				}
-				require.NoError(t, err)
 			}
 			require.NoError(t, err)
 			require.NotEmpty(t, resp)
 
 			configDesc, err := client.GetStartupConfigurationDescription(ctx)
+			t.Logf("Error type: %T,  Error:%v\n", err, err)
 			if err != nil {
 				var arangoErr shared.ArangoError
 				t.Logf("arangoErr code:%d", arangoErr.Code)
@@ -262,6 +264,8 @@ func Test_CompactDatabases(t *testing.T) {
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		withContextT(t, time.Minute, func(ctx context.Context, t testing.TB) {
 			resp, err := client.CompactDatabases(ctx, nil)
+			t.Logf("Error type: %T,  Error:%v\n", err, err)
+
 			if err != nil {
 				var arangoErr shared.ArangoError
 				t.Logf("arangoErr code:%d", arangoErr.Code)

--- a/v2/tests/admin_test.go
+++ b/v2/tests/admin_test.go
@@ -140,3 +140,13 @@ func Test_GetDeploymentSupportInfo(t *testing.T) {
 		})
 	})
 }
+
+func Test_GetStartupConfiguration(t *testing.T) {
+	Wrap(t, func(t *testing.T, client arangodb.Client) {
+		withContextT(t, time.Minute, func(ctx context.Context, t testing.TB) {
+			resp, err := client.GetStartupConfiguration(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, resp)
+		})
+	})
+}

--- a/v2/tests/admin_test.go
+++ b/v2/tests/admin_test.go
@@ -149,6 +149,16 @@ func Test_GetStartupConfiguration(t *testing.T) {
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		withContextT(t, time.Minute, func(ctx context.Context, t testing.TB) {
 			resp, err := client.GetStartupConfiguration(ctx)
+			if err != nil {
+				var arangoErr shared.ArangoError
+				t.Logf("arangoErr code:%d", arangoErr.Code)
+				if errors.As(err, &arangoErr) {
+					if arangoErr.Code == 403 || arangoErr.Code == 500 {
+						t.Skip("startup configuration API not enabled on this server")
+					}
+				}
+				require.NoError(t, err)
+			}
 			require.NoError(t, err)
 			require.NotEmpty(t, resp)
 
@@ -252,6 +262,16 @@ func Test_CompactDatabases(t *testing.T) {
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		withContextT(t, time.Minute, func(ctx context.Context, t testing.TB) {
 			resp, err := client.CompactDatabases(ctx, nil)
+			if err != nil {
+				var arangoErr shared.ArangoError
+				t.Logf("arangoErr code:%d", arangoErr.Code)
+				if errors.As(err, &arangoErr) {
+					if arangoErr.Code == 403 || arangoErr.Code == 500 {
+						t.Skip("The endpoint requires superuser access")
+					}
+				}
+				require.NoError(t, err)
+			}
 			require.NoError(t, err)
 			require.Empty(t, resp)
 
@@ -260,6 +280,16 @@ func Test_CompactDatabases(t *testing.T) {
 				CompactBottomMostLevel: false,
 			}
 			resp, err = client.CompactDatabases(ctx, opts)
+			if err != nil {
+				var arangoErr shared.ArangoError
+				t.Logf("arangoErr code:%d", arangoErr.Code)
+				if errors.As(err, &arangoErr) {
+					if arangoErr.Code == 403 || arangoErr.Code == 500 {
+						t.Skip("The endpoint requires superuser access")
+					}
+				}
+				require.NoError(t, err)
+			}
 			require.NoError(t, err)
 			require.Empty(t, resp)
 		})

--- a/v2/tests/admin_test.go
+++ b/v2/tests/admin_test.go
@@ -118,3 +118,25 @@ func Test_GetServerStatus(t *testing.T) {
 		})
 	})
 }
+
+func Test_GetDeploymentSupportInfo(t *testing.T) {
+	Wrap(t, func(t *testing.T, client arangodb.Client) {
+		withContextT(t, time.Minute, func(ctx context.Context, t testing.TB) {
+
+			serverRole, err := client.ServerRole(ctx)
+			require.NoError(t, err)
+			resp, err := client.GetDeploymentSupportInfo(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, resp)
+			require.NotEmpty(t, resp.Date)
+			require.NotEmpty(t, resp.Deployment)
+			require.NotEmpty(t, resp.Deployment.Type)
+			if serverRole == arangodb.ServerRoleCoordinator {
+				require.NotEmpty(t, resp.Deployment.Servers)
+			}
+			if serverRole == arangodb.ServerRoleSingle {
+				require.NotEmpty(t, resp.Host)
+			}
+		})
+	})
+}

--- a/v2/tests/admin_test.go
+++ b/v2/tests/admin_test.go
@@ -280,7 +280,6 @@ func Test_CompactDatabases(t *testing.T) {
 						t.Skip("The endpoint requires superuser access")
 					}
 				}
-				require.NoError(t, err)
 			}
 			require.NoError(t, err)
 			require.Empty(t, resp)
@@ -298,7 +297,6 @@ func Test_CompactDatabases(t *testing.T) {
 						t.Skip("The endpoint requires superuser access")
 					}
 				}
-				require.NoError(t, err)
 			}
 			require.NoError(t, err)
 			require.Empty(t, resp)

--- a/v2/tests/admin_test.go
+++ b/v2/tests/admin_test.go
@@ -247,3 +247,21 @@ func Test_ExecuteAdminScript(t *testing.T) {
 		}
 	})
 }
+
+func Test_CompactDatabases(t *testing.T) {
+	Wrap(t, func(t *testing.T, client arangodb.Client) {
+		withContextT(t, time.Minute, func(ctx context.Context, t testing.TB) {
+			resp, err := client.CompactDatabases(ctx, nil)
+			require.NoError(t, err)
+			require.Empty(t, resp)
+
+			opts := &arangodb.CompactOpts{
+				ChangeLevel:            true,
+				CompactBottomMostLevel: false,
+			}
+			resp, err = client.CompactDatabases(ctx, opts)
+			require.NoError(t, err)
+			require.Empty(t, resp)
+		})
+	})
+}

--- a/v2/tests/admin_test.go
+++ b/v2/tests/admin_test.go
@@ -150,7 +150,6 @@ func Test_GetStartupConfiguration(t *testing.T) {
 		withContextT(t, time.Minute, func(ctx context.Context, t testing.TB) {
 
 			resp, err := client.GetStartupConfiguration(ctx)
-			t.Logf("Error type: %T,  Error:%v\n", err, err)
 			if err != nil {
 				switch e := err.(type) {
 				case *shared.ArangoError:
@@ -169,7 +168,6 @@ func Test_GetStartupConfiguration(t *testing.T) {
 			require.NotEmpty(t, resp)
 
 			configDesc, err := client.GetStartupConfigurationDescription(ctx)
-			t.Logf("Error type: %T,  Error:%v\n", err, err)
 			if err != nil {
 				switch e := err.(type) {
 				case *shared.ArangoError:
@@ -274,8 +272,6 @@ func Test_CompactDatabases(t *testing.T) {
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		withContextT(t, time.Minute, func(ctx context.Context, t testing.TB) {
 			resp, err := client.CompactDatabases(ctx, nil)
-			t.Logf("Error type: %T,  Error:%v\n", err, err)
-
 			if err != nil {
 				var arangoErr *shared.ArangoError
 				if errors.As(err, &arangoErr) {


### PR DESCRIPTION
This PR includes the following Administration - related endpoints:

1. GET - /_db/{database-name}/_admin/time
2. GET - /_db/{database-name}/_admin/status
3. GET - /_db/_system/_admin/support-info
4. GET - /_db/_system/_admin/options
5. GET - /_db/_system/_admin/options-description
6. PUT - /_admin/compact
7. POST - /_db/{database-name}/_admin/routing/reload
8. POST - /_db/{database-name}/_admin/execute
