### PR TITLE
Switch to Go 1.25.13 to fix standard library security issues (GO-2026…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,17 +4,17 @@ orbs:
 executors:
   golang-executor:
     docker:
-      - image: gcr.io/gcr-for-testing/golang:1.25.12
+      - image: gcr.io/gcr-for-testing/golang:1.25.13
     resource_class: arangodb/medium-amd64
 
   x86-docker-executor:
     docker:
-      - image: gcr.io/gcr-for-testing/golang:1.25.12
+      - image: gcr.io/gcr-for-testing/golang:1.25.13
     resource_class: arangodb/medium-amd64-privileged
 
   arm-docker-executor:
     docker:
-      - image: gcr.io/gcr-for-testing/golang:1.25.12
+      - image: gcr.io/gcr-for-testing/golang:1.25.13
     resource_class: arangodb/medium-arm64-privileged
 aliases:
   - &notify_slack_on_fail
@@ -39,7 +39,7 @@ aliases:
 parameters:
   goImage:
     type: string
-    default: "gcr.io/gcr-for-testing/golang:1.25.12"
+    default: "gcr.io/gcr-for-testing/golang:1.25.13"
   arangodbImageV2:
     type: string
     default: "gcr.io/gcr-for-testing/arangodb/enterprise-preview:latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
+- Switch to Go 1.25.13 to fix standard library security issues (GO-2026-6218, GO-2026-6090, GO-2026-5972, GO-2026-5026)
 - Switch to Go 1.25.12 to fix Encrypted Client Hello privacy leak in crypto/tls (GO-2026-5856)
 - Switch to Go 1.25.11 to fix security issues in the standard library (GO-2026-5039, GO-2026-5037)
 - Switch to Go 1.25.10 and bump golang.org/x/net to v0.53.0 to fix security issues (GO-2026-4971, GO-2026-4918)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SCRIPTDIR := $(shell pwd)
 CURR=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 ROOTDIR:=$(CURR)
 
-GOVERSION ?= 1.25.12
+GOVERSION ?= 1.25.13
 GOTOOLCHAIN ?= auto
 GOIMAGE ?= golang:$(GOVERSION)
 GOV2IMAGE ?= $(GOIMAGE)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/arangodb/go-driver
 
 go 1.25.0
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 require (
 	github.com/arangodb/go-velocypack v0.0.0-20200318135517-5af53c29c67e

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
 - Replication: deprecate APIs removed in ArangoDB 3.12.10+ (`GetApplierConfig`, `UpdateApplierConfig`, `ApplierStart`, `ApplierStop`, `GetApplierState`, `MakeFollower`, `StartReplicationSync`, `LoggerFirstTick`, `LoggerTickRange`, `GetReplicationServerId`); related tests skip from 3.12.10.
+- Switch to Go 1.25.13 to fix standard library security issues (GO-2026-6218, GO-2026-6090, GO-2026-5972, GO-2026-5026)
 - Switch to Go 1.25.12 to fix Encrypted Client Hello privacy leak in crypto/tls (GO-2026-5856)
 - Connection: added optional `ArangoDBConfiguration.HostHeader` so clients can dial an IP/URL host while sending a different HTTP `Host` (e.g. ingress / virtual hosts).
 - Tests: added v2 Kubernetes resiliency and Toxiproxy suites (kind + kube-arangodb + ingress-nginx) with shared multi-driver runner docs.

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -2,7 +2,7 @@ module github.com/arangodb/go-driver/v2
 
 go 1.25.0
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 require (
 	github.com/Shopify/toxiproxy/v2 v2.12.0

--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
 - Replication: remove APIs gone in ArangoDB 3.12.10+ (applier methods, `StartReplicationSync`, `GetReplicationServerId`, and related types); see `MIGRATION.md`. WAL server identity type renamed to `ReplicationServer`.
+- Switch to Go 1.25.13 to fix standard library security issues (GO-2026-6218, GO-2026-6090, GO-2026-5972, GO-2026-5026)
 - Switch to Go 1.25.12 to fix Encrypted Client Hello privacy leak in crypto/tls (GO-2026-5856)
 - Replication: stop using DBserver forwarding for inventory and logger-state (server allows it only for batch/dump); LoggerState is not supported on Coordinators
 - Switch to Go 1.25.11 to fix security issues in the standard library (GO-2026-5039, GO-2026-5037)

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -2,7 +2,7 @@ module github.com/arangodb/go-driver/v3
 
 go 1.25.0
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 require (
 	github.com/arangodb/go-velocypack v0.0.0-20200318135517-5af53c29c67e


### PR DESCRIPTION
…-6218, GO-2026-6090, GO-2026-5972, GO-2026-5026)