### PR TITLE
CI: retry Docker image pulls so registry timeouts do not fail test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,17 +4,19 @@ orbs:
 executors:
   golang-executor:
     docker:
-      - image: gcr.io/gcr-for-testing/golang:1.25.13
+      - image: docker.io/library/golang:1.25.13
     resource_class: arangodb/medium-amd64
 
+  # Built for amd64 and arm64 from ci/Dockerfile.golang-docker.
+  # Rebuild and push this tag on Go upgrades; see MAINTAINERS.md.
   x86-docker-executor:
     docker:
-      - image: gcr.io/gcr-for-testing/golang:1.25.13
+      - image: gcr.io/gcr-for-testing/golang:1.25.13-docker
     resource_class: arangodb/medium-amd64-privileged
 
   arm-docker-executor:
     docker:
-      - image: gcr.io/gcr-for-testing/golang:1.25.13
+      - image: gcr.io/gcr-for-testing/golang:1.25.13-docker
     resource_class: arangodb/medium-arm64-privileged
 aliases:
   - &notify_slack_on_fail
@@ -30,7 +32,6 @@ aliases:
   - &integration_test_env_core
     GOIMAGE: << pipeline.parameters.goImage >>
     ALPINE_IMAGE: << pipeline.parameters.alpineImage >>
-    STARTER: << pipeline.parameters.starterImage >>
     ENABLE_DATABASE_EXTRA_FEATURES: << parameters.enable-extra-db-features >>
     ENABLE_VECTOR_INDEX: "true"
     TEST_DISALLOW_UNKNOWN_FIELDS: false
@@ -39,26 +40,18 @@ aliases:
 parameters:
   goImage:
     type: string
-    default: "gcr.io/gcr-for-testing/golang:1.25.13"
+    default: "docker.io/library/golang:1.25.13"
   # v2 tests ArangoDB 3.12 (enterprise-preview: server + client tools + JS).
   arangodbImageV2:
     type: string
-    default: "gcr.io/gcr-for-testing/arangodb/enterprise-preview:latest"
+    default: "docker.io/arangodb/enterprise-preview:3.12-nightly"
   # v3 tests ArangoDB 4.0 (core-preview: server only; client tools are a separate image).
   arangodbImageV3:
     type: string
-    default: "gcr.io/gcr-for-testing/arangodb/core-preview:4.0-nightly"
+    default: "docker.io/arangodb/core-preview:4.0-nightly"
   alpineImage:
     type: string
-    default: "gcr.io/gcr-for-testing/alpine:3.23"
-  # v2 / Kubernetes jobs (3.12). Do not point this at 4.0.
-  starterImage:
-    type: string
-    default: "arangodb/arangodb-starter:latest"
-  # v3 jobs (4.0 core-preview needs Starter 0.20 for arangodb4 layout / server-only image).
-  starterImageV3:
-    type: string
-    default: "arangodb/arangodb-starter:0.20.0-preview-16"
+    default: "docker.io/library/alpine:3.23"
   kubeArangoDBVersion:
     type: string
     default: "1.4.3"
@@ -73,7 +66,7 @@ parameters:
 
 commands:
   setup-docker:
-    description: "Install Docker and start the daemon in the job container"
+    description: "Start dockerd in the job container (image already includes Docker on privileged executors)"
     steps:
       - run:
           name: Set up Docker
@@ -238,10 +231,6 @@ jobs:
         type: string
       arangodb-image:
         type: string
-      starter-image:
-        type: string
-        default: << pipeline.parameters.starterImage >>
-        description: "ArangoDB Starter image. v3 jobs pass starterImageV3 (0.20); v2 keeps starterImage."
       enable-extra-db-features:
         type: boolean
         default: false
@@ -275,7 +264,6 @@ jobs:
     environment:
       <<: *integration_test_env_core
       ARANGODB: << parameters.arangodb-image >>
-      STARTER: << parameters.starter-image >>
 
   # ----------------------------------------
   # ARM INTEGRATION TEST JOB
@@ -287,10 +275,6 @@ jobs:
         type: string
       arangodb-image:
         type: string
-      starter-image:
-        type: string
-        default: << pipeline.parameters.starterImage >>
-        description: "ArangoDB Starter image. v3 jobs pass starterImageV3 (0.20); v2 keeps starterImage."
       enable-extra-db-features:
         type: boolean
         default: false
@@ -329,7 +313,6 @@ jobs:
     environment:
       <<: *integration_test_env_core
       ARANGODB: << parameters.arangodb-image >>
-      STARTER: << parameters.starter-image >>
 
   # ----------------------------------------
   # KUBERNETES INTEGRATION TEST JOB
@@ -660,7 +643,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-with-basic-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests:
           context:
@@ -671,7 +653,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-without-ssl
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests:
           context:
@@ -682,7 +663,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-without-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests:
           context:
@@ -693,7 +673,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-with-jwt-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests:
           context:
@@ -704,7 +683,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-with-basic-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
           enable-extra-db-features: true
 
       - run-integration-tests:
@@ -716,7 +694,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-without-ssl
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
           enable-extra-db-features: true
 
       - run-integration-tests:
@@ -728,7 +705,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-without-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
           enable-extra-db-features: true
 
       - run-integration-tests:
@@ -740,7 +716,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-with-jwt-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
           enable-extra-db-features: true
 
       - run-integration-tests:
@@ -752,7 +727,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-single-without-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests:
           context:
@@ -763,7 +737,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-single-with-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
 
       # ========================
       # Kubernetes Tests x86
@@ -849,7 +822,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-with-basic-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests-arm:
           context:
@@ -860,7 +832,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-without-ssl
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests-arm:
           context:
@@ -871,7 +842,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-without-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests-arm:
           context:
@@ -882,7 +852,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-cluster-with-jwt-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests-arm:
           context:
@@ -893,7 +862,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-single-without-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
 
       - run-integration-tests-arm:
           context:
@@ -904,7 +872,6 @@ workflows:
           needs_foxx_workspace: false
           test-to-run: run-v3-tests-single-with-auth
           arangodb-image: << pipeline.parameters.arangodbImageV3 >>
-          starter-image: << pipeline.parameters.starterImageV3 >>
 
   # Weekly vulnerability check
   weekly_vulncheck:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,9 @@ commands:
             if ! command -v docker >/dev/null 2>&1; then
               export DEBIAN_FRONTEND=noninteractive
               apt-get update
-              apt-get install -y docker.io
+              # Trixie: docker.io is dockerd only; the CLI is docker-cli.
+              apt-get install -y docker.io docker-cli
+              hash -r
             fi
             if ! docker info >/dev/null 2>&1; then
               dockerd >/tmp/dockerd.log 2>&1 &

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,9 +5,10 @@
 - After merging PR, always run `make changelog` and commit changes
 - Set ArangoDB docker container (used for testing) using `export ARANGODB=<image-name>`
 - Test image matrix:
-  - **v2 / ArangoDB 3.12:** `ARANGODB=arangodb/enterprise-preview:latest` (CI: `gcr.io/gcr-for-testing/arangodb/enterprise-preview:latest`) and `STARTER=arangodb/arangodb-starter:latest`
-  - **v3 / ArangoDB 4.0:** `ARANGODB=arangodb/core-preview:4.0-nightly` (CI: `gcr.io/gcr-for-testing/arangodb/core-preview:4.0-nightly`) and `STARTER=arangodb/arangodb-starter:0.20.0-preview-16`
-  - `make run-v3-tests-*` uses the 4.0 defaults above unless `ARANGODB` / `STARTER` are set in the environment or on the make command line
+  - **v2 / ArangoDB 3.12:** `ARANGODB=docker.io/arangodb/enterprise-preview:3.12-nightly`
+  - **v3 / ArangoDB 4.0:** `ARANGODB=docker.io/arangodb/core-preview:4.0-nightly`
+  - The matching Starter tag is detected from the ArangoDB image. Set `STARTER` in the environment or on the make command line only to override it.
+  - `make run-v3-tests-*` uses the 4.0 default above unless `ARANGODB` is set in the environment or on the make command line.
 - Run tests using:
   - `make run-tests-single`
   - `make run-tests-resilientsingle`
@@ -19,7 +20,17 @@
 
 # Change Golang version
 
-- Edit the [.circleci/config.yml](.circleci/config.yml) file and change ALL occurrences of `gcr.io/gcr-for-testing/golang` to the appropriate version.
+- Edit the [.circleci/config.yml](.circleci/config.yml) file: bump `goImage` and `golang-executor` (`docker.io/library/golang:<VER>`), and privileged executors (`gcr.io/gcr-for-testing/golang:<VER>-docker`).
+- Rebuild and push the privileged executor image for both CI architectures:
+  ```shell
+  docker buildx build \
+    --platform linux/amd64,linux/arm64 \
+    --build-arg GO_VERSION=<VER> \
+    -f ci/Dockerfile.golang-docker \
+    -t gcr.io/gcr-for-testing/golang:<VER>-docker \
+    --push \
+    .
+  ```
 - Edit the [Makefile](Makefile) and change the `GOVERSION` to the appropriate version.
 - For minor Go version updates, bump the Go version in [go.mod](go.mod) and in each **`vN/go.mod`** in use (`v2/`, `v3/`, …); run **`go mod tidy`** in the repository root and in each **`vN/`** module root.
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOIMAGE ?= golang:$(GOVERSION)
 GOV2IMAGE ?= $(GOIMAGE)
 ALPINE_IMAGE ?= alpine:3.23
 TMPDIR := ${SCRIPTDIR}/.tmp
-# Extra docker pull attempts after the first failure (Vadim: at least one retry).
+# Extra docker pull attempts after the first failure.
 DOCKER_PULL_RETRIES ?= 1
 
 DOCKER_CMD:=docker run

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ GOIMAGE ?= golang:$(GOVERSION)
 GOV2IMAGE ?= $(GOIMAGE)
 ALPINE_IMAGE ?= alpine:3.23
 TMPDIR := ${SCRIPTDIR}/.tmp
+DOCKER_PULL_RETRIES ?= 5
 
 DOCKER_CMD:=docker run
 DOCKER_PLATFORM ?=
@@ -289,6 +290,7 @@ run-k8s-v2-toxiproxy-e2e-tls:
 run-tests-http: run-unit-tests
 
 run-unit-tests: run-v2-unit-tests
+	@$(MAKE) __docker_pull_goimage
 	@$(DOCKER_CMD) \
 		--rm \
 		-v "${ROOTDIR}":/usr/code \
@@ -299,6 +301,7 @@ run-unit-tests: run-v2-unit-tests
 		go test $(TESTOPTIONS) $(REPOPATH) $(REPOPATH)/http $(REPOPATH)/agency $(REPOPATH)/vst/protocol
 
 run-v2-unit-tests:
+	@$(MAKE) __docker_pull_goimage
 	@$(DOCKER_CMD) \
 		--rm \
 		-v "${ROOTDIR}"/v2:/usr/code \
@@ -685,7 +688,16 @@ __dir_setup:
 	@mkdir -p "${TMPDIR}"
 	@echo "${TMPDIR}"
 
-__test_prepare: __dir_setup
+# Pre-pull GOIMAGE so docker run does not hit a one-shot GCR timeout (CircleCI DinD).
+__docker_pull_goimage:
+	@DOCKER_PULL_RETRIES=$(DOCKER_PULL_RETRIES) DOCKER_PLATFORM="$(DOCKER_PLATFORM)" \
+	  "${ROOTDIR}/test/docker_pull.sh" "$(GOIMAGE)"
+ifneq ($(GOV2IMAGE),$(GOIMAGE))
+	@DOCKER_PULL_RETRIES=$(DOCKER_PULL_RETRIES) DOCKER_PLATFORM="$(DOCKER_PLATFORM)" \
+	  "${ROOTDIR}/test/docker_pull.sh" "$(GOV2IMAGE)"
+endif
+
+__test_prepare: __dir_setup __docker_pull_goimage
 ifdef TEST_ENDPOINTS_OVERRIDE
 	@-docker rm -f -v $(TESTCONTAINER) >/dev/null 2>&1
 	@sleep 3

--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,7 @@ run-k8s-v2-toxiproxy-e2e-tls:
 # The below rule exists only for backward compatibility.
 run-tests-http: run-unit-tests
 
+# Unit tests run in GOIMAGE only. Do not pull GOV2IMAGE here.
 run-unit-tests: run-v2-unit-tests
 	@$(MAKE) __docker_pull_goimage
 	@$(DOCKER_CMD) \
@@ -298,7 +299,7 @@ run-unit-tests: run-v2-unit-tests
 		go test $(TESTOPTIONS) $(REPOPATH) $(REPOPATH)/http $(REPOPATH)/agency $(REPOPATH)/vst/protocol
 
 run-v2-unit-tests:
-	@$(MAKE) __docker_pull_goimage
+	@$(MAKE) __docker_pull_goimage # GOIMAGE only; GOV2IMAGE is for integration tests.
 	@$(DOCKER_CMD) \
 		--rm \
 		-v "${ROOTDIR}"/v2:/usr/code \
@@ -685,12 +686,12 @@ __dir_setup:
 	@mkdir -p "${TMPDIR}"
 	@echo "${TMPDIR}"
 
-# Pre-pull GOIMAGE so docker run does not fail on a one-shot registry timeout (CircleCI DinD).
+# Used by unit tests. Pulls GOIMAGE only.
 __docker_pull_goimage:
 	@DOCKER_PULL_RETRIES=$(DOCKER_PULL_RETRIES) DOCKER_PLATFORM="$(DOCKER_PLATFORM)" \
 	  "${ROOTDIR}/test/docker_pull.sh" "$(GOIMAGE)"
 
-# Integration tests may use a separate GOV2IMAGE; unit tests only need GOIMAGE.
+# Used by integration tests (__test_prepare). Pulls GOV2IMAGE only when it differs.
 __docker_pull_test_images: __docker_pull_goimage
 ifneq ($(GOV2IMAGE),$(GOIMAGE))
 	@DOCKER_PULL_RETRIES=$(DOCKER_PULL_RETRIES) DOCKER_PLATFORM="$(DOCKER_PLATFORM)" \

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ GOIMAGE ?= golang:$(GOVERSION)
 GOV2IMAGE ?= $(GOIMAGE)
 ALPINE_IMAGE ?= alpine:3.23
 TMPDIR := ${SCRIPTDIR}/.tmp
-DOCKER_PULL_RETRIES ?= 5
+# Extra docker pull attempts after the first failure (Vadim: at least one retry).
+DOCKER_PULL_RETRIES ?= 1
 
 DOCKER_CMD:=docker run
 DOCKER_PLATFORM ?=
@@ -20,11 +21,12 @@ DOCKER_CMD:=docker run $(DOCKER_PLATFORM)
 GOBUILDTAGS:=$(TAGS)
 GOBUILDTAGSOPT=-tags "$(GOBUILDTAGS)"
 
-ARANGODB ?= arangodb/enterprise:latest
-STARTER ?= arangodb/arangodb-starter:latest
-# v3 / ArangoDB 4.0 local defaults. CI sets ARANGODB and STARTER on the job.
+ARANGODB ?= arangodb/enterprise-preview:3.12-nightly
+# Empty by default: test/cluster.sh reads the Starter version from the ArangoDB
+# image. Set STARTER to pin a specific Starter image.
+STARTER ?=
+# v3 / ArangoDB 4.0 local default. CI sets ARANGODB on the job.
 ARANGODB_V3 ?= arangodb/core-preview:4.0-nightly
-STARTER_V3 ?= arangodb/arangodb-starter:0.20.0-preview-16
 K8S_DRIVER_TEST_RUNNER ?= $(ROOTDIR)/deploy/kubernetes/run-driver-tests.sh
 K8S_NAMESPACE ?= default
 K8S_DEPLOYMENT ?= arangodb-driver-tests
@@ -33,16 +35,11 @@ ifeq ($(origin K8S_RESILIENCY_TEST_VERBOSE),undefined)
 K8S_RESILIENCY_TEST_VERBOSE := -v
 endif
 
-# Use 4.0 images for v3 unless ARANGODB/STARTER were set from the environment or make CLI.
+# Use 4.0 images for v3 unless ARANGODB was set from the environment or make CLI.
 ifeq ($(filter environment command line,$(origin ARANGODB)),)
 V3_TEST_ARANGODB := $(ARANGODB_V3)
 else
 V3_TEST_ARANGODB := $(ARANGODB)
-endif
-ifeq ($(filter environment command line,$(origin STARTER)),)
-V3_TEST_STARTER := $(STARTER_V3)
-else
-V3_TEST_STARTER := $(STARTER)
 endif
 
 ifdef VERBOSE
@@ -688,16 +685,19 @@ __dir_setup:
 	@mkdir -p "${TMPDIR}"
 	@echo "${TMPDIR}"
 
-# Pre-pull GOIMAGE so docker run does not hit a one-shot GCR timeout (CircleCI DinD).
+# Pre-pull GOIMAGE so docker run does not fail on a one-shot registry timeout (CircleCI DinD).
 __docker_pull_goimage:
 	@DOCKER_PULL_RETRIES=$(DOCKER_PULL_RETRIES) DOCKER_PLATFORM="$(DOCKER_PLATFORM)" \
 	  "${ROOTDIR}/test/docker_pull.sh" "$(GOIMAGE)"
+
+# Integration tests may use a separate GOV2IMAGE; unit tests only need GOIMAGE.
+__docker_pull_test_images: __docker_pull_goimage
 ifneq ($(GOV2IMAGE),$(GOIMAGE))
 	@DOCKER_PULL_RETRIES=$(DOCKER_PULL_RETRIES) DOCKER_PLATFORM="$(DOCKER_PLATFORM)" \
 	  "${ROOTDIR}/test/docker_pull.sh" "$(GOV2IMAGE)"
 endif
 
-__test_prepare: __dir_setup __docker_pull_goimage
+__test_prepare: __dir_setup __docker_pull_test_images
 ifdef TEST_ENDPOINTS_OVERRIDE
 	@-docker rm -f -v $(TESTCONTAINER) >/dev/null 2>&1
 	@sleep 3
@@ -932,35 +932,35 @@ run-v3-tests-cluster: run-v3-tests-cluster-with-basic-auth run-v3-tests-cluster-
 
 run-v3-tests-cluster-with-basic-auth:
 	@echo "Cluster server, with basic authentication, v3"
-	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(V3_TEST_STARTER) TEST_MODE="cluster" TEST_SSL="auto" TEST_AUTH="rootpw" __run_v3_tests
+	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(STARTER) TEST_MODE="cluster" TEST_SSL="auto" TEST_AUTH="rootpw" __run_v3_tests
 
 run-v3-tests-cluster-with-jwt-auth:
 	@echo "Cluster server, with JWT authentication, v3"
-	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(V3_TEST_STARTER) TEST_MODE="cluster" TEST_SSL="auto" TEST_AUTH="jwt" __run_v3_tests
+	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(STARTER) TEST_MODE="cluster" TEST_SSL="auto" TEST_AUTH="jwt" __run_v3_tests
 
 run-v3-tests-cluster-without-auth:
 	@echo "Cluster server, without authentication, v3"
-	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(V3_TEST_STARTER) TEST_MODE="cluster" TEST_SSL="auto" TEST_AUTH="none" __run_v3_tests
+	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(STARTER) TEST_MODE="cluster" TEST_SSL="auto" TEST_AUTH="none" __run_v3_tests
 
 run-v3-tests-cluster-without-ssl:
 	@echo "Cluster server, without authentication and SSL, v3"
-	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(V3_TEST_STARTER) TEST_MODE="cluster" TEST_AUTH="none" __run_v3_tests
+	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(STARTER) TEST_MODE="cluster" TEST_AUTH="none" __run_v3_tests
 
 run-v3-tests-single: run-v3-tests-single-without-auth run-v3-tests-single-with-auth
 
 run-v3-tests-single-without-auth:
 	@echo "Single server, without authentication, v3"
-	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(V3_TEST_STARTER) TEST_MODE="single" TEST_AUTH="none" __run_v3_tests
+	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(STARTER) TEST_MODE="single" TEST_AUTH="none" __run_v3_tests
 
 run-v3-tests-single-with-auth:
 	@echo "Single server, with authentication, v3"
-	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(V3_TEST_STARTER) TEST_MODE="single" TEST_SSL="auto" TEST_AUTH="rootpw" __run_v3_tests
+	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(STARTER) TEST_MODE="single" TEST_SSL="auto" TEST_AUTH="rootpw" __run_v3_tests
 
 run-v3-tests-resilientsingle: run-v3-tests-resilientsingle-with-auth
 
 run-v3-tests-resilientsingle-with-auth:
 	@echo "Resilient Single, with authentication, v3"
-	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(V3_TEST_STARTER) TEST_MODE="resilientsingle" TEST_AUTH="rootpw" TESTV2PARALLEL=1 __run_v3_tests
+	@${MAKE} ARANGODB=$(V3_TEST_ARANGODB) STARTER=$(STARTER) TEST_MODE="resilientsingle" TEST_AUTH="rootpw" TESTV2PARALLEL=1 __run_v3_tests
 
 GH_RELEASE := $(TMPDIR)/bin/github-release
 RELEASE := $(SCRIPTDIR)/tools/release

--- a/ci/Dockerfile.golang-docker
+++ b/ci/Dockerfile.golang-docker
@@ -2,8 +2,9 @@ ARG GO_VERSION=1.25.13
 FROM golang:${GO_VERSION}
 
 ENV DEBIAN_FRONTEND=noninteractive
+# docker.io is the daemon only on Debian Trixie; docker-cli provides /usr/bin/docker.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends docker.io ca-certificates iptables \
+    && apt-get install -y --no-install-recommends docker.io docker-cli ca-certificates iptables \
     && rm -rf /var/lib/apt/lists/*
 
 # dockerd is started in the job (privileged), not at image build time.

--- a/ci/Dockerfile.golang-docker
+++ b/ci/Dockerfile.golang-docker
@@ -1,0 +1,9 @@
+ARG GO_VERSION=1.25.13
+FROM golang:${GO_VERSION}
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends docker.io ca-certificates iptables \
+    && rm -rf /var/lib/apt/lists/*
+
+# dockerd is started in the job (privileged), not at image build time.

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -77,22 +77,23 @@ if [ "$CMD" == "start" ]; then
         DOCKER_FWD_PORTS="-p 7001:7001 -p 7002:7002 -p 7003:7003 -p 7011:7011 -p 7012:7012 -p 7013:7013 -p 7021:7021 -p 7022:7022 -p 7023:7023"
     fi
 
-    set -x
+    # Fail the job if a required pull or container start fails (no errexit above).
+    set -ex
 
     PULL="${SCRIPT_DIR}/docker_pull.sh"
-    DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" DOCKER_PULL_FORCE=1 "$PULL" "${ARANGODB}" || exit 1
+    DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" DOCKER_PULL_FORCE=1 "$PULL" "${ARANGODB}"
 
     # Starter version comes from the server image unless the caller pinned one.
     if [ -z "${STARTER:-}" ]; then
-        STARTER="$(DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" "${SCRIPT_DIR}/starter_for_arangodb.sh" "${ARANGODB}")" || exit 1
+        STARTER="$(DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" "${SCRIPT_DIR}/starter_for_arangodb.sh" "${ARANGODB}")"
         echo "Detected Starter ${STARTER} for ${ARANGODB}"
     fi
 
-    DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" "$PULL" "${STARTER}" || exit 1
+    DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" "$PULL" "${STARTER}"
 
     if [ -z "$DOCKER_NETWORK" ]; then
         if [ -n "${ALPINE_IMAGE:-}" ]; then
-            DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" "$PULL" "${ALPINE_IMAGE}" || exit 1
+            DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" "$PULL" "${ALPINE_IMAGE}"
         fi
         DOCKER_NETWORK="--net=container:${NAMESPACE}"
         # Start network namespace

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -7,11 +7,6 @@ if [ -z "$TESTCONTAINER" ]; then
     exit 1 
 fi
 
-if [ -z "$STARTER" ]; then
-    echo "STARTER environment variable must be set"
-    exit 1
-fi
-
 NAMESPACE=${TESTCONTAINER}-ns
 STARTERVOLUME=${TESTCONTAINER}-vol
 STARTERCONTAINER=${TESTCONTAINER}-s
@@ -85,13 +80,20 @@ if [ "$CMD" == "start" ]; then
     set -x
 
     PULL="${SCRIPT_DIR}/docker_pull.sh"
-    DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" DOCKER_PULL_FORCE=1 "$PULL" "${ARANGODB}"
-    if [ -n "${ALPINE_IMAGE:-}" ]; then
-        DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" "$PULL" "${ALPINE_IMAGE}"
+    DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" DOCKER_PULL_FORCE=1 "$PULL" "${ARANGODB}" || exit 1
+
+    # Starter version comes from the server image unless the caller pinned one.
+    if [ -z "${STARTER:-}" ]; then
+        STARTER="$(DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" "${SCRIPT_DIR}/starter_for_arangodb.sh" "${ARANGODB}")" || exit 1
+        echo "Detected Starter ${STARTER} for ${ARANGODB}"
     fi
-    DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" "$PULL" "${STARTER}"
+
+    DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" "$PULL" "${STARTER}" || exit 1
 
     if [ -z "$DOCKER_NETWORK" ]; then
+        if [ -n "${ALPINE_IMAGE:-}" ]; then
+            DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" "$PULL" "${ALPINE_IMAGE}" || exit 1
+        fi
         DOCKER_NETWORK="--net=container:${NAMESPACE}"
         # Start network namespace
         docker run -d --name=${NAMESPACE} $DOCKERPLATFORMARG $DOCKER_DEBUG_PORT $DOCKER_FWD_PORTS "${ALPINE_IMAGE}" sleep 365d

--- a/test/cluster.sh
+++ b/test/cluster.sh
@@ -1,5 +1,7 @@
 #!/bin/bash 
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 if [ -z "$TESTCONTAINER" ]; then 
     echo "TESTCONTAINER environment variable must be set"
     exit 1 
@@ -80,19 +82,19 @@ if [ "$CMD" == "start" ]; then
         DOCKER_FWD_PORTS="-p 7001:7001 -p 7002:7002 -p 7003:7003 -p 7011:7011 -p 7012:7012 -p 7013:7013 -p 7021:7021 -p 7022:7022 -p 7023:7023"
     fi
 
+    set -x
+
+    PULL="${SCRIPT_DIR}/docker_pull.sh"
+    DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" DOCKER_PULL_FORCE=1 "$PULL" "${ARANGODB}"
+    if [ -n "${ALPINE_IMAGE:-}" ]; then
+        DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" "$PULL" "${ALPINE_IMAGE}"
+    fi
+    DOCKER_PLATFORM="${DOCKER_PLATFORM:-}" "$PULL" "${STARTER}"
+
     if [ -z "$DOCKER_NETWORK" ]; then
         DOCKER_NETWORK="--net=container:${NAMESPACE}"
         # Start network namespace
         docker run -d --name=${NAMESPACE} $DOCKERPLATFORMARG $DOCKER_DEBUG_PORT $DOCKER_FWD_PORTS "${ALPINE_IMAGE}" sleep 365d
-    fi
-
-    set -x
-    
-    # pull latest version of ArangoDB image
-    if [ -n "$DOCKER_PLATFORM" ]; then
-        docker pull ${DOCKER_PLATFORM} ${ARANGODB}
-    else
-        docker pull ${ARANGODB}
     fi
 
     # Start starters 

--- a/test/docker_pull.sh
+++ b/test/docker_pull.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Pull a Docker image with retries so a transient registry timeout does not fail
-# the whole test run (GCR timeouts are common in CircleCI docker-in-docker).
-# Images already present are reused unless DOCKER_PULL_FORCE is set.
+# the whole test run (CircleCI docker-in-docker). DOCKER_PULL_RETRIES is extra
+# attempts after the first pull (default 1). Images already present are reused
+# unless DOCKER_PULL_FORCE is set.
 set -u
 
 IMAGE="${1:-}"
@@ -29,10 +30,11 @@ if [ "$HAVE_LOCAL" = "yes" ] && [ -z "${DOCKER_PULL_FORCE:-}" ]; then
 	exit 0
 fi
 
-RETRIES="${DOCKER_PULL_RETRIES:-5}"
+RETRIES="${DOCKER_PULL_RETRIES:-1}"
+MAX_ATTEMPTS=$((RETRIES + 1))
 attempt=1
-while [ "$attempt" -le "$RETRIES" ]; do
-	echo "Pulling $IMAGE (attempt ${attempt}/${RETRIES})"
+while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+	echo "Pulling $IMAGE (attempt ${attempt}/${MAX_ATTEMPTS})"
 	if [ -n "${DOCKER_PLATFORM:-}" ]; then
 		# shellcheck disable=SC2086
 		if docker pull ${DOCKER_PLATFORM} "$IMAGE"; then
@@ -43,7 +45,7 @@ while [ "$attempt" -le "$RETRIES" ]; do
 			exit 0
 		fi
 	fi
-	if [ "$attempt" -eq "$RETRIES" ]; then
+	if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
 		break
 	fi
 	sleep_sec=$((attempt * 5))
@@ -53,9 +55,9 @@ while [ "$attempt" -le "$RETRIES" ]; do
 done
 
 if [ "$HAVE_LOCAL" = "yes" ]; then
-	echo "Failed to refresh $IMAGE after ${RETRIES} attempts; using local copy" >&2
+	echo "Failed to refresh $IMAGE after ${MAX_ATTEMPTS} attempts; using local copy" >&2
 	exit 0
 fi
 
-echo "Failed to pull $IMAGE after ${RETRIES} attempts" >&2
+echo "Failed to pull $IMAGE after ${MAX_ATTEMPTS} attempts" >&2
 exit 1

--- a/test/docker_pull.sh
+++ b/test/docker_pull.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Pull a Docker image with retries so a transient registry timeout does not fail
+# the whole test run (GCR timeouts are common in CircleCI docker-in-docker).
+# Images already present are reused unless DOCKER_PULL_FORCE is set.
+set -u
+
+IMAGE="${1:-}"
+if [ -z "$IMAGE" ]; then
+	echo "usage: docker_pull.sh IMAGE" >&2
+	exit 1
+fi
+
+# Locally built debug image; not in a registry.
+case "$IMAGE" in
+go-driver-tests:*)
+	echo "Skipping pull of local image: $IMAGE"
+	exit 0
+	;;
+esac
+
+HAVE_LOCAL=no
+if docker image inspect "$IMAGE" >/dev/null 2>&1; then
+	HAVE_LOCAL=yes
+fi
+
+# Mutable tags (nightly, latest) are refreshed on every run via DOCKER_PULL_FORCE.
+if [ "$HAVE_LOCAL" = "yes" ] && [ -z "${DOCKER_PULL_FORCE:-}" ]; then
+	echo "Image already present: $IMAGE"
+	exit 0
+fi
+
+RETRIES="${DOCKER_PULL_RETRIES:-5}"
+attempt=1
+while [ "$attempt" -le "$RETRIES" ]; do
+	echo "Pulling $IMAGE (attempt ${attempt}/${RETRIES})"
+	if [ -n "${DOCKER_PLATFORM:-}" ]; then
+		# shellcheck disable=SC2086
+		if docker pull ${DOCKER_PLATFORM} "$IMAGE"; then
+			exit 0
+		fi
+	else
+		if docker pull "$IMAGE"; then
+			exit 0
+		fi
+	fi
+	if [ "$attempt" -eq "$RETRIES" ]; then
+		break
+	fi
+	sleep_sec=$((attempt * 5))
+	echo "docker pull failed for $IMAGE; retrying in ${sleep_sec}s..."
+	sleep "$sleep_sec"
+	attempt=$((attempt + 1))
+done
+
+if [ "$HAVE_LOCAL" = "yes" ]; then
+	echo "Failed to refresh $IMAGE after ${RETRIES} attempts; using local copy" >&2
+	exit 0
+fi
+
+echo "Failed to pull $IMAGE after ${RETRIES} attempts" >&2
+exit 1

--- a/test/starter_for_arangodb.sh
+++ b/test/starter_for_arangodb.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Print the Starter image matching an ArangoDB server image.
+# The server image ships the starter binary; parse its --version output
+# instead of pinning a Starter tag here.
+set -eu
+
+IMAGE="${1:-}"
+if [ -z "$IMAGE" ]; then
+	echo "usage: starter_for_arangodb.sh ARANGODB_IMAGE" >&2
+	exit 1
+fi
+
+STARTER_REPO="${STARTER_REPO:-docker.io/arangodb/arangodb-starter}"
+
+# shellcheck disable=SC2086
+VERSION_LINE=$(docker run --rm ${DOCKER_PLATFORM:-} --entrypoint arangodb "$IMAGE" --version 2>/dev/null | head -1)
+# First line is "Version <tag>, build <hash>"; keep only <tag>.
+VERSION=$(printf '%s' "$VERSION_LINE" | sed -n 's/^[Vv]ersion[[:space:]]\+\([^,[:space:]]\+\).*/\1/p')
+
+if [ -z "$VERSION" ]; then
+	echo "Failed to detect Starter version from $IMAGE (got: '$VERSION_LINE')" >&2
+	echo "Set STARTER to pick the Starter image explicitly." >&2
+	exit 1
+fi
+
+echo "${STARTER_REPO}:${VERSION}"

--- a/v3/arangodb/database_query.go
+++ b/v3/arangodb/database_query.go
@@ -93,12 +93,13 @@ type DatabaseQuery interface {
 	// This will remove all cached query entries.
 	ClearQueryCache(ctx context.Context) error
 
-	// GetQueryCacheProperties returns the properties of the query cache.
-	// The result is a QueryCacheProperties object.
+	// GetQueryCacheProperties returns the global query cache properties.
+	// These settings apply to all databases. GET is allowed on any database.
 	GetQueryCacheProperties(ctx context.Context) (QueryCacheProperties, error)
 
-	// SetQueryCacheProperties sets the properties of the query cache.
-	// The properties are updated with the provided options.
+	// SetQueryCacheProperties updates the global query cache properties (all databases).
+	// Call this on the _system database. On ArangoDB 4.0 / HTTP API v1, PUT on a
+	// non-system database is rejected (error 1230: operation only allowed in system database).
 	SetQueryCacheProperties(ctx context.Context, options QueryCacheProperties) (QueryCacheProperties, error)
 }
 

--- a/v3/tests/database_query_test.go
+++ b/v3/tests/database_query_test.go
@@ -1329,16 +1329,27 @@ func Test_SetQueryCacheProperties(t *testing.T) {
 	Wrap(t, func(t *testing.T, client arangodb.Client) {
 		WithDatabase(t, client, nil, func(db arangodb.Database) {
 			withContextT(t, defaultTestTimeout, func(ctx context.Context, tb testing.TB) {
+				// GET is allowed on a user database; properties are global.
 				queryCacheProperties, err := db.GetQueryCacheProperties(ctx)
 				require.NoError(t, err)
 				propsJson, err := utils.ToJSONString(queryCacheProperties)
 				require.NoError(t, err)
 				t.Logf("Before Query Properties: %s", propsJson)
-				SetQueryCacheProperties, err := db.SetQueryCacheProperties(ctx, arangodb.QueryCacheProperties{
+
+				// PUT is global and, on ArangoDB 4.0 / API v1, allowed only on _system.
+				sysDB, err := client.GetDatabase(ctx, "_system", nil)
+				require.NoError(t, err)
+
+				SetQueryCacheProperties, err := sysDB.SetQueryCacheProperties(ctx, arangodb.QueryCacheProperties{
 					IncludeSystem: utils.NewType(true),
 					MaxResults:    utils.NewType(uint16(32)),
 				})
 				require.NoError(t, err)
+				defer func() {
+					_, restoreErr := sysDB.SetQueryCacheProperties(ctx, queryCacheProperties)
+					require.NoError(t, restoreErr)
+				}()
+
 				SetQueryCachePropertiesJson, err := utils.ToJSONString(SetQueryCacheProperties)
 				require.NoError(t, err)
 				t.Logf("After Setting - Query Properties: %s", SetQueryCachePropertiesJson)
@@ -1348,12 +1359,19 @@ func Test_SetQueryCacheProperties(t *testing.T) {
 				require.NotNil(t, SetQueryCacheProperties.MaxResults, "MaxResults should not be nil")
 				require.NotNil(t, SetQueryCacheProperties.MaxResultsSize, "MaxResultsSize should not be nil")
 				require.NotNil(t, SetQueryCacheProperties.Mode, "Mode should not be nil")
+				require.Equal(t, true, *SetQueryCacheProperties.IncludeSystem)
+				require.Equal(t, uint16(32), *SetQueryCacheProperties.MaxResults)
+
 				AfterSetQueryCacheProperties, err := db.GetQueryCacheProperties(ctx)
 				require.NoError(t, err)
 				AfterSetQueryCachePropertiesJson, err := utils.ToJSONString(AfterSetQueryCacheProperties)
 				require.NoError(t, err)
 				t.Logf("After Query Properties: %s", AfterSetQueryCachePropertiesJson)
+				require.Equal(t, true, *AfterSetQueryCacheProperties.IncludeSystem)
+				require.Equal(t, uint16(32), *AfterSetQueryCacheProperties.MaxResults)
 			})
 		})
+	}, WrapOptions{
+		Parallel: utils.NewType(false),
 	})
 }


### PR DESCRIPTION
## Summary
Test jobs run in docker-in-docker, where the daemon starts with an empty image store. The Go test image was fetched only by the implicit pull inside `docker run`, so a single GCR timeout aborted the job before any tests ran and left an ArangoDB log dump that looked like a test failure.

Pull images through a shared helper that retries with backoff, and pre-pull `GOIMAGE` in `__test_prepare` and the unit-test targets. Images already present are reused. `ARANGODB` still refreshes on every run and falls back to the local copy if the refresh fails.

## Additional v3 compatibility fix
ArangoDB 4.0 HTTP API v1 treats query-cache properties as global and only allows PUT requests through the `_system` database.
- Update `Test_SetQueryCacheProperties` to PUT through `_system`.
- Continue GET through the test database to verify the global update.
- Restore the original properties and run the test serially.
- Document the `_system` requirement in the v3 API godoc.
No driver API change is introduced.