### PR TITLE
DE-1202: Deprecate remaining 3.12.10+ replication APIs in v2 and remo…

### DIFF
--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
-- Replication applier / single-single replication API (`GetApplierConfig`, `UpdateApplierConfig`, `ApplierStart`, `ApplierStop`, `GetApplierState`, `MakeFollower`): Deprecated. Leader-follower and Active Failover already deprecated/removed earlier; these endpoints were kept until ArangoDB 3.12.10, where they were removed due to a security issue inherent to the applier design. Tests skip from 3.12.10.
+- Replication: deprecate APIs removed in ArangoDB 3.12.10+ (`GetApplierConfig`, `UpdateApplierConfig`, `ApplierStart`, `ApplierStop`, `GetApplierState`, `MakeFollower`, `StartReplicationSync`, `LoggerFirstTick`, `LoggerTickRange`, `GetReplicationServerId`); related tests skip from 3.12.10.
 - Switch to Go 1.25.12 to fix Encrypted Client Hello privacy leak in crypto/tls (GO-2026-5856)
 - Connection: added optional `ArangoDBConfiguration.HostHeader` so clients can dial an IP/URL host while sending a different HTTP `Host` (e.g. ingress / virtual hosts).
 - Tests: added v2 Kubernetes resiliency and Toxiproxy suites (kind + kube-arangodb + ingress-nginx) with shared multi-driver runner docs.

--- a/v2/arangodb/client_replication.go
+++ b/v2/arangodb/client_replication.go
@@ -44,18 +44,18 @@ type ClientReplication interface {
 	LoggerState(ctx context.Context, dbName string, DBserver *string) (LoggerStateResponse, error)
 	// LoggerFirstTick calls GET /_api/replication/logger-first-tick for the first tick of the replication logger.
 	//
-	// Deprecated: Do not use on ArangoDB 4.0 or newer. That release removes
-	// GET /_api/replication/logger-first-tick.
-	// For incremental write-ahead log updates, the 4.0 HTTP API documents
+	// Deprecated: Removed in ArangoDB 3.12.10+
+	// (GET /_api/replication/logger-first-tick).
+	// For incremental write-ahead log updates, use
 	// GET /_db/{database-name}/_api/wal/tail instead.
 	// On older versions this method still works.
 	LoggerFirstTick(ctx context.Context, dbName string) (LoggerFirstTickResponse, error)
 	// LoggerTickRange calls GET /_api/replication/logger-tick-ranges for tick ranges in WAL logfiles.
 	// On older servers the response may be a JSON array or a standard envelope whose "result" is that array.
 	//
-	// Deprecated: Do not use on ArangoDB 4.0 or newer. That release removes
-	// GET /_api/replication/logger-tick-ranges.
-	// For incremental WAL tailing, the 4.0 HTTP API documents
+	// Deprecated: Removed in ArangoDB 3.12.10+
+	// (GET /_api/replication/logger-tick-ranges).
+	// For incremental WAL tailing, use
 	// GET /_db/{database-name}/_api/wal/tail instead.
 	// On older versions this method still works.
 	LoggerTickRange(ctx context.Context, dbName string) ([]LoggerTickRangeResponseObj, error)
@@ -95,6 +95,9 @@ type ClientReplication interface {
 	// design (GET /_api/replication/applier-state). On older versions this method still works.
 	GetApplierState(ctx context.Context, dbName string, global *bool) (ApplierStateResp, error)
 	// GetReplicationServerId retrieves the server ID used for replication.
+	//
+	// Deprecated: Removed in ArangoDB 3.12.10+
+	// (GET /_api/replication/server-id). On older versions this method still works.
 	GetReplicationServerId(ctx context.Context, dbName string) (string, error)
 	// MakeFollower makes the current server a follower of the specified leader.
 	//
@@ -118,6 +121,9 @@ type ClientReplication interface {
 	// FetchRevisionDocuments retrieves documents by their revision IDs.
 	FetchRevisionDocuments(ctx context.Context, dbName string, queryParams RevisionQueryParams, opts []string) ([]map[string]interface{}, error)
 	// StartReplicationSync starts the replication synchronization process.
+	//
+	// Deprecated: Removed in ArangoDB 3.12.10+
+	// (PUT /_api/replication/sync). On older versions this method still works.
 	StartReplicationSync(ctx context.Context, dbName string, opts ReplicationSyncOptions) (ReplicationSyncResult, error)
 }
 

--- a/v2/arangodb/client_replication_impl.go
+++ b/v2/arangodb/client_replication_impl.go
@@ -323,8 +323,8 @@ func (c *clientReplication) LoggerState(ctx context.Context, dbName string, DBse
 
 // LoggerFirstTick implements ClientReplication.LoggerFirstTick.
 //
-// Deprecated: See [ClientReplication.LoggerFirstTick]. On ArangoDB 4.0+ use HTTP
-// GET /_db/{database}/_api/wal/tail for WAL tailing instead of this replication sub-path.
+// Deprecated: See [ClientReplication.LoggerFirstTick]. Removed in ArangoDB 3.12.10+;
+// use HTTP GET /_db/{database}/_api/wal/tail for WAL tailing instead.
 func (c *clientReplication) LoggerFirstTick(ctx context.Context, dbName string) (LoggerFirstTickResponse, error) {
 	// Check server role
 	serverRole, err := c.client.ServerRole(ctx)
@@ -356,8 +356,8 @@ func (c *clientReplication) LoggerFirstTick(ctx context.Context, dbName string) 
 
 // LoggerTickRange implements ClientReplication.LoggerTickRange.
 //
-// Deprecated: See [ClientReplication.LoggerTickRange]. On ArangoDB 4.0+ use HTTP
-// GET /_db/{database}/_api/wal/tail for WAL tailing instead of this replication sub-path.
+// Deprecated: See [ClientReplication.LoggerTickRange]. Removed in ArangoDB 3.12.10+;
+// use HTTP GET /_db/{database}/_api/wal/tail for WAL tailing instead.
 func (c *clientReplication) LoggerTickRange(ctx context.Context, dbName string) ([]LoggerTickRangeResponseObj, error) {
 	// Check server role
 	serverRole, err := c.client.ServerRole(ctx)
@@ -671,6 +671,9 @@ func (c *clientReplication) GetApplierState(ctx context.Context, dbName string, 
 	}
 }
 
+// GetReplicationServerId implements ClientReplication.GetReplicationServerId.
+//
+// Deprecated: See [ClientReplication.GetReplicationServerId]. Removed in ArangoDB 3.12.10+.
 func (c *clientReplication) GetReplicationServerId(ctx context.Context, dbName string) (string, error) {
 
 	// Build URL
@@ -930,6 +933,9 @@ func (c *clientReplication) formSyncBodyParams(opts ReplicationSyncOptions) (map
 	return params, nil
 }
 
+// StartReplicationSync implements ClientReplication.StartReplicationSync.
+//
+// Deprecated: See [ClientReplication.StartReplicationSync]. Removed in ArangoDB 3.12.10+.
 func (c *clientReplication) StartReplicationSync(ctx context.Context, dbName string, opts ReplicationSyncOptions) (ReplicationSyncResult, error) {
 	// Check server role
 	serverRole, err := c.client.ServerRole(ctx)

--- a/v2/tests/client_replication_test.go
+++ b/v2/tests/client_replication_test.go
@@ -191,7 +191,8 @@ func Test_LoggerFirstTick(t *testing.T) {
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		WithDatabase(t, client, nil, func(db arangodb.Database) {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
-				skipFromVersion(client, ctx, "4.0", tb)
+				// GET /_api/replication/logger-first-tick removed in ArangoDB 3.12.10+.
+				skipFromVersion(client, ctx, "3.12.10", tb)
 				serverRole, err := client.ServerRole(ctx)
 				require.NoError(t, err)
 				t.Logf("ServerRole is %s\n", serverRole)
@@ -213,7 +214,8 @@ func Test_LoggerTickRange(t *testing.T) {
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		WithDatabase(t, client, nil, func(db arangodb.Database) {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
-				skipFromVersion(client, ctx, "4.0", tb)
+				// GET /_api/replication/logger-tick-ranges removed in ArangoDB 3.12.10+.
+				skipFromVersion(client, ctx, "3.12.10", tb)
 				serverRole, err := client.ServerRole(ctx)
 				require.NoError(t, err)
 				t.Logf("ServerRole is %s\n", serverRole)
@@ -405,6 +407,8 @@ func Test_GetReplicationServerId(t *testing.T) {
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		WithDatabase(t, client, nil, func(db arangodb.Database) {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
+				// GET /_api/replication/server-id removed in ArangoDB 3.12.10+.
+				skipFromVersion(client, ctx, "3.12.10", tb)
 				t.Run("Get replication server ID", func(t *testing.T) {
 					resp, err := client.GetReplicationServerId(ctx, db.Name())
 					require.NoError(t, err)
@@ -696,6 +700,8 @@ func Test_StartReplicationSync(t *testing.T) {
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		WithDatabase(t, client, nil, func(db arangodb.Database) {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
+				// PUT /_api/replication/sync removed in ArangoDB 3.12.10+.
+				skipFromVersion(client, ctx, "3.12.10", tb)
 				// Version checking
 				if os.Getenv("TEST_CONNECTION") == "vst" {
 					skipBelowVersion(client, ctx, "3.8", t)

--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
-- Replication: removed single-single replication applier API (`GetApplierConfig`, `UpdateApplierConfig`, `ApplierStart`, `ApplierStop`, `GetApplierState`, `MakeFollower`) and related types. Those endpoints were removed in ArangoDB 3.12.10 for a security issue and are absent in 4.0. WAL server identity type renamed to `ReplicationServer`.
+- Replication: remove APIs gone in ArangoDB 3.12.10+ (applier methods, `StartReplicationSync`, `GetReplicationServerId`, and related types); see `MIGRATION.md`. WAL server identity type renamed to `ReplicationServer`.
 - Switch to Go 1.25.12 to fix Encrypted Client Hello privacy leak in crypto/tls (GO-2026-5856)
 - Replication: stop using DBserver forwarding for inventory and logger-state (server allows it only for batch/dump); LoggerState is not supported on Coordinators
 - Switch to Go 1.25.11 to fix security issues in the standard library (GO-2026-5039, GO-2026-5037)

--- a/v3/MIGRATION.md
+++ b/v3/MIGRATION.md
@@ -20,13 +20,29 @@ The following packages/files are removed in `v3`:
 - `GetMetrics` (`/_admin/metrics/v2`) -> use `Metrics` (`/_admin/metrics`)
 - `HandleAdminVersion` (`/_admin/version`) -> use `Version` or `VersionWithOptions` (`/_api/version`)
 - `ExecuteAdminScript` (`/_admin/execute`) -> removed with no direct replacement
-- `LoggerFirstTick` (`/_api/replication/logger-first-tick`) -> removed in ArangoDB 4.0
-- `LoggerTickRange` (`/_api/replication/logger-tick-ranges`) -> removed in ArangoDB 4.0
 - `GetUserDefinedFunctions` (`/_api/aqlfunction`) -> removed in ArangoDB 4.0
 - `CreateUserDefinedFunction` (`/_api/aqlfunction`) -> removed in ArangoDB 4.0
 - `DeleteUserDefinedFunction` (`/_api/aqlfunction/{name}`) -> removed in ArangoDB 4.0
 - `TransactionJS` (`/_api/transaction`) -> removed in ArangoDB 4.0
 - `ReloadRoutingTable` (`/_admin/routing/reload`) -> removed because Action/Foxx microservice route reloading is removed in ArangoDB 4.0
+
+### Replication endpoints removed in ArangoDB 3.12.10+
+
+These endpoints are removed in ArangoDB 3.12.10+ (applier endpoints for a security
+issue inherent to the design; remaining single-single replication endpoints as part
+of the same cleanup). Leader-follower was deprecated since 3.9; Active Failover was
+deprecated in 3.11 and removed in 3.12.
+
+- `GetApplierConfig` (`/_api/replication/applier-config`) -> removed with no direct replacement
+- `UpdateApplierConfig` (`/_api/replication/applier-config`) -> removed with no direct replacement
+- `ApplierStart` (`/_api/replication/applier-start`) -> removed with no direct replacement
+- `ApplierStop` (`/_api/replication/applier-stop`) -> removed with no direct replacement
+- `GetApplierState` (`/_api/replication/applier-state`) -> removed with no direct replacement
+- `MakeFollower` (`/_api/replication/make-follower`) -> removed with no direct replacement
+- `StartReplicationSync` (`/_api/replication/sync`) -> removed with no direct replacement
+- `LoggerFirstTick` (`/_api/replication/logger-first-tick`) -> use `GetWALTail` (`/_api/wal/tail`)
+- `LoggerTickRange` (`/_api/replication/logger-tick-ranges`) -> use `GetWALTail` (`/_api/wal/tail`)
+- `GetReplicationServerId` (`/_api/replication/server-id`) -> removed with no direct replacement
 
 ## Removed Fields and Replacements
 

--- a/v3/arangodb/client_replication.go
+++ b/v3/arangodb/client_replication.go
@@ -42,8 +42,6 @@ type ClientReplication interface {
 	// Not supported on Coordinators. DBserver is ignored; forwarding is
 	// restricted to batch and dump.
 	LoggerState(ctx context.Context, dbName string, DBserver *string) (LoggerStateResponse, error)
-	// GetReplicationServerId retrieves the server ID used for replication.
-	GetReplicationServerId(ctx context.Context, dbName string) (string, error)
 	// GetWALRange retrieves the WAL range information.
 	GetWALRange(ctx context.Context, dbName string) (WALRangeResponse, error)
 	// GetWALLastTick retrieves the last available tick information.
@@ -58,8 +56,6 @@ type ClientReplication interface {
 	ListDocumentRevisionsInRange(ctx context.Context, dbName string, queryParams RevisionQueryParams, opts [][2]string) ([][2]string, error)
 	// FetchRevisionDocuments retrieves documents by their revision IDs.
 	FetchRevisionDocuments(ctx context.Context, dbName string, queryParams RevisionQueryParams, opts []string) ([]map[string]interface{}, error)
-	// StartReplicationSync starts the replication synchronization process.
-	StartReplicationSync(ctx context.Context, dbName string, opts ReplicationSyncOptions) (ReplicationSyncResult, error)
 }
 
 // CreateNewBatchOptions represents the request body for creating a batch.
@@ -357,59 +353,4 @@ type RevisionQueryParams struct {
 	BatchId    string `json:"batchId"`
 	// The revisionId at which to resume, if a previous request was truncated
 	Resume *string `json:"resume,omitempty"`
-}
-
-// ReplicationSyncResult is the response format from /_api/replication/sync
-type ReplicationSyncResult struct {
-	// Collections is an array of collections that were synchronized
-	// from the leader to the local database.
-	Collections []map[string]interface{} `json:"collections"`
-
-	// LastLogTick is the log tick value from the leader at the time
-	// the synchronization started. This value can be used later as
-	// the "from" tick when setting up continuous replication.
-	LastLogTick string `json:"lastLogTick"`
-}
-
-// ReplicationSyncOptions holds optional parameters for sync
-type ReplicationSyncOptions struct {
-	// Database specifies the name of the leader database to replicate from.
-	// If not provided, defaults to the current database.
-	Database *string `json:"database,omitempty"`
-
-	// Endpoint is the leader endpoint (e.g., "http+tcp://192.168.1.65:8529").
-	// This field is required.
-	Endpoint string `json:"endpoint,omitempty"`
-
-	// Username is the login name used for authentication on the leader endpoint.
-	Username string `json:"username,omitempty"`
-
-	// Password is the corresponding password used for authentication
-	// on the leader endpoint.
-	Password string `json:"password,omitempty"`
-
-	// IncludeSystem determines whether system collections should be included
-	// in the synchronization. Defaults to false.
-	IncludeSystem *bool `json:"includeSystem,omitempty"`
-
-	// Incremental indicates if incremental synchronization should be used.
-	// When true, only differences are transferred, which is faster if the
-	// local database already has some of the leader’s data.
-	// When false (default), a full synchronization is performed.
-	Incremental *bool `json:"incremental,omitempty"`
-
-	// RestrictType controls how RestrictCollections is applied.
-	// Possible values:
-	//   - "include": only collections listed in RestrictCollections are replicated.
-	//   - "exclude": all collections except those listed are replicated.
-	RestrictType *string `json:"restrictType,omitempty"`
-
-	// RestrictCollections is the list of collections used together with
-	// RestrictType to filter which collections are synchronized.
-	RestrictCollections *[]string `json:"restrictCollections,omitempty"`
-
-	// InitialSyncMaxWaitSec specifies the maximum wait time (in seconds)
-	// the synchronization will wait for a response from the leader during
-	// initial collection data fetch. A value of 0 disables the wait time limit.
-	InitialSyncMaxWaitSec int `json:"initialSyncMaxWaitSec,omitempty"`
 }

--- a/v3/arangodb/client_replication_impl.go
+++ b/v3/arangodb/client_replication_impl.go
@@ -321,29 +321,6 @@ func (c *clientReplication) LoggerState(ctx context.Context, dbName string, DBse
 	}
 }
 
-func (c *clientReplication) GetReplicationServerId(ctx context.Context, dbName string) (string, error) {
-
-	// Build URL
-	url := c.url(dbName, []string{"server-id"}, nil)
-
-	var response struct {
-		shared.ResponseStruct `json:",inline"`
-		ServerId              string `json:"serverId"`
-	}
-
-	resp, err := connection.CallGet(ctx, c.client.connection, url, &response)
-	if err != nil {
-		return "", errors.WithStack(err)
-	}
-
-	switch code := resp.Code(); code {
-	case http.StatusOK:
-		return response.ServerId, nil
-	default:
-		return "", response.AsArangoErrorWithCode(code)
-	}
-}
-
 // RebuildShardRevisionTree triggers a rebuild of the Merkle tree for a specific shard.
 // This API must be called directly against a DBServer (not a Coordinator).
 func (c *clientReplication) RebuildShardRevisionTree(ctx context.Context, dbName string, shardID ShardID) error {
@@ -506,74 +483,6 @@ func (c *clientReplication) FetchRevisionDocuments(ctx context.Context, dbName s
 		return response, nil
 	default:
 		return nil, (&shared.ResponseStruct{}).AsArangoErrorWithCode(resp.Code())
-	}
-}
-
-func (c *clientReplication) formSyncBodyParams(opts ReplicationSyncOptions) (map[string]interface{}, error) {
-	params := map[string]interface{}{}
-	if opts.Endpoint == "" {
-		return nil, RequiredFieldError("endpoint")
-	}
-	params["endpoint"] = opts.Endpoint
-	if opts.Database != nil && *opts.Database != "" {
-		params["database"] = *opts.Database
-	}
-	if opts.Username != "" {
-		params["username"] = opts.Username
-	}
-	if opts.Password != "" {
-		params["password"] = opts.Password
-	}
-	if opts.IncludeSystem != nil {
-		params["includeSystem"] = *opts.IncludeSystem
-	}
-	if opts.Incremental != nil {
-		params["incremental"] = *opts.Incremental
-	}
-	if opts.RestrictType != nil && *opts.RestrictType != "" {
-		params["restrictType"] = *opts.RestrictType
-	}
-	if opts.RestrictCollections != nil && len(*opts.RestrictCollections) > 0 {
-		params["restrictCollections"] = *opts.RestrictCollections
-	}
-	params["initialSyncMaxWaitTime"] = opts.InitialSyncMaxWaitSec
-	return params, nil
-}
-
-func (c *clientReplication) StartReplicationSync(ctx context.Context, dbName string, opts ReplicationSyncOptions) (ReplicationSyncResult, error) {
-	// Check server role
-	serverRole, err := c.client.ServerRole(ctx)
-
-	if err != nil {
-		return ReplicationSyncResult{}, errors.WithStack(err)
-	}
-	if serverRole == ServerRoleCoordinator {
-		return ReplicationSyncResult{}, errors.New("replication sync is not supported on Coordinators")
-	}
-	// Form request body params
-	body, err := c.formSyncBodyParams(opts)
-	if err != nil {
-		return ReplicationSyncResult{}, err
-	}
-
-	// Build URL
-	url := c.url(dbName, []string{"sync"}, nil)
-
-	var response struct {
-		shared.ResponseStruct `json:",inline"`
-		ReplicationSyncResult `json:",inline"`
-	}
-
-	resp, err := connection.CallPut(ctx, c.client.connection, url, &response, body)
-	if err != nil {
-		return ReplicationSyncResult{}, errors.WithStack(err)
-	}
-
-	switch code := resp.Code(); code {
-	case http.StatusOK:
-		return response.ReplicationSyncResult, nil
-	default:
-		return ReplicationSyncResult{}, response.AsArangoErrorWithCode(code)
 	}
 }
 

--- a/v3/tests/client_replication_test.go
+++ b/v3/tests/client_replication_test.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -33,24 +32,6 @@ import (
 	"github.com/arangodb/go-driver/v3/utils"
 	"github.com/stretchr/testify/require"
 )
-
-// getSyncEndpoint returns the endpoint from TEST_ENDPOINTS environment variable
-// converted to the format expected by ReplicationSyncOptions (http+tcp:// or https+ssl://).
-// TEST_ENDPOINTS must be set; if it is not, the test will fail.
-func getSyncEndpoint(t testing.TB) string {
-	eps := getEndpointsFromEnv(t)
-	// getEndpointsFromEnv will have already failed if TEST_ENDPOINTS is not set,
-	// so we can safely use the first endpoint
-
-	// Get the first endpoint and convert from http/https to http+tcp/https+ssl format
-	endpoint := eps[0]
-	if strings.HasPrefix(endpoint, "https://") {
-		endpoint = strings.Replace(endpoint, "https://", "https+ssl://", 1)
-	} else if strings.HasPrefix(endpoint, "http://") {
-		endpoint = strings.Replace(endpoint, "http://", "http+tcp://", 1)
-	}
-	return endpoint
-}
 
 func Test_CreateNewBatch(t *testing.T) {
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
@@ -163,21 +144,6 @@ func Test_LoggerState(t *testing.T) {
 				require.NotEmpty(t, resp.State)
 				require.NotEmpty(t, resp.Server)
 				require.GreaterOrEqual(t, len(resp.Clients), 0)
-			})
-		})
-	})
-}
-
-func Test_GetReplicationServerId(t *testing.T) {
-	Wrap(t, func(t *testing.T, client arangodb.Client) {
-		WithDatabase(t, client, nil, func(db arangodb.Database) {
-			withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
-				t.Run("Get replication server ID", func(t *testing.T) {
-					resp, err := client.GetReplicationServerId(ctx, db.Name())
-					require.NoError(t, err)
-					require.NotNil(t, resp)
-					t.Logf("Replication Server ID: %s", resp)
-				})
 			})
 		})
 	})
@@ -398,45 +364,6 @@ func Test_FetchRevisionDocuments(t *testing.T) {
 					require.NoError(t, err)
 					require.NotNil(t, revDocs)
 				})
-			})
-		})
-	})
-}
-
-func Test_StartReplicationSync(t *testing.T) {
-	Wrap(t, func(t *testing.T, client arangodb.Client) {
-		WithDatabase(t, client, nil, func(db arangodb.Database) {
-			withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
-				// Version checking
-				if os.Getenv("TEST_CONNECTION") == "vst" {
-					skipBelowVersion(client, ctx, "3.8", t)
-				}
-
-				// Role check
-				serverRole, err := client.ServerRole(ctx)
-				require.NoError(t, err)
-				t.Logf("ServerRole: %s", serverRole)
-
-				if serverRole == arangodb.ServerRoleCoordinator || serverRole == arangodb.ServerRoleSingle {
-					t.Skipf("Replication sync not supported on role: %s", serverRole)
-				}
-
-				opts := arangodb.ReplicationSyncOptions{
-					Endpoint: getSyncEndpoint(t),
-					Username: "root",
-				}
-
-				result, err := client.StartReplicationSync(ctx, db.Name(), opts)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				if len(result.Collections) == 0 {
-					t.Errorf("expected collections in result")
-				}
-				if result.LastLogTick == "" {
-					t.Errorf("expected lastLogTick in result")
-				}
 			})
 		})
 	})


### PR DESCRIPTION
- Mark **sync, logger-first-tick, logger-tick-ranges, and server-id** as deprecated in v2 (tests skip from 3.12.10)
- Remove them from v3, and document all 3.12.10+ replication removals in MIGRATION.md.