### PR TITLE
Fix Version.CompareTo for pre-release patch suffixes (e.g. -nightly) …

### DIFF
--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -58,6 +58,9 @@ if [ "$CMD" == "start" ]; then
             --args.all.vector-index=true \
             --args.all.experimental-vector-index=true"
     fi
+    # 3.12.9+ hides startup options from require("internal").options() unless allowlisted.
+    # Match ArangoDB's own test instances so integration tests can assert option shapes.
+    STARTERARGS="$STARTERARGS --args.all.javascript.startup-options-allowlist=.*"
     # Use DOCKER_PLATFORM if set (e.g., from CircleCI for ARM), otherwise use macOS default
     if [ -n "$DOCKER_PLATFORM" ]; then
         DOCKERPLATFORMARG="$DOCKER_PLATFORM"

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
+- Fix `Version.CompareTo` for pre-release patch suffixes (e.g. `-nightly`) by comparing the numeric patch instead of the full sub-version string
 - Add `DontFollowRedirect` fields to HTTP connection configuration
 - Switched to Go 1.25.8 to fix a security vulnerability
 - QueryProperties: Added slowStreamingQueryThreshold field

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
-- Tests: `test/cluster.sh` passes `javascript.startup-options-allowlist=.*` for ArangoDB 3.12.9+ `internal.options()` in JS transactions
+- Tests: `test/cluster.sh` passes `javascript.startup-options-allowlist=.*` for ArangoDB 3.12.9+ `require("internal").options()` in JS transactions
 - Fix `Version.CompareTo` for pre-release patch suffixes (e.g. `-nightly`) by comparing the numeric patch instead of the full sub-version string
 - Add `DontFollowRedirect` fields to HTTP connection configuration
 - Switched to Go 1.25.8 to fix a security vulnerability

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
+- Tests: `test/cluster.sh` passes `javascript.startup-options-allowlist=.*` for ArangoDB 3.12.9+ `internal.options()` in JS transactions
 - Fix `Version.CompareTo` for pre-release patch suffixes (e.g. `-nightly`) by comparing the numeric patch instead of the full sub-version string
 - Add `DontFollowRedirect` fields to HTTP connection configuration
 - Switched to Go 1.25.8 to fix a security vulnerability

--- a/v2/arangodb/version.go
+++ b/v2/arangodb/version.go
@@ -98,7 +98,8 @@ func patchLevelForCompare(sub string) (n int, ok bool) {
 // The result will be 0 if v==other, -1 if v < other, and +1 if v > other.
 // If major & minor parts are equal, patch levels are compared numerically when
 // both subs parse as integers or as a numeric prefix before '-' or '.' (e.g. "10-nightly.x").
-// Otherwise the sub parts are compared lexicographically.
+// When numeric patches tie, purely numeric subs compare equal (e.g. "01" vs "1"); if either
+// sub is not a full integer string, the full sub strings are compared lexicographically.
 func (v Version) CompareTo(other Version) int {
 	a := v.Major()
 	b := other.Major()
@@ -126,6 +127,13 @@ func (v Version) CompareTo(other Version) int {
 		}
 		if a > b {
 			return 1
+		}
+		// Same numeric patch: pure integers (e.g. "01" vs "1") compare equal like SubInt;
+		// pre-release subs still tie-break lexicographically.
+		_, errA := strconv.Atoi(v.Sub())
+		_, errB := strconv.Atoi(other.Sub())
+		if errA == nil && errB == nil {
+			return 0
 		}
 		return strings.Compare(v.Sub(), other.Sub())
 	}

--- a/v2/arangodb/version.go
+++ b/v2/arangodb/version.go
@@ -119,8 +119,10 @@ func (v Version) CompareTo(other Version) int {
 		return 1
 	}
 
-	a, aOK := patchLevelForCompare(v.Sub())
-	b, bOK := patchLevelForCompare(other.Sub())
+	vSub := v.Sub()
+	otherSub := other.Sub()
+	a, aOK := patchLevelForCompare(vSub)
+	b, bOK := patchLevelForCompare(otherSub)
 	if aOK && bOK {
 		if a < b {
 			return -1
@@ -130,12 +132,12 @@ func (v Version) CompareTo(other Version) int {
 		}
 		// Same numeric patch: pure integers (e.g. "01" vs "1") compare equal like SubInt;
 		// pre-release subs still tie-break lexicographically.
-		_, errA := strconv.Atoi(v.Sub())
-		_, errB := strconv.Atoi(other.Sub())
+		_, errA := strconv.Atoi(vSub)
+		_, errB := strconv.Atoi(otherSub)
 		if errA == nil && errB == nil {
 			return 0
 		}
-		return strings.Compare(v.Sub(), other.Sub())
+		return strings.Compare(vSub, otherSub)
 	}
-	return strings.Compare(v.Sub(), other.Sub())
+	return strings.Compare(vSub, otherSub)
 }

--- a/v2/arangodb/version.go
+++ b/v2/arangodb/version.go
@@ -67,10 +67,38 @@ func (v Version) SubInt() (int, bool) {
 	return result, err == nil
 }
 
+// patchLevelForCompare returns the numeric patch level used in CompareTo.
+// Pre-release style subs like "10-nightly.xxx" yield 10; purely textual subs
+// like "3a" do not (so lexicographic comparison is preserved).
+func patchLevelForCompare(sub string) (n int, ok bool) {
+	if sub == "" {
+		return 0, false
+	}
+	if n, err := strconv.Atoi(sub); err == nil {
+		return n, true
+	}
+	i := 0
+	for i < len(sub) && sub[i] >= '0' && sub[i] <= '9' {
+		i++
+	}
+	if i == 0 || i >= len(sub) {
+		return 0, false
+	}
+	if sub[i] != '-' && sub[i] != '.' {
+		return 0, false
+	}
+	n, err := strconv.Atoi(sub[:i])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
 // CompareTo returns an integer comparing two versions.
 // The result will be 0 if v==other, -1 if v < other, and +1 if v > other.
-// If major & minor parts are equal and sub part is not a number,
-// the sub part will be compared using lexicographical string comparison.
+// If major & minor parts are equal, patch levels are compared numerically when
+// both subs parse as integers or as a numeric prefix before '-' or '.' (e.g. "10-nightly.x").
+// Otherwise the sub parts are compared lexicographically.
 func (v Version) CompareTo(other Version) int {
 	a := v.Major()
 	b := other.Major()
@@ -90,18 +118,16 @@ func (v Version) CompareTo(other Version) int {
 		return 1
 	}
 
-	a, aIsInt := v.SubInt()
-	b, bIsInt := other.SubInt()
-
-	if !aIsInt || !bIsInt {
-		// Do a string comparison
+	a, aOK := patchLevelForCompare(v.Sub())
+	b, bOK := patchLevelForCompare(other.Sub())
+	if aOK && bOK {
+		if a < b {
+			return -1
+		}
+		if a > b {
+			return 1
+		}
 		return strings.Compare(v.Sub(), other.Sub())
 	}
-	if a < b {
-		return -1
-	}
-	if a > b {
-		return 1
-	}
-	return 0
+	return strings.Compare(v.Sub(), other.Sub())
 }

--- a/v2/arangodb/version.go
+++ b/v2/arangodb/version.go
@@ -68,7 +68,7 @@ func (v Version) SubInt() (int, bool) {
 }
 
 // patchLevelForCompare returns the numeric patch level used in CompareTo.
-// Pre-release style subs like "10-nightly.xxx" yield 10; purely textual subs
+// Pre-release style subs like "10-nightly.xxx" yield 10; mixed alphanumeric subs
 // like "3a" do not (so lexicographic comparison is preserved).
 func patchLevelForCompare(sub string) (n int, ok bool) {
 	if sub == "" {


### PR DESCRIPTION
…by comparing the numeric patch instead of the full sub-version string