### PR TITLE
DE-1208: Use ArangoDB 4.0 core-preview images for v3 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,18 +40,25 @@ parameters:
   goImage:
     type: string
     default: "gcr.io/gcr-for-testing/golang:1.25.13"
+  # v2 tests ArangoDB 3.12 (enterprise-preview: server + client tools + JS).
   arangodbImageV2:
     type: string
     default: "gcr.io/gcr-for-testing/arangodb/enterprise-preview:latest"
+  # v3 tests ArangoDB 4.0 (core-preview: server only; client tools are a separate image).
   arangodbImageV3:
     type: string
-    default: "gcr.io/gcr-for-testing/arangodb/enterprise-preview:4.0-nightly"
+    default: "gcr.io/gcr-for-testing/arangodb/core-preview:4.0-nightly"
   alpineImage:
     type: string
     default: "gcr.io/gcr-for-testing/alpine:3.23"
+  # v2 / Kubernetes jobs (3.12). Do not point this at 4.0.
   starterImage:
     type: string
     default: "arangodb/arangodb-starter:latest"
+  # v3 jobs (4.0 core-preview needs Starter 0.20 for arangodb4 layout / server-only image).
+  starterImageV3:
+    type: string
+    default: "arangodb/arangodb-starter:0.20.0-preview-16"
   kubeArangoDBVersion:
     type: string
     default: "1.4.3"
@@ -231,6 +238,10 @@ jobs:
         type: string
       arangodb-image:
         type: string
+      starter-image:
+        type: string
+        default: << pipeline.parameters.starterImage >>
+        description: "ArangoDB Starter image. v3 jobs pass starterImageV3 (0.20); v2 keeps starterImage."
       enable-extra-db-features:
         type: boolean
         default: false
@@ -264,6 +275,7 @@ jobs:
     environment:
       <<: *integration_test_env_core
       ARANGODB: << parameters.arangodb-image >>
+      STARTER: << parameters.starter-image >>
 
   # ----------------------------------------
   # ARM INTEGRATION TEST JOB
@@ -275,6 +287,10 @@ jobs:
         type: string
       arangodb-image:
         type: string
+      starter-image:
+        type: string
+        default: << pipeline.parameters.starterImage >>
+        description: "ArangoDB Starter image. v3 jobs pass starterImageV3 (0.20); v2 keeps starterImage."
       enable-extra-db-features:
         type: boolean
         default: false
@@ -313,6 +329,7 @@ jobs:
     environment:
       <<: *integration_test_env_core
       ARANGODB: << parameters.arangodb-image >>
+      STARTER: << parameters.starter-image >>
 
   # ----------------------------------------
   # KUBERNETES INTEGRATION TEST JOB
@@ -643,6 +660,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-with-basic-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests:
           context:
@@ -653,6 +671,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-without-ssl
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests:
           context:
@@ -663,6 +682,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-without-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests:
           context:
@@ -673,6 +693,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-with-jwt-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests:
           context:
@@ -683,6 +704,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-with-basic-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
           enable-extra-db-features: true
 
       - run-integration-tests:
@@ -694,6 +716,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-without-ssl
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
           enable-extra-db-features: true
 
       - run-integration-tests:
@@ -705,6 +728,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-without-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
           enable-extra-db-features: true
 
       - run-integration-tests:
@@ -716,6 +740,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-with-jwt-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
           enable-extra-db-features: true
 
       - run-integration-tests:
@@ -727,6 +752,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-single-without-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests:
           context:
@@ -737,6 +763,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-single-with-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
 
       # ========================
       # Kubernetes Tests x86
@@ -822,6 +849,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-with-basic-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests-arm:
           context:
@@ -832,6 +860,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-without-ssl
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests-arm:
           context:
@@ -842,6 +871,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-without-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests-arm:
           context:
@@ -852,6 +882,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-with-jwt-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests-arm:
           context:
@@ -862,6 +893,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-single-without-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests-arm:
           context:
@@ -872,6 +904,7 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-single-with-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
+          starter-image: << pipeline.parameters.starterImageV3 >>
 
   # Weekly vulnerability check
   weekly_vulncheck:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,6 +4,10 @@
 - Build using `make clean && make`
 - After merging PR, always run `make changelog` and commit changes
 - Set ArangoDB docker container (used for testing) using `export ARANGODB=<image-name>`
+- Test image matrix:
+  - **v2 / ArangoDB 3.12:** `ARANGODB=arangodb/enterprise-preview:latest` (CI: `gcr.io/gcr-for-testing/arangodb/enterprise-preview:latest`) and `STARTER=arangodb/arangodb-starter:latest`
+  - **v3 / ArangoDB 4.0:** `ARANGODB=arangodb/core-preview:4.0-nightly` (CI: `gcr.io/gcr-for-testing/arangodb/core-preview:4.0-nightly`) and `STARTER=arangodb/arangodb-starter:0.20.0-preview-16`
+  - `make run-v3-tests-*` uses the 4.0 defaults above unless `ARANGODB` / `STARTER` are set in the environment or on the make command line
 - Run tests using:
   - `make run-tests-single`
   - `make run-tests-resilientsingle`

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,27 @@ GOBUILDTAGSOPT=-tags "$(GOBUILDTAGS)"
 
 ARANGODB ?= arangodb/enterprise:latest
 STARTER ?= arangodb/arangodb-starter:latest
+# v3 / ArangoDB 4.0 local defaults. CI sets ARANGODB and STARTER on the job.
+ARANGODB_V3 ?= arangodb/core-preview:4.0-nightly
+STARTER_V3 ?= arangodb/arangodb-starter:0.20.0-preview-16
 K8S_DRIVER_TEST_RUNNER ?= $(ROOTDIR)/deploy/kubernetes/run-driver-tests.sh
 K8S_NAMESPACE ?= default
 K8S_DEPLOYMENT ?= arangodb-driver-tests
 
 ifeq ($(origin K8S_RESILIENCY_TEST_VERBOSE),undefined)
 K8S_RESILIENCY_TEST_VERBOSE := -v
+endif
+
+# Use 4.0 images for v3 unless ARANGODB/STARTER were set from the environment or make CLI.
+ifeq ($(filter environment command line,$(origin ARANGODB)),)
+V3_TEST_ARANGODB := $(ARANGODB_V3)
+else
+V3_TEST_ARANGODB := $(ARANGODB)
+endif
+ifeq ($(filter environment command line,$(origin STARTER)),)
+V3_TEST_STARTER := $(STARTER_V3)
+else
+V3_TEST_STARTER := $(STARTER)
 endif
 
 ifdef VERBOSE
@@ -905,35 +920,35 @@ run-v3-tests-cluster: run-v3-tests-cluster-with-basic-auth run-v3-tests-cluster-
 
 run-v3-tests-cluster-with-basic-auth:
 	@echo "Cluster server, with basic authentication, v3"
-	@${MAKE} TEST_MODE="cluster" TEST_SSL="auto" TEST_AUTH="rootpw" __run_v3_tests
+	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(V3_TEST_STARTER) TEST_MODE="cluster" TEST_SSL="auto" TEST_AUTH="rootpw" __run_v3_tests
 
 run-v3-tests-cluster-with-jwt-auth:
 	@echo "Cluster server, with JWT authentication, v3"
-	@${MAKE} TEST_MODE="cluster" TEST_SSL="auto" TEST_AUTH="jwt" __run_v3_tests
+	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(V3_TEST_STARTER) TEST_MODE="cluster" TEST_SSL="auto" TEST_AUTH="jwt" __run_v3_tests
 
 run-v3-tests-cluster-without-auth:
 	@echo "Cluster server, without authentication, v3"
-	@${MAKE} TEST_MODE="cluster" TEST_SSL="auto" TEST_AUTH="none" __run_v3_tests
+	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(V3_TEST_STARTER) TEST_MODE="cluster" TEST_SSL="auto" TEST_AUTH="none" __run_v3_tests
 
 run-v3-tests-cluster-without-ssl:
 	@echo "Cluster server, without authentication and SSL, v3"
-	@${MAKE} TEST_MODE="cluster" TEST_AUTH="none" __run_v3_tests
+	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(V3_TEST_STARTER) TEST_MODE="cluster" TEST_AUTH="none" __run_v3_tests
 
 run-v3-tests-single: run-v3-tests-single-without-auth run-v3-tests-single-with-auth
 
 run-v3-tests-single-without-auth:
 	@echo "Single server, without authentication, v3"
-	@${MAKE} TEST_MODE="single" TEST_AUTH="none" __run_v3_tests
+	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(V3_TEST_STARTER) TEST_MODE="single" TEST_AUTH="none" __run_v3_tests
 
 run-v3-tests-single-with-auth:
 	@echo "Single server, with authentication, v3"
-	@${MAKE} TEST_MODE="single" TEST_SSL="auto" TEST_AUTH="rootpw" __run_v3_tests
+	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(V3_TEST_STARTER) TEST_MODE="single" TEST_SSL="auto" TEST_AUTH="rootpw" __run_v3_tests
 
 run-v3-tests-resilientsingle: run-v3-tests-resilientsingle-with-auth
 
 run-v3-tests-resilientsingle-with-auth:
 	@echo "Resilient Single, with authentication, v3"
-	@${MAKE} TEST_MODE="resilientsingle" TEST_AUTH="rootpw" TESTV2PARALLEL=1 __run_v3_tests
+	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(V3_TEST_STARTER) TEST_MODE="resilientsingle" TEST_AUTH="rootpw" TESTV2PARALLEL=1 __run_v3_tests
 
 GH_RELEASE := $(TMPDIR)/bin/github-release
 RELEASE := $(SCRIPTDIR)/tools/release

--- a/v3/CHANGELOG.md
+++ b/v3/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [master](https://github.com/arangodb/go-driver/tree/master) (N/A)
+- Tests: run v3 integration jobs against `arangodb/core-preview:4.0-nightly` with Starter `0.20.0-preview-16` (4.0 server-only image). v2 stays on `enterprise-preview:latest`.
 - Replication: remove APIs gone in ArangoDB 3.12.10+ (applier methods, `StartReplicationSync`, `GetReplicationServerId`, and related types); see `MIGRATION.md`. WAL server identity type renamed to `ReplicationServer`.
 - Switch to Go 1.25.13 to fix standard library security issues (GO-2026-6218, GO-2026-6090, GO-2026-5972, GO-2026-5026)
 - Switch to Go 1.25.12 to fix Encrypted Client Hello privacy leak in crypto/tls (GO-2026-5856)


### PR DESCRIPTION
[DE-1208](https://arangodb.atlassian.net/browse/DE-1208): Point v3 tests at ArangoDB 4.0 core-preview and Starter 0.20

4.0 nightlies now ship as the server-only core-preview image, so v3 CI and local make targets need that image plus Starter 0.20. v2 stays on enterprise-preview.

[DE-1208]: https://arangodb.atlassian.net/browse/DE-1208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ